### PR TITLE
Recommend from liked

### DIFF
--- a/implicit/als.py
+++ b/implicit/als.py
@@ -58,6 +58,7 @@ class AlternatingLeastSquares(RecommenderBase):
         """
         Ciu, Cui = item_users.tocsr(), item_users.T.tocsr()
         items, users = Ciu.shape
+        self._YtY = None
 
         # Initialize the variables randomly if they haven't already been set
         if self.user_factors is None:

--- a/implicit/annoy_als.py
+++ b/implicit/annoy_als.py
@@ -88,7 +88,9 @@ class AnnoyAlternatingLeastSquares(AlternatingLeastSquares):
         # transform distances back to cosine from euclidean distance
         return zip(neighbours, 1 - (numpy.array(dist) ** 2) / 2)
 
-    def recommend(self, userid, user_items, N=10, filter_items=None):
+    def recommend(self, userid, user_items, N=10, filter_items=None, recalculate_user=False):
+        user = self._user_factor(userid, user_items, recalculate_user)
+
         # calculate the top N items, removing the users own liked items from the results
         liked = set(user_items[userid].indices)
         if filter_items:
@@ -96,5 +98,5 @@ class AnnoyAlternatingLeastSquares(AlternatingLeastSquares):
         count = N + len(liked)
 
         # get the top items by dot product
-        ids, dist = self.inner_product_index.get_nns_by_vector(self.user_factors[userid], count)
+        ids, dist = self.inner_product_index.get_nns_by_vector(user, count)
         return list(itertools.islice((rec for rec in zip(ids, dist) if rec[0] not in liked), N))

--- a/implicit/nearest_neighbours.py
+++ b/implicit/nearest_neighbours.py
@@ -20,19 +20,11 @@ class ItemItemRecommender(RecommenderBase):
         """ Computes and stores the similarity matrix """
         self.similarity = all_pairs_knn(weighted, self.K).tocsr()
 
-    def recommend(self, userid, user_items, N=10, filter_items=None):
+    def recommend(self, userid, user_items, N=10, filter_items=None, recalculate_user=False):
         """ returns the best N recommendations for a user given its id"""
-        return self._recommend_from_like_vector(user_items[userid], N, filter_items)
+        # recalculate_user is ignored because this is not a model based algorithm
+        liked_vector = user_items[userid]
 
-    def recommend_from_liked(self, liked, N=10, filter_items=None):
-        """ returns the best N recommendations for a user given its history"""
-        data = [1.0 for _ in liked]
-        i = [0 for _ in liked]
-        shape = (1, self.similarity.shape[0])
-        liked_vector = coo_matrix((data, (i, liked)), shape=shape).tocsr()
-        return self._recommend_from_like_vector(liked_vector, N, filter_items)
-
-    def _recommend_from_like_vector(self, liked_vector, N=10, filter_items=None):
         # calculate the top related items
         recommendations = liked_vector.dot(self.similarity)
         best = sorted(zip(recommendations.indices, recommendations.data), key=lambda x: -x[1])

--- a/implicit/recommender_base.py
+++ b/implicit/recommender_base.py
@@ -13,13 +13,8 @@ class RecommenderBase(object):
         pass
 
     @abstractmethod
-    def recommend(self, user_items, userid=None, N=10, filter_items=None):
+    def recommend(self, userid, user_items, N=10, filter_items=None, recalculate_user=False):
         """ Recommends items for a user"""
-        pass
-
-    @abstractmethod
-    def recommend_from_liked(self, liked, N=10, filter_items=None):
-        """ Returns the top N ranked items for a single user, given its history """
         pass
 
     @abstractmethod

--- a/implicit/recommender_base.py
+++ b/implicit/recommender_base.py
@@ -13,8 +13,13 @@ class RecommenderBase(object):
         pass
 
     @abstractmethod
-    def recommend(self, userid, user_items, N=10, filter_items=None):
-        """ Recommends items for a user """
+    def recommend(self, user_items, userid=None, N=10, filter_items=None):
+        """ Recommends items for a user"""
+        pass
+
+    @abstractmethod
+    def recommend_from_liked(self, liked, N=10, filter_items=None):
+        """ Returns the top N ranked items for a single user, given its history """
         pass
 
     @abstractmethod

--- a/tests/knn_test.py
+++ b/tests/knn_test.py
@@ -36,7 +36,7 @@ class NearestNeighboursTest(unittest.TestCase):
                              [0, 0, 0, 0, 6, 0]], dtype=np.float64)
         counts = implicit.nearest_neighbours.tfidf_weight(counts).tocsr()
 
-        # compute all neighbours usiong matrix dot product
+        # compute all neighbours using matrix dot product
         all_neighbours = counts.dot(counts.T).tocsr()
         K = 3
         knn = implicit.nearest_neighbours.all_pairs_knn(counts, K).tocsr()

--- a/tests/recommender_base_test.py
+++ b/tests/recommender_base_test.py
@@ -29,9 +29,10 @@ class TestRecommenderBaseMixin(object):
             # all the other similar users
             self.assertEqual(recs[0][0], userid)
 
-            # we should get the same item and scores if we use the list of likes
-            liked = user_items[userid].indices
-            recs_from_liked = model.recommend_from_liked(liked, N=1)
+            # we should get the same item if we recalculate_user
+            user_vector = user_items[userid]
+            recs_from_liked = model.recommend(userid=0, user_items=user_vector,
+                                              N=1, recalculate_user=True)
             self.assertEqual(recs[0][0], recs_from_liked[0][0])
             self.assertAlmostEqual(recs[0][1], recs_from_liked[0][1], places=6)
 

--- a/tests/recommender_base_test.py
+++ b/tests/recommender_base_test.py
@@ -29,6 +29,12 @@ class TestRecommenderBaseMixin(object):
             # all the other similar users
             self.assertEqual(recs[0][0], userid)
 
+            # we should get the same item and scores if we use the list of likes
+            liked = user_items[userid].indices
+            recs_from_liked = model.recommend_from_liked(liked, N=1)
+            self.assertEqual(recs[0][0], recs_from_liked[0][0])
+            self.assertAlmostEqual(recs[0][1], recs_from_liked[0][1], places=6)
+
         # try asking for more items than possible,
         # should return only the available items
         # https://github.com/benfred/implicit/issues/22


### PR DESCRIPTION
Hi Benfred,

Thanks so much for this library!

I'm not sure if you are aware, but it's a standard practice to [sample users to get item factors](https://www.quora.com/How-do-I-speed-up-matrix-factorization-by-sampling-users-without-losing-precision) and then use those vectors to generate recommendations for all users.

The trick is to cache item factors only and compute user vectors on the fly to generate recommendations. Another advantage of this approach is that we can recompute user recommendations as soon as we have more data, without needing to rebuild the whole model.

This is a rough implementation of the idea. It introduces the `recommend_from_liked` method that accepts a list of items that were consumed by the user.

I did not reuse the code that computes the user vector in the iterations loop. With some refactoring, I think we could reuse the "solver", adding native and cg support. I can do that myself if you think this feature is helpful.

Any thoughts?