### PR TITLE
Make AnnoyALS model serializable

### DIFF
--- a/implicit/annoy_als.py
+++ b/implicit/annoy_als.py
@@ -161,7 +161,8 @@ class AnnoyAlternatingLeastSquares(AlternatingLeastSquares):
         and cosine index have been saved to.
         """
         obj = joblib.load('{}_annoy_als.pkl'.format(base_filename))
-        obj.inner_product_index = MaximumInnerProductIndex.from_file(base_filename + '_inner_product_index')
+        obj.inner_product_index = MaximumInnerProductIndex.from_file(base_filename +
+                                                                     '_inner_product_index')
 
         obj.cosine_index = annoy.AnnoyIndex(obj.index_dim, 'angular')
 

--- a/implicit/annoy_als.py
+++ b/implicit/annoy_als.py
@@ -5,6 +5,7 @@ import itertools
 import logging
 
 import numpy
+import joblib
 
 from implicit.als import AlternatingLeastSquares
 
@@ -42,12 +43,32 @@ class MaximumInnerProductIndex(object):
         extra = numpy.append(factors, extra_dimension.reshape(norms.shape[0], 1), axis=1)
 
         # add the extended matrix to an annoy index
-        index = annoy.AnnoyIndex(factors.shape[1] + 1, 'angular')
+        self.index_dim = factors.shape[1] + 1
+        index = annoy.AnnoyIndex(self.index_dim, 'angular')
         for i, row in enumerate(extra):
             index.add_item(i, row)
 
         index.build(num_trees)
         self.index = index
+    
+    @classmethod
+    def from_file(cls, base_filename):
+        """ Factory method to create a MaximumInnerProductIndex model from :filename: """
+        obj = joblib.load(base_filename + '.pkl')
+        index = annoy.AnnoyIndex(obj.index_dim, 'angular')
+        index.load(base_filename + '_index.bin')
+
+        obj.index = index
+        return obj
+
+    def to_file(self, base_filename):
+        """ Save the current MaximumInnerProductIndex to file."""
+        # Make None so that not trying to pickle Annoy object
+        index = self.index
+        self.index = None
+
+        joblib.dump(self, base_filename + '.pkl', compress=3)
+        index.save(base_filename + '_index.bin')
 
     def get_nns_by_vector(self, v, N=10):
         return self._get_nns(numpy.append(v, 0), N)
@@ -74,8 +95,10 @@ class AnnoyAlternatingLeastSquares(AlternatingLeastSquares):
         # train the model
         super(AnnoyAlternatingLeastSquares, self).fit(Ciu)
 
+        self.index_dim = self.item_factors.shape[1]
+
         # build up an Annoy Index with all the item_factors (for calculating similar items)
-        self.cosine_index = annoy.AnnoyIndex(self.item_factors.shape[1], 'angular')
+        self.cosine_index = annoy.AnnoyIndex(self.index_dim, 'angular')
         for i, row in enumerate(self.item_factors):
             self.cosine_index.add_item(i, row)
         self.cosine_index.build(self.factors)
@@ -100,3 +123,42 @@ class AnnoyAlternatingLeastSquares(AlternatingLeastSquares):
         # get the top items by dot product
         ids, dist = self.inner_product_index.get_nns_by_vector(user, count)
         return list(itertools.islice((rec for rec in zip(ids, dist) if rec[0] not in liked), N))
+
+    def to_files(self, base_filename):
+        """
+        Saves an Annoy ALS to filenames:
+        :base_filename: + '_annoy_als.pkl'
+        :base_filename: + '_inner_product_index.pkl'
+        :base_filename: + '_cosine_index.pkl'
+
+        *** Warning: If future Annoy fields are added in future, will have to
+        save / restore these separately as well.
+        """
+        # Remove fields with annoy.AnnoyIndex members
+        inner_product_index = self.inner_product_index
+        cosine_index = self.cosine_index
+
+        self.inner_product_index = None
+        self.cosine_index = None
+
+        joblib.dump(self, '{}_annoy_als.pkl'.format(base_filename), compress=3)
+        inner_product_index.to_file(base_filename + '_inner_product_index')
+        cosine_index.save('{}_cosine_index.bin'.format(base_filename))
+
+    
+
+    @classmethod
+    def from_files(cls, base_filename):
+        """
+        Factory to load AnnoyAlternatingLeastSquares model from files.
+
+        :base_filename: describes the base filename that the inner product index
+        and cosine index have been saved to.
+        """
+        obj = joblib.load('{}_annoy_als.pkl'.format(base_filename))
+        obj.inner_product_index = MaximumInnerProductIndex.from_file(base_filename + '_inner_product_index')
+
+        obj.cosine_index = annoy.AnnoyIndex(obj.index_dim, 'angular')
+
+        obj.cosine_index.load('{}_cosine_index.bin'.format(base_filename))
+        return obj

--- a/implicit/annoy_als.py
+++ b/implicit/annoy_als.py
@@ -50,7 +50,7 @@ class MaximumInnerProductIndex(object):
 
         index.build(num_trees)
         self.index = index
-    
+
     @classmethod
     def from_file(cls, base_filename):
         """ Factory method to create a MaximumInnerProductIndex model from :filename: """
@@ -69,6 +69,9 @@ class MaximumInnerProductIndex(object):
 
         joblib.dump(self, base_filename + '.pkl', compress=3)
         index.save(base_filename + '_index.bin')
+
+        # Put index back
+        self.index = index
 
     def get_nns_by_vector(self, v, N=10):
         return self._get_nns(numpy.append(v, 0), N)
@@ -145,7 +148,9 @@ class AnnoyAlternatingLeastSquares(AlternatingLeastSquares):
         inner_product_index.to_file(base_filename + '_inner_product_index')
         cosine_index.save('{}_cosine_index.bin'.format(base_filename))
 
-    
+        # Put fields back so that can still use model after saving
+        self.inner_product_index = inner_product_index
+        self.cosine_index = cosine_index
 
     @classmethod
     def from_files(cls, base_filename):

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
              'Collaborative Filtering, Recommender Systems',
 
     packages=[SRC_ROOT],
-    install_requires=['numpy', 'scipy>=0.16'],
+    install_requires=['numpy', 'scipy>=0.16', 'joblib'],
     setup_requires=["Cython >= 0.19"],
     ext_modules=define_extensions(use_cython),
     test_suite="tests",


### PR DESCRIPTION
I'm using Annoy's save / load functionality to serialize the AnnoyAlternatingLeastSquares model to a file.

Added joblib as a dependency.

Still need to : 
- Add tests
- Rework `to_file` / `to_files` to restore any `AnnoyIndex` fields after saving.

Could also add the to_file / from_file functions to `AlternatingLeastSquares` or `RecommenderBase`.