### PR TITLE
Reduce random approximate_als unittest failures

### DIFF
--- a/tests/approximate_als_test.py
+++ b/tests/approximate_als_test.py
@@ -23,7 +23,8 @@ try:
 
     class NMSLibALSTest(unittest.TestCase, TestRecommenderBaseMixin):
         def _get_model(self):
-            return NMSLibAlternatingLeastSquares(factors=2, regularization=0)
+            return NMSLibAlternatingLeastSquares(factors=2, regularization=0,
+                                                 index_params={'post': 2})
 except ImportError:
     pass
 

--- a/tests/recommender_base_test.py
+++ b/tests/recommender_base_test.py
@@ -34,7 +34,7 @@ class TestRecommenderBaseMixin(object):
             recs_from_liked = model.recommend(userid=0, user_items=user_vector,
                                               N=1, recalculate_user=True)
             self.assertEqual(recs[0][0], recs_from_liked[0][0])
-            self.assertAlmostEqual(recs[0][1], recs_from_liked[0][1], places=6)
+            self.assertAlmostEqual(recs[0][1], recs_from_liked[0][1], places=5)
 
         # try asking for more items than possible,
         # should return only the available items


### PR DESCRIPTION
Try to reduce the number of random unittest failures coming from
the approximate als methods.