### PR TITLE
examples/lastfm.py: fix

### DIFF
--- a/examples/lastfm.py
+++ b/examples/lastfm.py
@@ -65,7 +65,8 @@ def read_data(filename):
     logging.debug("reading data from %s", filename)
     data = pandas.read_table(filename,
                              usecols=[0, 2, 3],
-                             names=['user', 'artist', 'plays'])
+                             names=['user', 'artist', 'plays'],
+                             na_filter=False)
 
     # map each artist and user to a unique numeric value
     data['user'] = data['user'].astype("category")


### PR DESCRIPTION
Fixed `ValueError: negative row index found` for lastfm.py example which is occuring with 360K lastfm dataset from [there](http://www.dtic.upf.edu/~ocelma/MusicRecommendationDataset/lastfm-360K.html).