### PR TITLE
allow macOS to find GOMP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,21 @@
 language: python
-sudo: false
+sudo: require
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
+
+matrix:
+  include:
+    - language: generic
+      os: osx
+      python: 2.7.13
+    - language: generic
+      os: osx
+      python: 3.5.4
+    - language: generic
+      os: osx
+      python: 3.6.4
 
 addons:
   apt:
@@ -12,10 +25,15 @@ addons:
     - gfortran
 
 before_install:
-  - pip install -U pip setuptools wheel
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo chown -R $USER /Library/Python/2.7; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo easy_install pip; fi
+  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then pip install -U pip setuptools wheel; fi
 
 install:
-  - travis_wait travis_retry pip install -r requirements.txt flake8 isort cpplint annoy
+  - travis_wait travis_retry sudo pip install -r requirements.txt --ignore-installed flake8 isort cpplint annoy
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry sudo chown -R $USER /Library/Python/2.7; fi
   - travis_retry python setup.py build install
 
 script:


### PR DESCRIPTION
Hi, this PR adds code that enables `setup.py` to find GOMP on macOS systems, so `pip install implicit` should just work on macOS. 

This also updates the Travis config to test on macOS - tests pass: https://travis-ci.org/stillmatic/implicit