### PR TITLE
Explain recommendations

### DIFF
--- a/implicit/als.py
+++ b/implicit/als.py
@@ -107,7 +107,8 @@ class AlternatingLeastSquares(RecommenderBase):
     def _user_factor(self, userid, user_items, recalculate_user=False):
         if not recalculate_user:
             return self.user_factors[userid]
-        return user_factor(self.item_factors, self.YtY, user_items, userid,
+        return user_factor(self.item_factors, self.YtY,
+                           user_items.tocsr(), userid,
                            self.regularization, self.factors)
 
     def explain(self, userid, user_items, itemid, user_weights=None, N=10):
@@ -116,11 +117,13 @@ class AlternatingLeastSquares(RecommenderBase):
             and a user latent factor weight that can be cached if you want to
             get more than one explanation for the same user.
         """
-        # user_weights = Wu^-1 from section 5 of the paper CF for Implicit Feedback Datasets
+        # user_weights = Cholesky decomposition of Wu^-1
+        # from section 5 of the paper CF for Implicit Feedback Datasets
+        user_items = user_items.tocsr()
         if user_weights is None:
             A, _ = user_linear_equation(self.item_factors, self.YtY,
-                                                   user_items, userid,
-                                                   self.regularization, self.factors)
+                                        user_items, userid,
+                                        self.regularization, self.factors)
             user_weights = scipy.linalg.cho_factor(A)
         seed_item = self.item_factors[itemid]
 

--- a/implicit/als.py
+++ b/implicit/als.py
@@ -128,8 +128,7 @@ class AlternatingLeastSquares(RecommenderBase):
         h = []
         for i, (itemid, confidence) in enumerate(nonzeros(user_items, userid)):
             factor = self.item_factors[itemid]
-            similarity = weighted_item.dot(factor)
-            score = similarity * confidence
+            score = weighted_item.dot(factor) * confidence
             total_score += score
             contribution = (score, itemid)
             if i < N:

--- a/implicit/als.py
+++ b/implicit/als.py
@@ -5,6 +5,7 @@ import logging
 import time
 
 import numpy as np
+import scipy
 
 from . import _als
 from .recommender_base import RecommenderBase
@@ -117,13 +118,14 @@ class AlternatingLeastSquares(RecommenderBase):
         """
         # user_weights = Wu^-1 from section 5 of the paper CF for Implicit Feedback Datasets
         if user_weights is None:
-            user_weights, _ = user_linear_equation(self.item_factors, self.YtY,
+            A, _ = user_linear_equation(self.item_factors, self.YtY,
                                                    user_items, userid,
                                                    self.regularization, self.factors)
+            user_weights = scipy.linalg.cho_factor(A)
         seed_item = self.item_factors[itemid]
 
         # weighted_item = y_i^t W_u
-        weighted_item = np.linalg.solve(user_weights.T, seed_item)
+        weighted_item = scipy.linalg.cho_solve(user_weights, seed_item)
 
         total_score = 0.0
         h = []

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -50,6 +50,7 @@ class ALSTest(unittest.TestCase, TestRecommenderBaseMixin):
                              [0, 0, 1, 1, 0, 1],
                              [0, 1, 0, 0, 0, 1],
                              [0, 0, 0, 0, 1, 1]], dtype=np.float64)
+        user_items = counts * 2
 
         # try all 8 variants of native/python, cg/cholesky, and
         # 64 vs 32 bit factors
@@ -63,7 +64,7 @@ class ALSTest(unittest.TestCase, TestRecommenderBaseMixin):
                                                         use_native=use_native,
                                                         use_cg=use_cg)
                         np.random.seed(23)
-                        model.fit(counts * 2)
+                        model.fit(user_items)
                         rows, cols = model.item_factors, model.user_factors
 
                     except Exception as e:
@@ -80,6 +81,32 @@ class ALSTest(unittest.TestCase, TestRecommenderBaseMixin):
                                                        " value=%.5f, dtype=%s, cg=%s, native=%s"
                                                        % (i, j, reconstructed[i, j], dtype, use_cg,
                                                           use_native))
+
+    def test_explain(self):
+        counts = csr_matrix([[1, 1, 0, 1, 0, 0],
+                             [0, 1, 1, 1, 0, 0],
+                             [1, 0, 1, 0, 0, 0],
+                             [1, 1, 0, 0, 0, 0],
+                             [0, 0, 1, 1, 0, 1],
+                             [0, 1, 0, 0, 0, 1],
+                             [0, 0, 0, 0, 1, 1]], dtype=np.float64)
+        user_items = counts * 2
+
+        model = AlternatingLeastSquares(factors=4,
+                                        regularization=1e-1,
+                                        use_native=False,
+                                        use_cg=False,
+                                        iterations=10)
+        np.random.seed(23)
+        model.fit(user_items)
+        model.item_factors, model.user_factors
+
+        userid = 0
+        recs = model.recommend(userid, user_items, N=10, recalculate_user=True)
+        top_rec, score = recs[0]
+        score_explained, contributions, W = model.explain(userid, user_items, itemid=top_rec)
+        self.assertAlmostEqual(score, score_explained, 4)
+        self.assertAlmostEqual(score, sum(s for _, s in contributions), 4)
 
 
 if __name__ == "__main__":

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -104,9 +104,23 @@ class ALSTest(unittest.TestCase, TestRecommenderBaseMixin):
         userid = 0
         recs = model.recommend(userid, user_items, N=10, recalculate_user=True)
         top_rec, score = recs[0]
-        score_explained, contributions, W = model.explain(userid, user_items, itemid=top_rec)
+        score_explained, contributions, W = model.explain(
+            userid, user_items, itemid=top_rec)
+        scores = [s for _, s in contributions]
+        items = [i for i, _ in contributions]
         self.assertAlmostEqual(score, score_explained, 4)
-        self.assertAlmostEqual(score, sum(s for _, s in contributions), 4)
+        self.assertAlmostEqual(score, sum(scores), 4)
+        self.assertEqual(scores, sorted(scores, reverse=True), "Scores not in order")
+        self.assertEqual([0, 1, 3], sorted(items), "Items not seen by user")
+
+        # run again with precomputed user weigths
+        score_explained, contributions, W = model.explain(
+            userid, user_items, itemid=top_rec, user_weights=W, N=2)
+        scores = [s for _, s in contributions]
+        items = [i for i, _ in contributions]
+        self.assertAlmostEqual(score, score_explained, 4)
+        self.assertNotAlmostEqual(score, sum(scores), 4)
+        self.assertEqual(scores, sorted(scores, reverse=True), "Scores not in order")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi @benfred. I implemented another feature, for explaining recommendations.

The new method returns the items in the user history that contributed the most for a recommendation.

The equations for this are in section 5 of the http://yifanhu.net/PUB/cf.pdf

Would it make sense to add this? What do you think about the API?