### PR TITLE
Adds a batch recommendation method to AlternatingLeastSquares

### DIFF
--- a/implicit/als.py
+++ b/implicit/als.py
@@ -187,7 +187,7 @@ class AlternatingLeastSquares(RecommenderBase):
         item_latent = item_latent[item_ids, :]  # item_ids x factors
 
         # Calculate the recommendation weights
-        weights = (user_latent @ item_latent.T)  # users x items
+        weights = user_latent.dot(item_latent.T)  # users x items
 
         # Optionally remove weights for items with high confidences
         if ignore_pairs is not None:


### PR DESCRIPTION
To really benefit from `implicit`, I found that I had to implement batch recommendations. So, here it is, all shined up!

Do consider this an RFC; I am looking forward to hear your thoughts on the architecture:

- Should this be split up in smaller functions?
- Should this even be here? (I think yes, of course)
- Should this share more code with `.recommend()`, since it is almost a superset of it?
    - I didn't implement `recalculate_user` (yet).
    - I chose a different style for filtering items: For batch processing, I am interested in filtering away certain items for certain users, not certain items for all users.
- Should and could something similar be implemented for the other subclasses of `RecommenderBase`?

Code quality wise, let me know if you think there is more to be done w.r.t. style, comments, or naming conventions. I tried to adhere to the style of the existing code, but let me know if I missed something important :-)