### PR TITLE
Fix issues with windows CUDA install

### DIFF
--- a/cuda_setup.py
+++ b/cuda_setup.py
@@ -53,11 +53,6 @@ def locate_cuda():
                   'nvcc': nvcc,
                   'include': os.path.join(home, 'include'),
                   'lib64':   os.path.join(home, 'lib64')}
-    for k, v in cudaconfig.items():
-        if not os.path.exists(v):
-            logging.warning('The CUDA %s path could not be located in %s', k, v)
-            return None
-
     post_args = ['-gencode=arch=compute_30,code=sm_30',
                  '-gencode=arch=compute_50,code=sm_50',
                  '-gencode=arch=compute_60,code=sm_60',
@@ -69,6 +64,11 @@ def locate_cuda():
         post_args += ['-Xcompiler', '/MD']
     else:
         post_args += ['-c', '--compiler-options', "'-fPIC'"]
+
+    for k, v in cudaconfig.items():
+        if not os.path.exists(v):
+            logging.warning('The CUDA %s path could not be located in %s', k, v)
+            return None
 
     cudaconfig['post_args'] = post_args
     return cudaconfig

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ def define_extensions(use_cython=False):
                                  extra_link_args=link_args,
                                  library_dirs=[CUDA['lib64']],
                                  libraries=['cudart', 'cublas', 'curand'],
-                                 runtime_library_dirs=[CUDA['lib64']],
                                  include_dirs=[CUDA['include'], '.']))
     else:
         print("Failed to find CUDA toolkit. Building without GPU acceleration.")


### PR DESCRIPTION
The check for the cuda lib64 directory was happening before it was properly
set: move the check to the correct place. Also remove unneeded
runtime_library_dirs option from build.