### PR TITLE
Add option for negative preferences in ALS

### DIFF
--- a/implicit/_als.cpp
+++ b/implicit/_als.cpp
@@ -13,7 +13,6 @@
             "-std=c++11"
         ],
         "extra_link_args": [
-            "-Wl,-rpath,/usr/local/opt/gcc/lib/gcc/7/",
             "-fopenmp",
             "-std=c++11"
         ],
@@ -5135,17 +5134,49 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
                                     /* "implicit/_als.pyx":100
  *                     # b += Yi Cui Pui
  *                     # Pui is implicit, its defined to be 1 for non-zero entries
- *                     axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)             # <<<<<<<<<<<<<<
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ */
+                                    __pyx_t_15 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_15) {
+
+                                      /* "implicit/_als.pyx":101
+ *                     # Pui is implicit, its defined to be 1 for non-zero entries
+ *                     if confidence > 0:
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         confidence = -1 * confidence
+ */
+                                      __pyx_t_27 = __pyx_v_i;
+                                      __pyx_t_28 = 0;
+                                      if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
+                                      if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
+                                      __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_factors), (&__pyx_v_confidence), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_b, (&__pyx_v_one));
+
+                                      /* "implicit/_als.pyx":100
+ *                     # b += Yi Cui Pui
+ *                     # Pui is implicit, its defined to be 1 for non-zero entries
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ */
+                                      goto __pyx_L22;
+                                    }
+
+                                    /* "implicit/_als.pyx":103
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
  * 
  *                     # A += Yi^T Cui Yi
  */
-                                    __pyx_t_27 = __pyx_v_i;
-                                    __pyx_t_28 = 0;
-                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
-                                    __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_factors), (&__pyx_v_confidence), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_b, (&__pyx_v_one));
+                                    /*else*/ {
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L22:;
 
-                                    /* "implicit/_als.pyx":104
+                                    /* "implicit/_als.pyx":107
  *                     # A += Yi^T Cui Yi
  *                     # Since we've already added in YtY, we subtract 1 from confidence
  *                     for j in range(factors):             # <<<<<<<<<<<<<<
@@ -5156,7 +5187,7 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
                                     for (__pyx_t_30 = 0; __pyx_t_30 < __pyx_t_29; __pyx_t_30+=1) {
                                       __pyx_v_j = __pyx_t_30;
 
-                                      /* "implicit/_als.pyx":105
+                                      /* "implicit/_als.pyx":108
  *                     # Since we've already added in YtY, we subtract 1 from confidence
  *                     for j in range(factors):
  *                         temp = (confidence - 1) * Y[i, j]             # <<<<<<<<<<<<<<
@@ -5169,7 +5200,7 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
                                       if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_Y.shape[1];
                                       __pyx_v_temp = ((__pyx_v_confidence - 1.0) * (*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_31 * __pyx_v_Y.strides[0]) ) + __pyx_t_32 * __pyx_v_Y.strides[1]) ))));
 
-                                      /* "implicit/_als.pyx":106
+                                      /* "implicit/_als.pyx":109
  *                     for j in range(factors):
  *                         temp = (confidence - 1) * Y[i, j]
  *                         axpy(&factors, &temp, &Y[i, 0], &one, A + j * factors, &one)             # <<<<<<<<<<<<<<
@@ -5184,7 +5215,7 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
                                     }
                                   }
 
-                                  /* "implicit/_als.pyx":108
+                                  /* "implicit/_als.pyx":111
  *                         axpy(&factors, &temp, &Y[i, 0], &one, A + j * factors, &one)
  * 
  *                 err = 0             # <<<<<<<<<<<<<<
@@ -5193,7 +5224,7 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
  */
                                   __pyx_v_err = 0;
 
-                                  /* "implicit/_als.pyx":109
+                                  /* "implicit/_als.pyx":112
  * 
  *                 err = 0
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)             # <<<<<<<<<<<<<<
@@ -5202,7 +5233,7 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
  */
                                   __pyx_fuse_0__pyx_f_8implicit_4_als_posv(((char *)"U"), (&__pyx_v_factors), (&__pyx_v_one), __pyx_v_A, (&__pyx_v_factors), __pyx_v_b, (&__pyx_v_factors), (&__pyx_v_err));
 
-                                  /* "implicit/_als.pyx":111
+                                  /* "implicit/_als.pyx":114
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)
  * 
  *                 if not err:             # <<<<<<<<<<<<<<
@@ -5212,7 +5243,7 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
                                   __pyx_t_15 = ((!(__pyx_v_err != 0)) != 0);
                                   if (__pyx_t_15) {
 
-                                    /* "implicit/_als.pyx":112
+                                    /* "implicit/_als.pyx":115
  * 
  *                 if not err:
  *                     memcpy(&X[u, 0], b, sizeof(floating) * factors)             # <<<<<<<<<<<<<<
@@ -5225,17 +5256,17 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
                                     if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_X.shape[1];
                                     memcpy((&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_35 * __pyx_v_X.strides[0]) ) + __pyx_t_36 * __pyx_v_X.strides[1]) )))), __pyx_v_b, ((sizeof(float)) * __pyx_v_factors));
 
-                                    /* "implicit/_als.pyx":111
+                                    /* "implicit/_als.pyx":114
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)
  * 
  *                 if not err:             # <<<<<<<<<<<<<<
  *                     memcpy(&X[u, 0], b, sizeof(floating) * factors)
  *                 else:
  */
-                                    goto __pyx_L24;
+                                    goto __pyx_L25;
                                   }
 
-                                  /* "implicit/_als.pyx":118
+                                  /* "implicit/_als.pyx":121
  *                     # since a= Yt(Cu + regularization I)Y a is always positive. its also non
  *                     # zero if the regularization factor > 0.
  *                     with gil:             # <<<<<<<<<<<<<<
@@ -5249,18 +5280,18 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
                                         #endif
                                         /*try:*/ {
 
-                                          /* "implicit/_als.pyx":120
+                                          /* "implicit/_als.pyx":123
  *                     with gil:
  *                         raise ValueError("cython_lapack.posv failed (err=%i) on row %i. Try "
  *                                          "increasing the regularization parameter." % (err, u))             # <<<<<<<<<<<<<<
  * 
  *         finally:
  */
-                                          __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_err); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_err); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_5);
-                                          __pyx_t_2 = __Pyx_PyInt_From_int(__pyx_v_u); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyInt_From_int(__pyx_v_u); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
-                                          __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_1);
                                           __Pyx_GIVEREF(__pyx_t_5);
                                           PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_5);
@@ -5268,31 +5299,31 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
                                           PyTuple_SET_ITEM(__pyx_t_1, 1, __pyx_t_2);
                                           __pyx_t_5 = 0;
                                           __pyx_t_2 = 0;
-                                          __pyx_t_2 = __Pyx_PyString_Format(__pyx_kp_s_cython_lapack_posv_failed_err_i, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyString_Format(__pyx_kp_s_cython_lapack_posv_failed_err_i, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
                                           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-                                          /* "implicit/_als.pyx":119
+                                          /* "implicit/_als.pyx":122
  *                     # zero if the regularization factor > 0.
  *                     with gil:
  *                         raise ValueError("cython_lapack.posv failed (err=%i) on row %i. Try "             # <<<<<<<<<<<<<<
  *                                          "increasing the regularization parameter." % (err, u))
  * 
  */
-                                          __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 122, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_1);
                                           __Pyx_GIVEREF(__pyx_t_2);
                                           PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_2);
                                           __pyx_t_2 = 0;
-                                          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 122, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
                                           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
                                           __Pyx_Raise(__pyx_t_2, 0, 0, 0);
                                           __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-                                          __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __PYX_ERR(0, 122, __pyx_L29_error)
                                         }
 
-                                        /* "implicit/_als.pyx":118
+                                        /* "implicit/_als.pyx":121
  *                     # since a= Yt(Cu + regularization I)Y a is always positive. its also non
  *                     # zero if the regularization factor > 0.
  *                     with gil:             # <<<<<<<<<<<<<<
@@ -5300,7 +5331,7 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
  *                                          "increasing the regularization parameter." % (err, u))
  */
                                         /*finally:*/ {
-                                          __pyx_L28_error: {
+                                          __pyx_L29_error: {
                                             #ifdef WITH_THREAD
                                             __Pyx_PyGILState_Release(__pyx_gilstate_save);
                                             #endif
@@ -5309,10 +5340,10 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
                                         }
                                     }
                                   }
-                                  __pyx_L24:;
-                                  goto __pyx_L31;
+                                  __pyx_L25:;
+                                  goto __pyx_L32;
                                   __pyx_L15_continue:;
-                                  goto __pyx_L31;
+                                  goto __pyx_L32;
                                   __pyx_L17_error:;
                                   {
                                       #ifdef WITH_THREAD
@@ -5331,8 +5362,8 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
                                       #endif
                                   }
                                   __pyx_parallel_why = 4;
-                                  goto __pyx_L30;
-                                  __pyx_L30:;
+                                  goto __pyx_L31;
+                                  __pyx_L31:;
                                   #ifdef _OPENMP
                                   #pragma omp critical(__pyx_parallel_lastprivates0)
                                   #endif /* _OPENMP */
@@ -5345,7 +5376,7 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
                                       __pyx_parallel_temp5 = __pyx_v_temp;
                                       __pyx_parallel_temp6 = __pyx_v_u;
                                   }
-                                  __pyx_L31:;
+                                  __pyx_L32:;
                                   #ifdef _OPENMP
                                   #pragma omp flush(__pyx_parallel_why)
                                   #endif /* _OPENMP */
@@ -5383,7 +5414,7 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
                   }
                 }
 
-                /* "implicit/_als.pyx":123
+                /* "implicit/_als.pyx":126
  * 
  *         finally:
  *             free(A)             # <<<<<<<<<<<<<<
@@ -5394,7 +5425,7 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
                   /*normal exit:*/{
                     free(__pyx_v_A);
 
-                    /* "implicit/_als.pyx":124
+                    /* "implicit/_als.pyx":127
  *         finally:
  *             free(A)
  *             free(b)             # <<<<<<<<<<<<<<
@@ -5438,7 +5469,7 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
                     #endif
                     {
 
-                      /* "implicit/_als.pyx":123
+                      /* "implicit/_als.pyx":126
  * 
  *         finally:
  *             free(A)             # <<<<<<<<<<<<<<
@@ -5447,7 +5478,7 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
  */
                       free(__pyx_v_A);
 
-                      /* "implicit/_als.pyx":124
+                      /* "implicit/_als.pyx":127
  *         finally:
  *             free(A)
  *             free(b)             # <<<<<<<<<<<<<<
@@ -5479,7 +5510,7 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
                   }
                   __pyx_L14:;
                 }
-                goto __pyx_L37;
+                goto __pyx_L38;
                 __pyx_L8_error:;
                 {
                     #ifdef WITH_THREAD
@@ -5498,8 +5529,8 @@ static PyObject *__pyx_pf_8implicit_4_als_12_least_squares(CYTHON_UNUSED PyObjec
                     #endif
                 }
                 __pyx_parallel_why = 4;
-                goto __pyx_L37;
-                __pyx_L37:;
+                goto __pyx_L38;
+                __pyx_L38:;
                 #ifdef _OPENMP
                 Py_END_ALLOW_THREADS
                 #else
@@ -6303,17 +6334,49 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
                                     /* "implicit/_als.pyx":100
  *                     # b += Yi Cui Pui
  *                     # Pui is implicit, its defined to be 1 for non-zero entries
- *                     axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)             # <<<<<<<<<<<<<<
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ */
+                                    __pyx_t_15 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_15) {
+
+                                      /* "implicit/_als.pyx":101
+ *                     # Pui is implicit, its defined to be 1 for non-zero entries
+ *                     if confidence > 0:
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         confidence = -1 * confidence
+ */
+                                      __pyx_t_27 = __pyx_v_i;
+                                      __pyx_t_28 = 0;
+                                      if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
+                                      if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
+                                      __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_factors), (&__pyx_v_confidence), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_b, (&__pyx_v_one));
+
+                                      /* "implicit/_als.pyx":100
+ *                     # b += Yi Cui Pui
+ *                     # Pui is implicit, its defined to be 1 for non-zero entries
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ */
+                                      goto __pyx_L22;
+                                    }
+
+                                    /* "implicit/_als.pyx":103
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
  * 
  *                     # A += Yi^T Cui Yi
  */
-                                    __pyx_t_27 = __pyx_v_i;
-                                    __pyx_t_28 = 0;
-                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
-                                    __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_factors), (&__pyx_v_confidence), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_b, (&__pyx_v_one));
+                                    /*else*/ {
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L22:;
 
-                                    /* "implicit/_als.pyx":104
+                                    /* "implicit/_als.pyx":107
  *                     # A += Yi^T Cui Yi
  *                     # Since we've already added in YtY, we subtract 1 from confidence
  *                     for j in range(factors):             # <<<<<<<<<<<<<<
@@ -6324,7 +6387,7 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
                                     for (__pyx_t_30 = 0; __pyx_t_30 < __pyx_t_29; __pyx_t_30+=1) {
                                       __pyx_v_j = __pyx_t_30;
 
-                                      /* "implicit/_als.pyx":105
+                                      /* "implicit/_als.pyx":108
  *                     # Since we've already added in YtY, we subtract 1 from confidence
  *                     for j in range(factors):
  *                         temp = (confidence - 1) * Y[i, j]             # <<<<<<<<<<<<<<
@@ -6337,7 +6400,7 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
                                       if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_Y.shape[1];
                                       __pyx_v_temp = ((__pyx_v_confidence - 1.0) * (*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_31 * __pyx_v_Y.strides[0]) ) + __pyx_t_32 * __pyx_v_Y.strides[1]) ))));
 
-                                      /* "implicit/_als.pyx":106
+                                      /* "implicit/_als.pyx":109
  *                     for j in range(factors):
  *                         temp = (confidence - 1) * Y[i, j]
  *                         axpy(&factors, &temp, &Y[i, 0], &one, A + j * factors, &one)             # <<<<<<<<<<<<<<
@@ -6352,7 +6415,7 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
                                     }
                                   }
 
-                                  /* "implicit/_als.pyx":108
+                                  /* "implicit/_als.pyx":111
  *                         axpy(&factors, &temp, &Y[i, 0], &one, A + j * factors, &one)
  * 
  *                 err = 0             # <<<<<<<<<<<<<<
@@ -6361,7 +6424,7 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
  */
                                   __pyx_v_err = 0;
 
-                                  /* "implicit/_als.pyx":109
+                                  /* "implicit/_als.pyx":112
  * 
  *                 err = 0
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)             # <<<<<<<<<<<<<<
@@ -6370,7 +6433,7 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
  */
                                   __pyx_fuse_1__pyx_f_8implicit_4_als_posv(((char *)"U"), (&__pyx_v_factors), (&__pyx_v_one), __pyx_v_A, (&__pyx_v_factors), __pyx_v_b, (&__pyx_v_factors), (&__pyx_v_err));
 
-                                  /* "implicit/_als.pyx":111
+                                  /* "implicit/_als.pyx":114
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)
  * 
  *                 if not err:             # <<<<<<<<<<<<<<
@@ -6380,7 +6443,7 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
                                   __pyx_t_15 = ((!(__pyx_v_err != 0)) != 0);
                                   if (__pyx_t_15) {
 
-                                    /* "implicit/_als.pyx":112
+                                    /* "implicit/_als.pyx":115
  * 
  *                 if not err:
  *                     memcpy(&X[u, 0], b, sizeof(floating) * factors)             # <<<<<<<<<<<<<<
@@ -6393,17 +6456,17 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
                                     if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_X.shape[1];
                                     memcpy((&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_35 * __pyx_v_X.strides[0]) ) + __pyx_t_36 * __pyx_v_X.strides[1]) )))), __pyx_v_b, ((sizeof(double)) * __pyx_v_factors));
 
-                                    /* "implicit/_als.pyx":111
+                                    /* "implicit/_als.pyx":114
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)
  * 
  *                 if not err:             # <<<<<<<<<<<<<<
  *                     memcpy(&X[u, 0], b, sizeof(floating) * factors)
  *                 else:
  */
-                                    goto __pyx_L24;
+                                    goto __pyx_L25;
                                   }
 
-                                  /* "implicit/_als.pyx":118
+                                  /* "implicit/_als.pyx":121
  *                     # since a= Yt(Cu + regularization I)Y a is always positive. its also non
  *                     # zero if the regularization factor > 0.
  *                     with gil:             # <<<<<<<<<<<<<<
@@ -6417,18 +6480,18 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
                                         #endif
                                         /*try:*/ {
 
-                                          /* "implicit/_als.pyx":120
+                                          /* "implicit/_als.pyx":123
  *                     with gil:
  *                         raise ValueError("cython_lapack.posv failed (err=%i) on row %i. Try "
  *                                          "increasing the regularization parameter." % (err, u))             # <<<<<<<<<<<<<<
  * 
  *         finally:
  */
-                                          __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_err); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_err); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_5);
-                                          __pyx_t_2 = __Pyx_PyInt_From_int(__pyx_v_u); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyInt_From_int(__pyx_v_u); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
-                                          __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_1);
                                           __Pyx_GIVEREF(__pyx_t_5);
                                           PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_5);
@@ -6436,31 +6499,31 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
                                           PyTuple_SET_ITEM(__pyx_t_1, 1, __pyx_t_2);
                                           __pyx_t_5 = 0;
                                           __pyx_t_2 = 0;
-                                          __pyx_t_2 = __Pyx_PyString_Format(__pyx_kp_s_cython_lapack_posv_failed_err_i, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyString_Format(__pyx_kp_s_cython_lapack_posv_failed_err_i, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
                                           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-                                          /* "implicit/_als.pyx":119
+                                          /* "implicit/_als.pyx":122
  *                     # zero if the regularization factor > 0.
  *                     with gil:
  *                         raise ValueError("cython_lapack.posv failed (err=%i) on row %i. Try "             # <<<<<<<<<<<<<<
  *                                          "increasing the regularization parameter." % (err, u))
  * 
  */
-                                          __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 122, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_1);
                                           __Pyx_GIVEREF(__pyx_t_2);
                                           PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_2);
                                           __pyx_t_2 = 0;
-                                          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 122, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
                                           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
                                           __Pyx_Raise(__pyx_t_2, 0, 0, 0);
                                           __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-                                          __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __PYX_ERR(0, 122, __pyx_L29_error)
                                         }
 
-                                        /* "implicit/_als.pyx":118
+                                        /* "implicit/_als.pyx":121
  *                     # since a= Yt(Cu + regularization I)Y a is always positive. its also non
  *                     # zero if the regularization factor > 0.
  *                     with gil:             # <<<<<<<<<<<<<<
@@ -6468,7 +6531,7 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
  *                                          "increasing the regularization parameter." % (err, u))
  */
                                         /*finally:*/ {
-                                          __pyx_L28_error: {
+                                          __pyx_L29_error: {
                                             #ifdef WITH_THREAD
                                             __Pyx_PyGILState_Release(__pyx_gilstate_save);
                                             #endif
@@ -6477,10 +6540,10 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
                                         }
                                     }
                                   }
-                                  __pyx_L24:;
-                                  goto __pyx_L31;
+                                  __pyx_L25:;
+                                  goto __pyx_L32;
                                   __pyx_L15_continue:;
-                                  goto __pyx_L31;
+                                  goto __pyx_L32;
                                   __pyx_L17_error:;
                                   {
                                       #ifdef WITH_THREAD
@@ -6499,8 +6562,8 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
                                       #endif
                                   }
                                   __pyx_parallel_why = 4;
-                                  goto __pyx_L30;
-                                  __pyx_L30:;
+                                  goto __pyx_L31;
+                                  __pyx_L31:;
                                   #ifdef _OPENMP
                                   #pragma omp critical(__pyx_parallel_lastprivates1)
                                   #endif /* _OPENMP */
@@ -6513,7 +6576,7 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
                                       __pyx_parallel_temp5 = __pyx_v_temp;
                                       __pyx_parallel_temp6 = __pyx_v_u;
                                   }
-                                  __pyx_L31:;
+                                  __pyx_L32:;
                                   #ifdef _OPENMP
                                   #pragma omp flush(__pyx_parallel_why)
                                   #endif /* _OPENMP */
@@ -6551,7 +6614,7 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
                   }
                 }
 
-                /* "implicit/_als.pyx":123
+                /* "implicit/_als.pyx":126
  * 
  *         finally:
  *             free(A)             # <<<<<<<<<<<<<<
@@ -6562,7 +6625,7 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
                   /*normal exit:*/{
                     free(__pyx_v_A);
 
-                    /* "implicit/_als.pyx":124
+                    /* "implicit/_als.pyx":127
  *         finally:
  *             free(A)
  *             free(b)             # <<<<<<<<<<<<<<
@@ -6606,7 +6669,7 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
                     #endif
                     {
 
-                      /* "implicit/_als.pyx":123
+                      /* "implicit/_als.pyx":126
  * 
  *         finally:
  *             free(A)             # <<<<<<<<<<<<<<
@@ -6615,7 +6678,7 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
  */
                       free(__pyx_v_A);
 
-                      /* "implicit/_als.pyx":124
+                      /* "implicit/_als.pyx":127
  *         finally:
  *             free(A)
  *             free(b)             # <<<<<<<<<<<<<<
@@ -6647,7 +6710,7 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
                   }
                   __pyx_L14:;
                 }
-                goto __pyx_L37;
+                goto __pyx_L38;
                 __pyx_L8_error:;
                 {
                     #ifdef WITH_THREAD
@@ -6666,8 +6729,8 @@ static PyObject *__pyx_pf_8implicit_4_als_14_least_squares(CYTHON_UNUSED PyObjec
                     #endif
                 }
                 __pyx_parallel_why = 4;
-                goto __pyx_L37;
-                __pyx_L37:;
+                goto __pyx_L38;
+                __pyx_L38:;
                 #ifdef _OPENMP
                 Py_END_ALLOW_THREADS
                 #else
@@ -7471,17 +7534,49 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
                                     /* "implicit/_als.pyx":100
  *                     # b += Yi Cui Pui
  *                     # Pui is implicit, its defined to be 1 for non-zero entries
- *                     axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)             # <<<<<<<<<<<<<<
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ */
+                                    __pyx_t_15 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_15) {
+
+                                      /* "implicit/_als.pyx":101
+ *                     # Pui is implicit, its defined to be 1 for non-zero entries
+ *                     if confidence > 0:
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         confidence = -1 * confidence
+ */
+                                      __pyx_t_27 = __pyx_v_i;
+                                      __pyx_t_28 = 0;
+                                      if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
+                                      if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
+                                      __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_factors), (&__pyx_v_confidence), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_b, (&__pyx_v_one));
+
+                                      /* "implicit/_als.pyx":100
+ *                     # b += Yi Cui Pui
+ *                     # Pui is implicit, its defined to be 1 for non-zero entries
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ */
+                                      goto __pyx_L22;
+                                    }
+
+                                    /* "implicit/_als.pyx":103
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
  * 
  *                     # A += Yi^T Cui Yi
  */
-                                    __pyx_t_27 = __pyx_v_i;
-                                    __pyx_t_28 = 0;
-                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
-                                    __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_factors), (&__pyx_v_confidence), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_b, (&__pyx_v_one));
+                                    /*else*/ {
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L22:;
 
-                                    /* "implicit/_als.pyx":104
+                                    /* "implicit/_als.pyx":107
  *                     # A += Yi^T Cui Yi
  *                     # Since we've already added in YtY, we subtract 1 from confidence
  *                     for j in range(factors):             # <<<<<<<<<<<<<<
@@ -7492,7 +7587,7 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
                                     for (__pyx_t_30 = 0; __pyx_t_30 < __pyx_t_29; __pyx_t_30+=1) {
                                       __pyx_v_j = __pyx_t_30;
 
-                                      /* "implicit/_als.pyx":105
+                                      /* "implicit/_als.pyx":108
  *                     # Since we've already added in YtY, we subtract 1 from confidence
  *                     for j in range(factors):
  *                         temp = (confidence - 1) * Y[i, j]             # <<<<<<<<<<<<<<
@@ -7505,7 +7600,7 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
                                       if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_Y.shape[1];
                                       __pyx_v_temp = ((__pyx_v_confidence - 1.0) * (*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_31 * __pyx_v_Y.strides[0]) ) + __pyx_t_32 * __pyx_v_Y.strides[1]) ))));
 
-                                      /* "implicit/_als.pyx":106
+                                      /* "implicit/_als.pyx":109
  *                     for j in range(factors):
  *                         temp = (confidence - 1) * Y[i, j]
  *                         axpy(&factors, &temp, &Y[i, 0], &one, A + j * factors, &one)             # <<<<<<<<<<<<<<
@@ -7520,7 +7615,7 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
                                     }
                                   }
 
-                                  /* "implicit/_als.pyx":108
+                                  /* "implicit/_als.pyx":111
  *                         axpy(&factors, &temp, &Y[i, 0], &one, A + j * factors, &one)
  * 
  *                 err = 0             # <<<<<<<<<<<<<<
@@ -7529,7 +7624,7 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
  */
                                   __pyx_v_err = 0;
 
-                                  /* "implicit/_als.pyx":109
+                                  /* "implicit/_als.pyx":112
  * 
  *                 err = 0
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)             # <<<<<<<<<<<<<<
@@ -7538,7 +7633,7 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
  */
                                   __pyx_fuse_0__pyx_f_8implicit_4_als_posv(((char *)"U"), (&__pyx_v_factors), (&__pyx_v_one), __pyx_v_A, (&__pyx_v_factors), __pyx_v_b, (&__pyx_v_factors), (&__pyx_v_err));
 
-                                  /* "implicit/_als.pyx":111
+                                  /* "implicit/_als.pyx":114
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)
  * 
  *                 if not err:             # <<<<<<<<<<<<<<
@@ -7548,7 +7643,7 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
                                   __pyx_t_15 = ((!(__pyx_v_err != 0)) != 0);
                                   if (__pyx_t_15) {
 
-                                    /* "implicit/_als.pyx":112
+                                    /* "implicit/_als.pyx":115
  * 
  *                 if not err:
  *                     memcpy(&X[u, 0], b, sizeof(floating) * factors)             # <<<<<<<<<<<<<<
@@ -7561,17 +7656,17 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
                                     if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_X.shape[1];
                                     memcpy((&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_35 * __pyx_v_X.strides[0]) ) + __pyx_t_36 * __pyx_v_X.strides[1]) )))), __pyx_v_b, ((sizeof(float)) * __pyx_v_factors));
 
-                                    /* "implicit/_als.pyx":111
+                                    /* "implicit/_als.pyx":114
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)
  * 
  *                 if not err:             # <<<<<<<<<<<<<<
  *                     memcpy(&X[u, 0], b, sizeof(floating) * factors)
  *                 else:
  */
-                                    goto __pyx_L24;
+                                    goto __pyx_L25;
                                   }
 
-                                  /* "implicit/_als.pyx":118
+                                  /* "implicit/_als.pyx":121
  *                     # since a= Yt(Cu + regularization I)Y a is always positive. its also non
  *                     # zero if the regularization factor > 0.
  *                     with gil:             # <<<<<<<<<<<<<<
@@ -7585,18 +7680,18 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
                                         #endif
                                         /*try:*/ {
 
-                                          /* "implicit/_als.pyx":120
+                                          /* "implicit/_als.pyx":123
  *                     with gil:
  *                         raise ValueError("cython_lapack.posv failed (err=%i) on row %i. Try "
  *                                          "increasing the regularization parameter." % (err, u))             # <<<<<<<<<<<<<<
  * 
  *         finally:
  */
-                                          __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_err); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_err); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_5);
-                                          __pyx_t_2 = __Pyx_PyInt_From_int(__pyx_v_u); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyInt_From_int(__pyx_v_u); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
-                                          __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_1);
                                           __Pyx_GIVEREF(__pyx_t_5);
                                           PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_5);
@@ -7604,31 +7699,31 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
                                           PyTuple_SET_ITEM(__pyx_t_1, 1, __pyx_t_2);
                                           __pyx_t_5 = 0;
                                           __pyx_t_2 = 0;
-                                          __pyx_t_2 = __Pyx_PyString_Format(__pyx_kp_s_cython_lapack_posv_failed_err_i, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyString_Format(__pyx_kp_s_cython_lapack_posv_failed_err_i, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
                                           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-                                          /* "implicit/_als.pyx":119
+                                          /* "implicit/_als.pyx":122
  *                     # zero if the regularization factor > 0.
  *                     with gil:
  *                         raise ValueError("cython_lapack.posv failed (err=%i) on row %i. Try "             # <<<<<<<<<<<<<<
  *                                          "increasing the regularization parameter." % (err, u))
  * 
  */
-                                          __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 122, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_1);
                                           __Pyx_GIVEREF(__pyx_t_2);
                                           PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_2);
                                           __pyx_t_2 = 0;
-                                          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 122, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
                                           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
                                           __Pyx_Raise(__pyx_t_2, 0, 0, 0);
                                           __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-                                          __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __PYX_ERR(0, 122, __pyx_L29_error)
                                         }
 
-                                        /* "implicit/_als.pyx":118
+                                        /* "implicit/_als.pyx":121
  *                     # since a= Yt(Cu + regularization I)Y a is always positive. its also non
  *                     # zero if the regularization factor > 0.
  *                     with gil:             # <<<<<<<<<<<<<<
@@ -7636,7 +7731,7 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
  *                                          "increasing the regularization parameter." % (err, u))
  */
                                         /*finally:*/ {
-                                          __pyx_L28_error: {
+                                          __pyx_L29_error: {
                                             #ifdef WITH_THREAD
                                             __Pyx_PyGILState_Release(__pyx_gilstate_save);
                                             #endif
@@ -7645,10 +7740,10 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
                                         }
                                     }
                                   }
-                                  __pyx_L24:;
-                                  goto __pyx_L31;
+                                  __pyx_L25:;
+                                  goto __pyx_L32;
                                   __pyx_L15_continue:;
-                                  goto __pyx_L31;
+                                  goto __pyx_L32;
                                   __pyx_L17_error:;
                                   {
                                       #ifdef WITH_THREAD
@@ -7667,8 +7762,8 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
                                       #endif
                                   }
                                   __pyx_parallel_why = 4;
-                                  goto __pyx_L30;
-                                  __pyx_L30:;
+                                  goto __pyx_L31;
+                                  __pyx_L31:;
                                   #ifdef _OPENMP
                                   #pragma omp critical(__pyx_parallel_lastprivates2)
                                   #endif /* _OPENMP */
@@ -7681,7 +7776,7 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
                                       __pyx_parallel_temp5 = __pyx_v_temp;
                                       __pyx_parallel_temp6 = __pyx_v_u;
                                   }
-                                  __pyx_L31:;
+                                  __pyx_L32:;
                                   #ifdef _OPENMP
                                   #pragma omp flush(__pyx_parallel_why)
                                   #endif /* _OPENMP */
@@ -7719,7 +7814,7 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
                   }
                 }
 
-                /* "implicit/_als.pyx":123
+                /* "implicit/_als.pyx":126
  * 
  *         finally:
  *             free(A)             # <<<<<<<<<<<<<<
@@ -7730,7 +7825,7 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
                   /*normal exit:*/{
                     free(__pyx_v_A);
 
-                    /* "implicit/_als.pyx":124
+                    /* "implicit/_als.pyx":127
  *         finally:
  *             free(A)
  *             free(b)             # <<<<<<<<<<<<<<
@@ -7774,7 +7869,7 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
                     #endif
                     {
 
-                      /* "implicit/_als.pyx":123
+                      /* "implicit/_als.pyx":126
  * 
  *         finally:
  *             free(A)             # <<<<<<<<<<<<<<
@@ -7783,7 +7878,7 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
  */
                       free(__pyx_v_A);
 
-                      /* "implicit/_als.pyx":124
+                      /* "implicit/_als.pyx":127
  *         finally:
  *             free(A)
  *             free(b)             # <<<<<<<<<<<<<<
@@ -7815,7 +7910,7 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
                   }
                   __pyx_L14:;
                 }
-                goto __pyx_L37;
+                goto __pyx_L38;
                 __pyx_L8_error:;
                 {
                     #ifdef WITH_THREAD
@@ -7834,8 +7929,8 @@ static PyObject *__pyx_pf_8implicit_4_als_16_least_squares(CYTHON_UNUSED PyObjec
                     #endif
                 }
                 __pyx_parallel_why = 4;
-                goto __pyx_L37;
-                __pyx_L37:;
+                goto __pyx_L38;
+                __pyx_L38:;
                 #ifdef _OPENMP
                 Py_END_ALLOW_THREADS
                 #else
@@ -8639,17 +8734,49 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
                                     /* "implicit/_als.pyx":100
  *                     # b += Yi Cui Pui
  *                     # Pui is implicit, its defined to be 1 for non-zero entries
- *                     axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)             # <<<<<<<<<<<<<<
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ */
+                                    __pyx_t_15 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_15) {
+
+                                      /* "implicit/_als.pyx":101
+ *                     # Pui is implicit, its defined to be 1 for non-zero entries
+ *                     if confidence > 0:
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         confidence = -1 * confidence
+ */
+                                      __pyx_t_27 = __pyx_v_i;
+                                      __pyx_t_28 = 0;
+                                      if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
+                                      if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
+                                      __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_factors), (&__pyx_v_confidence), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_b, (&__pyx_v_one));
+
+                                      /* "implicit/_als.pyx":100
+ *                     # b += Yi Cui Pui
+ *                     # Pui is implicit, its defined to be 1 for non-zero entries
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ */
+                                      goto __pyx_L22;
+                                    }
+
+                                    /* "implicit/_als.pyx":103
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
  * 
  *                     # A += Yi^T Cui Yi
  */
-                                    __pyx_t_27 = __pyx_v_i;
-                                    __pyx_t_28 = 0;
-                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
-                                    __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_factors), (&__pyx_v_confidence), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_b, (&__pyx_v_one));
+                                    /*else*/ {
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L22:;
 
-                                    /* "implicit/_als.pyx":104
+                                    /* "implicit/_als.pyx":107
  *                     # A += Yi^T Cui Yi
  *                     # Since we've already added in YtY, we subtract 1 from confidence
  *                     for j in range(factors):             # <<<<<<<<<<<<<<
@@ -8660,7 +8787,7 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
                                     for (__pyx_t_30 = 0; __pyx_t_30 < __pyx_t_29; __pyx_t_30+=1) {
                                       __pyx_v_j = __pyx_t_30;
 
-                                      /* "implicit/_als.pyx":105
+                                      /* "implicit/_als.pyx":108
  *                     # Since we've already added in YtY, we subtract 1 from confidence
  *                     for j in range(factors):
  *                         temp = (confidence - 1) * Y[i, j]             # <<<<<<<<<<<<<<
@@ -8673,7 +8800,7 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
                                       if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_Y.shape[1];
                                       __pyx_v_temp = ((__pyx_v_confidence - 1.0) * (*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_31 * __pyx_v_Y.strides[0]) ) + __pyx_t_32 * __pyx_v_Y.strides[1]) ))));
 
-                                      /* "implicit/_als.pyx":106
+                                      /* "implicit/_als.pyx":109
  *                     for j in range(factors):
  *                         temp = (confidence - 1) * Y[i, j]
  *                         axpy(&factors, &temp, &Y[i, 0], &one, A + j * factors, &one)             # <<<<<<<<<<<<<<
@@ -8688,7 +8815,7 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
                                     }
                                   }
 
-                                  /* "implicit/_als.pyx":108
+                                  /* "implicit/_als.pyx":111
  *                         axpy(&factors, &temp, &Y[i, 0], &one, A + j * factors, &one)
  * 
  *                 err = 0             # <<<<<<<<<<<<<<
@@ -8697,7 +8824,7 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
  */
                                   __pyx_v_err = 0;
 
-                                  /* "implicit/_als.pyx":109
+                                  /* "implicit/_als.pyx":112
  * 
  *                 err = 0
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)             # <<<<<<<<<<<<<<
@@ -8706,7 +8833,7 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
  */
                                   __pyx_fuse_1__pyx_f_8implicit_4_als_posv(((char *)"U"), (&__pyx_v_factors), (&__pyx_v_one), __pyx_v_A, (&__pyx_v_factors), __pyx_v_b, (&__pyx_v_factors), (&__pyx_v_err));
 
-                                  /* "implicit/_als.pyx":111
+                                  /* "implicit/_als.pyx":114
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)
  * 
  *                 if not err:             # <<<<<<<<<<<<<<
@@ -8716,7 +8843,7 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
                                   __pyx_t_15 = ((!(__pyx_v_err != 0)) != 0);
                                   if (__pyx_t_15) {
 
-                                    /* "implicit/_als.pyx":112
+                                    /* "implicit/_als.pyx":115
  * 
  *                 if not err:
  *                     memcpy(&X[u, 0], b, sizeof(floating) * factors)             # <<<<<<<<<<<<<<
@@ -8729,17 +8856,17 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
                                     if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_X.shape[1];
                                     memcpy((&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_35 * __pyx_v_X.strides[0]) ) + __pyx_t_36 * __pyx_v_X.strides[1]) )))), __pyx_v_b, ((sizeof(double)) * __pyx_v_factors));
 
-                                    /* "implicit/_als.pyx":111
+                                    /* "implicit/_als.pyx":114
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)
  * 
  *                 if not err:             # <<<<<<<<<<<<<<
  *                     memcpy(&X[u, 0], b, sizeof(floating) * factors)
  *                 else:
  */
-                                    goto __pyx_L24;
+                                    goto __pyx_L25;
                                   }
 
-                                  /* "implicit/_als.pyx":118
+                                  /* "implicit/_als.pyx":121
  *                     # since a= Yt(Cu + regularization I)Y a is always positive. its also non
  *                     # zero if the regularization factor > 0.
  *                     with gil:             # <<<<<<<<<<<<<<
@@ -8753,18 +8880,18 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
                                         #endif
                                         /*try:*/ {
 
-                                          /* "implicit/_als.pyx":120
+                                          /* "implicit/_als.pyx":123
  *                     with gil:
  *                         raise ValueError("cython_lapack.posv failed (err=%i) on row %i. Try "
  *                                          "increasing the regularization parameter." % (err, u))             # <<<<<<<<<<<<<<
  * 
  *         finally:
  */
-                                          __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_err); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_err); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_5);
-                                          __pyx_t_2 = __Pyx_PyInt_From_int(__pyx_v_u); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyInt_From_int(__pyx_v_u); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
-                                          __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_1);
                                           __Pyx_GIVEREF(__pyx_t_5);
                                           PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_5);
@@ -8772,31 +8899,31 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
                                           PyTuple_SET_ITEM(__pyx_t_1, 1, __pyx_t_2);
                                           __pyx_t_5 = 0;
                                           __pyx_t_2 = 0;
-                                          __pyx_t_2 = __Pyx_PyString_Format(__pyx_kp_s_cython_lapack_posv_failed_err_i, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyString_Format(__pyx_kp_s_cython_lapack_posv_failed_err_i, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
                                           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-                                          /* "implicit/_als.pyx":119
+                                          /* "implicit/_als.pyx":122
  *                     # zero if the regularization factor > 0.
  *                     with gil:
  *                         raise ValueError("cython_lapack.posv failed (err=%i) on row %i. Try "             # <<<<<<<<<<<<<<
  *                                          "increasing the regularization parameter." % (err, u))
  * 
  */
-                                          __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 122, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_1);
                                           __Pyx_GIVEREF(__pyx_t_2);
                                           PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_2);
                                           __pyx_t_2 = 0;
-                                          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 122, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
                                           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
                                           __Pyx_Raise(__pyx_t_2, 0, 0, 0);
                                           __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-                                          __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __PYX_ERR(0, 122, __pyx_L29_error)
                                         }
 
-                                        /* "implicit/_als.pyx":118
+                                        /* "implicit/_als.pyx":121
  *                     # since a= Yt(Cu + regularization I)Y a is always positive. its also non
  *                     # zero if the regularization factor > 0.
  *                     with gil:             # <<<<<<<<<<<<<<
@@ -8804,7 +8931,7 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
  *                                          "increasing the regularization parameter." % (err, u))
  */
                                         /*finally:*/ {
-                                          __pyx_L28_error: {
+                                          __pyx_L29_error: {
                                             #ifdef WITH_THREAD
                                             __Pyx_PyGILState_Release(__pyx_gilstate_save);
                                             #endif
@@ -8813,10 +8940,10 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
                                         }
                                     }
                                   }
-                                  __pyx_L24:;
-                                  goto __pyx_L31;
+                                  __pyx_L25:;
+                                  goto __pyx_L32;
                                   __pyx_L15_continue:;
-                                  goto __pyx_L31;
+                                  goto __pyx_L32;
                                   __pyx_L17_error:;
                                   {
                                       #ifdef WITH_THREAD
@@ -8835,8 +8962,8 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
                                       #endif
                                   }
                                   __pyx_parallel_why = 4;
-                                  goto __pyx_L30;
-                                  __pyx_L30:;
+                                  goto __pyx_L31;
+                                  __pyx_L31:;
                                   #ifdef _OPENMP
                                   #pragma omp critical(__pyx_parallel_lastprivates3)
                                   #endif /* _OPENMP */
@@ -8849,7 +8976,7 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
                                       __pyx_parallel_temp5 = __pyx_v_temp;
                                       __pyx_parallel_temp6 = __pyx_v_u;
                                   }
-                                  __pyx_L31:;
+                                  __pyx_L32:;
                                   #ifdef _OPENMP
                                   #pragma omp flush(__pyx_parallel_why)
                                   #endif /* _OPENMP */
@@ -8887,7 +9014,7 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
                   }
                 }
 
-                /* "implicit/_als.pyx":123
+                /* "implicit/_als.pyx":126
  * 
  *         finally:
  *             free(A)             # <<<<<<<<<<<<<<
@@ -8898,7 +9025,7 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
                   /*normal exit:*/{
                     free(__pyx_v_A);
 
-                    /* "implicit/_als.pyx":124
+                    /* "implicit/_als.pyx":127
  *         finally:
  *             free(A)
  *             free(b)             # <<<<<<<<<<<<<<
@@ -8942,7 +9069,7 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
                     #endif
                     {
 
-                      /* "implicit/_als.pyx":123
+                      /* "implicit/_als.pyx":126
  * 
  *         finally:
  *             free(A)             # <<<<<<<<<<<<<<
@@ -8951,7 +9078,7 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
  */
                       free(__pyx_v_A);
 
-                      /* "implicit/_als.pyx":124
+                      /* "implicit/_als.pyx":127
  *         finally:
  *             free(A)
  *             free(b)             # <<<<<<<<<<<<<<
@@ -8983,7 +9110,7 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
                   }
                   __pyx_L14:;
                 }
-                goto __pyx_L37;
+                goto __pyx_L38;
                 __pyx_L8_error:;
                 {
                     #ifdef WITH_THREAD
@@ -9002,8 +9129,8 @@ static PyObject *__pyx_pf_8implicit_4_als_18_least_squares(CYTHON_UNUSED PyObjec
                     #endif
                 }
                 __pyx_parallel_why = 4;
-                goto __pyx_L37;
-                __pyx_L37:;
+                goto __pyx_L38;
+                __pyx_L38:;
                 #ifdef _OPENMP
                 Py_END_ALLOW_THREADS
                 #else
@@ -9807,17 +9934,49 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
                                     /* "implicit/_als.pyx":100
  *                     # b += Yi Cui Pui
  *                     # Pui is implicit, its defined to be 1 for non-zero entries
- *                     axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)             # <<<<<<<<<<<<<<
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ */
+                                    __pyx_t_15 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_15) {
+
+                                      /* "implicit/_als.pyx":101
+ *                     # Pui is implicit, its defined to be 1 for non-zero entries
+ *                     if confidence > 0:
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         confidence = -1 * confidence
+ */
+                                      __pyx_t_27 = __pyx_v_i;
+                                      __pyx_t_28 = 0;
+                                      if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
+                                      if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
+                                      __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_factors), (&__pyx_v_confidence), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_b, (&__pyx_v_one));
+
+                                      /* "implicit/_als.pyx":100
+ *                     # b += Yi Cui Pui
+ *                     # Pui is implicit, its defined to be 1 for non-zero entries
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ */
+                                      goto __pyx_L22;
+                                    }
+
+                                    /* "implicit/_als.pyx":103
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
  * 
  *                     # A += Yi^T Cui Yi
  */
-                                    __pyx_t_27 = __pyx_v_i;
-                                    __pyx_t_28 = 0;
-                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
-                                    __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_factors), (&__pyx_v_confidence), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_b, (&__pyx_v_one));
+                                    /*else*/ {
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L22:;
 
-                                    /* "implicit/_als.pyx":104
+                                    /* "implicit/_als.pyx":107
  *                     # A += Yi^T Cui Yi
  *                     # Since we've already added in YtY, we subtract 1 from confidence
  *                     for j in range(factors):             # <<<<<<<<<<<<<<
@@ -9828,7 +9987,7 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
                                     for (__pyx_t_30 = 0; __pyx_t_30 < __pyx_t_29; __pyx_t_30+=1) {
                                       __pyx_v_j = __pyx_t_30;
 
-                                      /* "implicit/_als.pyx":105
+                                      /* "implicit/_als.pyx":108
  *                     # Since we've already added in YtY, we subtract 1 from confidence
  *                     for j in range(factors):
  *                         temp = (confidence - 1) * Y[i, j]             # <<<<<<<<<<<<<<
@@ -9841,7 +10000,7 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
                                       if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_Y.shape[1];
                                       __pyx_v_temp = ((__pyx_v_confidence - 1.0) * (*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_31 * __pyx_v_Y.strides[0]) ) + __pyx_t_32 * __pyx_v_Y.strides[1]) ))));
 
-                                      /* "implicit/_als.pyx":106
+                                      /* "implicit/_als.pyx":109
  *                     for j in range(factors):
  *                         temp = (confidence - 1) * Y[i, j]
  *                         axpy(&factors, &temp, &Y[i, 0], &one, A + j * factors, &one)             # <<<<<<<<<<<<<<
@@ -9856,7 +10015,7 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
                                     }
                                   }
 
-                                  /* "implicit/_als.pyx":108
+                                  /* "implicit/_als.pyx":111
  *                         axpy(&factors, &temp, &Y[i, 0], &one, A + j * factors, &one)
  * 
  *                 err = 0             # <<<<<<<<<<<<<<
@@ -9865,7 +10024,7 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
  */
                                   __pyx_v_err = 0;
 
-                                  /* "implicit/_als.pyx":109
+                                  /* "implicit/_als.pyx":112
  * 
  *                 err = 0
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)             # <<<<<<<<<<<<<<
@@ -9874,7 +10033,7 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
  */
                                   __pyx_fuse_0__pyx_f_8implicit_4_als_posv(((char *)"U"), (&__pyx_v_factors), (&__pyx_v_one), __pyx_v_A, (&__pyx_v_factors), __pyx_v_b, (&__pyx_v_factors), (&__pyx_v_err));
 
-                                  /* "implicit/_als.pyx":111
+                                  /* "implicit/_als.pyx":114
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)
  * 
  *                 if not err:             # <<<<<<<<<<<<<<
@@ -9884,7 +10043,7 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
                                   __pyx_t_15 = ((!(__pyx_v_err != 0)) != 0);
                                   if (__pyx_t_15) {
 
-                                    /* "implicit/_als.pyx":112
+                                    /* "implicit/_als.pyx":115
  * 
  *                 if not err:
  *                     memcpy(&X[u, 0], b, sizeof(floating) * factors)             # <<<<<<<<<<<<<<
@@ -9897,17 +10056,17 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
                                     if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_X.shape[1];
                                     memcpy((&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_35 * __pyx_v_X.strides[0]) ) + __pyx_t_36 * __pyx_v_X.strides[1]) )))), __pyx_v_b, ((sizeof(float)) * __pyx_v_factors));
 
-                                    /* "implicit/_als.pyx":111
+                                    /* "implicit/_als.pyx":114
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)
  * 
  *                 if not err:             # <<<<<<<<<<<<<<
  *                     memcpy(&X[u, 0], b, sizeof(floating) * factors)
  *                 else:
  */
-                                    goto __pyx_L24;
+                                    goto __pyx_L25;
                                   }
 
-                                  /* "implicit/_als.pyx":118
+                                  /* "implicit/_als.pyx":121
  *                     # since a= Yt(Cu + regularization I)Y a is always positive. its also non
  *                     # zero if the regularization factor > 0.
  *                     with gil:             # <<<<<<<<<<<<<<
@@ -9921,18 +10080,18 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
                                         #endif
                                         /*try:*/ {
 
-                                          /* "implicit/_als.pyx":120
+                                          /* "implicit/_als.pyx":123
  *                     with gil:
  *                         raise ValueError("cython_lapack.posv failed (err=%i) on row %i. Try "
  *                                          "increasing the regularization parameter." % (err, u))             # <<<<<<<<<<<<<<
  * 
  *         finally:
  */
-                                          __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_err); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_err); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_5);
-                                          __pyx_t_2 = __Pyx_PyInt_From_int(__pyx_v_u); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyInt_From_int(__pyx_v_u); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
-                                          __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_1);
                                           __Pyx_GIVEREF(__pyx_t_5);
                                           PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_5);
@@ -9940,31 +10099,31 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
                                           PyTuple_SET_ITEM(__pyx_t_1, 1, __pyx_t_2);
                                           __pyx_t_5 = 0;
                                           __pyx_t_2 = 0;
-                                          __pyx_t_2 = __Pyx_PyString_Format(__pyx_kp_s_cython_lapack_posv_failed_err_i, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyString_Format(__pyx_kp_s_cython_lapack_posv_failed_err_i, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
                                           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-                                          /* "implicit/_als.pyx":119
+                                          /* "implicit/_als.pyx":122
  *                     # zero if the regularization factor > 0.
  *                     with gil:
  *                         raise ValueError("cython_lapack.posv failed (err=%i) on row %i. Try "             # <<<<<<<<<<<<<<
  *                                          "increasing the regularization parameter." % (err, u))
  * 
  */
-                                          __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 122, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_1);
                                           __Pyx_GIVEREF(__pyx_t_2);
                                           PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_2);
                                           __pyx_t_2 = 0;
-                                          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 122, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
                                           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
                                           __Pyx_Raise(__pyx_t_2, 0, 0, 0);
                                           __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-                                          __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __PYX_ERR(0, 122, __pyx_L29_error)
                                         }
 
-                                        /* "implicit/_als.pyx":118
+                                        /* "implicit/_als.pyx":121
  *                     # since a= Yt(Cu + regularization I)Y a is always positive. its also non
  *                     # zero if the regularization factor > 0.
  *                     with gil:             # <<<<<<<<<<<<<<
@@ -9972,7 +10131,7 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
  *                                          "increasing the regularization parameter." % (err, u))
  */
                                         /*finally:*/ {
-                                          __pyx_L28_error: {
+                                          __pyx_L29_error: {
                                             #ifdef WITH_THREAD
                                             __Pyx_PyGILState_Release(__pyx_gilstate_save);
                                             #endif
@@ -9981,10 +10140,10 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
                                         }
                                     }
                                   }
-                                  __pyx_L24:;
-                                  goto __pyx_L31;
+                                  __pyx_L25:;
+                                  goto __pyx_L32;
                                   __pyx_L15_continue:;
-                                  goto __pyx_L31;
+                                  goto __pyx_L32;
                                   __pyx_L17_error:;
                                   {
                                       #ifdef WITH_THREAD
@@ -10003,8 +10162,8 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
                                       #endif
                                   }
                                   __pyx_parallel_why = 4;
-                                  goto __pyx_L30;
-                                  __pyx_L30:;
+                                  goto __pyx_L31;
+                                  __pyx_L31:;
                                   #ifdef _OPENMP
                                   #pragma omp critical(__pyx_parallel_lastprivates4)
                                   #endif /* _OPENMP */
@@ -10017,7 +10176,7 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
                                       __pyx_parallel_temp5 = __pyx_v_temp;
                                       __pyx_parallel_temp6 = __pyx_v_u;
                                   }
-                                  __pyx_L31:;
+                                  __pyx_L32:;
                                   #ifdef _OPENMP
                                   #pragma omp flush(__pyx_parallel_why)
                                   #endif /* _OPENMP */
@@ -10055,7 +10214,7 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
                   }
                 }
 
-                /* "implicit/_als.pyx":123
+                /* "implicit/_als.pyx":126
  * 
  *         finally:
  *             free(A)             # <<<<<<<<<<<<<<
@@ -10066,7 +10225,7 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
                   /*normal exit:*/{
                     free(__pyx_v_A);
 
-                    /* "implicit/_als.pyx":124
+                    /* "implicit/_als.pyx":127
  *         finally:
  *             free(A)
  *             free(b)             # <<<<<<<<<<<<<<
@@ -10110,7 +10269,7 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
                     #endif
                     {
 
-                      /* "implicit/_als.pyx":123
+                      /* "implicit/_als.pyx":126
  * 
  *         finally:
  *             free(A)             # <<<<<<<<<<<<<<
@@ -10119,7 +10278,7 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
  */
                       free(__pyx_v_A);
 
-                      /* "implicit/_als.pyx":124
+                      /* "implicit/_als.pyx":127
  *         finally:
  *             free(A)
  *             free(b)             # <<<<<<<<<<<<<<
@@ -10151,7 +10310,7 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
                   }
                   __pyx_L14:;
                 }
-                goto __pyx_L37;
+                goto __pyx_L38;
                 __pyx_L8_error:;
                 {
                     #ifdef WITH_THREAD
@@ -10170,8 +10329,8 @@ static PyObject *__pyx_pf_8implicit_4_als_20_least_squares(CYTHON_UNUSED PyObjec
                     #endif
                 }
                 __pyx_parallel_why = 4;
-                goto __pyx_L37;
-                __pyx_L37:;
+                goto __pyx_L38;
+                __pyx_L38:;
                 #ifdef _OPENMP
                 Py_END_ALLOW_THREADS
                 #else
@@ -10975,17 +11134,49 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
                                     /* "implicit/_als.pyx":100
  *                     # b += Yi Cui Pui
  *                     # Pui is implicit, its defined to be 1 for non-zero entries
- *                     axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)             # <<<<<<<<<<<<<<
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ */
+                                    __pyx_t_15 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_15) {
+
+                                      /* "implicit/_als.pyx":101
+ *                     # Pui is implicit, its defined to be 1 for non-zero entries
+ *                     if confidence > 0:
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         confidence = -1 * confidence
+ */
+                                      __pyx_t_27 = __pyx_v_i;
+                                      __pyx_t_28 = 0;
+                                      if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
+                                      if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
+                                      __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_factors), (&__pyx_v_confidence), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_b, (&__pyx_v_one));
+
+                                      /* "implicit/_als.pyx":100
+ *                     # b += Yi Cui Pui
+ *                     # Pui is implicit, its defined to be 1 for non-zero entries
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ */
+                                      goto __pyx_L22;
+                                    }
+
+                                    /* "implicit/_als.pyx":103
+ *                         axpy(&factors, &confidence, &Y[i, 0], &one, b, &one)
+ *                     else:
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
  * 
  *                     # A += Yi^T Cui Yi
  */
-                                    __pyx_t_27 = __pyx_v_i;
-                                    __pyx_t_28 = 0;
-                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
-                                    __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_factors), (&__pyx_v_confidence), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_b, (&__pyx_v_one));
+                                    /*else*/ {
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L22:;
 
-                                    /* "implicit/_als.pyx":104
+                                    /* "implicit/_als.pyx":107
  *                     # A += Yi^T Cui Yi
  *                     # Since we've already added in YtY, we subtract 1 from confidence
  *                     for j in range(factors):             # <<<<<<<<<<<<<<
@@ -10996,7 +11187,7 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
                                     for (__pyx_t_30 = 0; __pyx_t_30 < __pyx_t_29; __pyx_t_30+=1) {
                                       __pyx_v_j = __pyx_t_30;
 
-                                      /* "implicit/_als.pyx":105
+                                      /* "implicit/_als.pyx":108
  *                     # Since we've already added in YtY, we subtract 1 from confidence
  *                     for j in range(factors):
  *                         temp = (confidence - 1) * Y[i, j]             # <<<<<<<<<<<<<<
@@ -11009,7 +11200,7 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
                                       if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_Y.shape[1];
                                       __pyx_v_temp = ((__pyx_v_confidence - 1.0) * (*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_31 * __pyx_v_Y.strides[0]) ) + __pyx_t_32 * __pyx_v_Y.strides[1]) ))));
 
-                                      /* "implicit/_als.pyx":106
+                                      /* "implicit/_als.pyx":109
  *                     for j in range(factors):
  *                         temp = (confidence - 1) * Y[i, j]
  *                         axpy(&factors, &temp, &Y[i, 0], &one, A + j * factors, &one)             # <<<<<<<<<<<<<<
@@ -11024,7 +11215,7 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
                                     }
                                   }
 
-                                  /* "implicit/_als.pyx":108
+                                  /* "implicit/_als.pyx":111
  *                         axpy(&factors, &temp, &Y[i, 0], &one, A + j * factors, &one)
  * 
  *                 err = 0             # <<<<<<<<<<<<<<
@@ -11033,7 +11224,7 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
  */
                                   __pyx_v_err = 0;
 
-                                  /* "implicit/_als.pyx":109
+                                  /* "implicit/_als.pyx":112
  * 
  *                 err = 0
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)             # <<<<<<<<<<<<<<
@@ -11042,7 +11233,7 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
  */
                                   __pyx_fuse_1__pyx_f_8implicit_4_als_posv(((char *)"U"), (&__pyx_v_factors), (&__pyx_v_one), __pyx_v_A, (&__pyx_v_factors), __pyx_v_b, (&__pyx_v_factors), (&__pyx_v_err));
 
-                                  /* "implicit/_als.pyx":111
+                                  /* "implicit/_als.pyx":114
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)
  * 
  *                 if not err:             # <<<<<<<<<<<<<<
@@ -11052,7 +11243,7 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
                                   __pyx_t_15 = ((!(__pyx_v_err != 0)) != 0);
                                   if (__pyx_t_15) {
 
-                                    /* "implicit/_als.pyx":112
+                                    /* "implicit/_als.pyx":115
  * 
  *                 if not err:
  *                     memcpy(&X[u, 0], b, sizeof(floating) * factors)             # <<<<<<<<<<<<<<
@@ -11065,17 +11256,17 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
                                     if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_X.shape[1];
                                     memcpy((&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_35 * __pyx_v_X.strides[0]) ) + __pyx_t_36 * __pyx_v_X.strides[1]) )))), __pyx_v_b, ((sizeof(double)) * __pyx_v_factors));
 
-                                    /* "implicit/_als.pyx":111
+                                    /* "implicit/_als.pyx":114
  *                 posv("U", &factors, &one, A, &factors, b, &factors, &err)
  * 
  *                 if not err:             # <<<<<<<<<<<<<<
  *                     memcpy(&X[u, 0], b, sizeof(floating) * factors)
  *                 else:
  */
-                                    goto __pyx_L24;
+                                    goto __pyx_L25;
                                   }
 
-                                  /* "implicit/_als.pyx":118
+                                  /* "implicit/_als.pyx":121
  *                     # since a= Yt(Cu + regularization I)Y a is always positive. its also non
  *                     # zero if the regularization factor > 0.
  *                     with gil:             # <<<<<<<<<<<<<<
@@ -11089,18 +11280,18 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
                                         #endif
                                         /*try:*/ {
 
-                                          /* "implicit/_als.pyx":120
+                                          /* "implicit/_als.pyx":123
  *                     with gil:
  *                         raise ValueError("cython_lapack.posv failed (err=%i) on row %i. Try "
  *                                          "increasing the regularization parameter." % (err, u))             # <<<<<<<<<<<<<<
  * 
  *         finally:
  */
-                                          __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_err); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_5 = __Pyx_PyInt_From_int(__pyx_v_err); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_5);
-                                          __pyx_t_2 = __Pyx_PyInt_From_int(__pyx_v_u); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyInt_From_int(__pyx_v_u); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
-                                          __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_1);
                                           __Pyx_GIVEREF(__pyx_t_5);
                                           PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_5);
@@ -11108,31 +11299,31 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
                                           PyTuple_SET_ITEM(__pyx_t_1, 1, __pyx_t_2);
                                           __pyx_t_5 = 0;
                                           __pyx_t_2 = 0;
-                                          __pyx_t_2 = __Pyx_PyString_Format(__pyx_kp_s_cython_lapack_posv_failed_err_i, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 120, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyString_Format(__pyx_kp_s_cython_lapack_posv_failed_err_i, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 123, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
                                           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-                                          /* "implicit/_als.pyx":119
+                                          /* "implicit/_als.pyx":122
  *                     # zero if the regularization factor > 0.
  *                     with gil:
  *                         raise ValueError("cython_lapack.posv failed (err=%i) on row %i. Try "             # <<<<<<<<<<<<<<
  *                                          "increasing the regularization parameter." % (err, u))
  * 
  */
-                                          __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 122, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_1);
                                           __Pyx_GIVEREF(__pyx_t_2);
                                           PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_2);
                                           __pyx_t_2 = 0;
-                                          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 122, __pyx_L29_error)
                                           __Pyx_GOTREF(__pyx_t_2);
                                           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
                                           __Pyx_Raise(__pyx_t_2, 0, 0, 0);
                                           __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-                                          __PYX_ERR(0, 119, __pyx_L28_error)
+                                          __PYX_ERR(0, 122, __pyx_L29_error)
                                         }
 
-                                        /* "implicit/_als.pyx":118
+                                        /* "implicit/_als.pyx":121
  *                     # since a= Yt(Cu + regularization I)Y a is always positive. its also non
  *                     # zero if the regularization factor > 0.
  *                     with gil:             # <<<<<<<<<<<<<<
@@ -11140,7 +11331,7 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
  *                                          "increasing the regularization parameter." % (err, u))
  */
                                         /*finally:*/ {
-                                          __pyx_L28_error: {
+                                          __pyx_L29_error: {
                                             #ifdef WITH_THREAD
                                             __Pyx_PyGILState_Release(__pyx_gilstate_save);
                                             #endif
@@ -11149,10 +11340,10 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
                                         }
                                     }
                                   }
-                                  __pyx_L24:;
-                                  goto __pyx_L31;
+                                  __pyx_L25:;
+                                  goto __pyx_L32;
                                   __pyx_L15_continue:;
-                                  goto __pyx_L31;
+                                  goto __pyx_L32;
                                   __pyx_L17_error:;
                                   {
                                       #ifdef WITH_THREAD
@@ -11171,8 +11362,8 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
                                       #endif
                                   }
                                   __pyx_parallel_why = 4;
-                                  goto __pyx_L30;
-                                  __pyx_L30:;
+                                  goto __pyx_L31;
+                                  __pyx_L31:;
                                   #ifdef _OPENMP
                                   #pragma omp critical(__pyx_parallel_lastprivates5)
                                   #endif /* _OPENMP */
@@ -11185,7 +11376,7 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
                                       __pyx_parallel_temp5 = __pyx_v_temp;
                                       __pyx_parallel_temp6 = __pyx_v_u;
                                   }
-                                  __pyx_L31:;
+                                  __pyx_L32:;
                                   #ifdef _OPENMP
                                   #pragma omp flush(__pyx_parallel_why)
                                   #endif /* _OPENMP */
@@ -11223,7 +11414,7 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
                   }
                 }
 
-                /* "implicit/_als.pyx":123
+                /* "implicit/_als.pyx":126
  * 
  *         finally:
  *             free(A)             # <<<<<<<<<<<<<<
@@ -11234,7 +11425,7 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
                   /*normal exit:*/{
                     free(__pyx_v_A);
 
-                    /* "implicit/_als.pyx":124
+                    /* "implicit/_als.pyx":127
  *         finally:
  *             free(A)
  *             free(b)             # <<<<<<<<<<<<<<
@@ -11278,7 +11469,7 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
                     #endif
                     {
 
-                      /* "implicit/_als.pyx":123
+                      /* "implicit/_als.pyx":126
  * 
  *         finally:
  *             free(A)             # <<<<<<<<<<<<<<
@@ -11287,7 +11478,7 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
  */
                       free(__pyx_v_A);
 
-                      /* "implicit/_als.pyx":124
+                      /* "implicit/_als.pyx":127
  *         finally:
  *             free(A)
  *             free(b)             # <<<<<<<<<<<<<<
@@ -11319,7 +11510,7 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
                   }
                   __pyx_L14:;
                 }
-                goto __pyx_L37;
+                goto __pyx_L38;
                 __pyx_L8_error:;
                 {
                     #ifdef WITH_THREAD
@@ -11338,8 +11529,8 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
                     #endif
                 }
                 __pyx_parallel_why = 4;
-                goto __pyx_L37;
-                __pyx_L37:;
+                goto __pyx_L38;
+                __pyx_L38:;
                 #ifdef _OPENMP
                 Py_END_ALLOW_THREADS
                 #else
@@ -11468,7 +11659,7 @@ static PyObject *__pyx_pf_8implicit_4_als_22_least_squares(CYTHON_UNUSED PyObjec
   return __pyx_r;
 }
 
-/* "implicit/_als.pyx":127
+/* "implicit/_als.pyx":130
  * 
  * 
  * def least_squares_cg(Cui, X, Y, regularization, num_threads=0, cg_steps=3):             # <<<<<<<<<<<<<<
@@ -11522,19 +11713,19 @@ static PyObject *__pyx_pw_8implicit_4_als_5least_squares_cg(PyObject *__pyx_self
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_X)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("least_squares_cg", 0, 4, 6, 1); __PYX_ERR(0, 127, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("least_squares_cg", 0, 4, 6, 1); __PYX_ERR(0, 130, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_Y)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("least_squares_cg", 0, 4, 6, 2); __PYX_ERR(0, 127, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("least_squares_cg", 0, 4, 6, 2); __PYX_ERR(0, 130, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_regularization)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("least_squares_cg", 0, 4, 6, 3); __PYX_ERR(0, 127, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("least_squares_cg", 0, 4, 6, 3); __PYX_ERR(0, 130, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
@@ -11550,7 +11741,7 @@ static PyObject *__pyx_pw_8implicit_4_als_5least_squares_cg(PyObject *__pyx_self
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "least_squares_cg") < 0)) __PYX_ERR(0, 127, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "least_squares_cg") < 0)) __PYX_ERR(0, 130, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -11575,7 +11766,7 @@ static PyObject *__pyx_pw_8implicit_4_als_5least_squares_cg(PyObject *__pyx_self
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("least_squares_cg", 0, 4, 6, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 127, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("least_squares_cg", 0, 4, 6, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 130, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("implicit._als.least_squares_cg", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -11601,7 +11792,7 @@ static PyObject *__pyx_pf_8implicit_4_als_4least_squares_cg(CYTHON_UNUSED PyObje
   PyObject *__pyx_t_8 = NULL;
   __Pyx_RefNannySetupContext("least_squares_cg", 0);
 
-  /* "implicit/_als.pyx":128
+  /* "implicit/_als.pyx":131
  * 
  * def least_squares_cg(Cui, X, Y, regularization, num_threads=0, cg_steps=3):
  *     return _least_squares_cg(Cui.indptr, Cui.indices, Cui.data.astype('float32'),             # <<<<<<<<<<<<<<
@@ -11609,22 +11800,22 @@ static PyObject *__pyx_pf_8implicit_4_als_4least_squares_cg(CYTHON_UNUSED PyObje
  * 
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_least_squares_cg); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 128, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_least_squares_cg); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 131, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_indptr); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 128, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_indptr); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 131, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_indices); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 128, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_indices); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 131, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_data); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 128, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_data); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 131, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_astype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 128, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_astype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 131, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_tuple__10, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 128, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_tuple__10, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 131, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
 
-  /* "implicit/_als.pyx":129
+  /* "implicit/_als.pyx":132
  * def least_squares_cg(Cui, X, Y, regularization, num_threads=0, cg_steps=3):
  *     return _least_squares_cg(Cui.indptr, Cui.indices, Cui.data.astype('float32'),
  *                              X, Y, regularization, num_threads, cg_steps)             # <<<<<<<<<<<<<<
@@ -11646,7 +11837,7 @@ static PyObject *__pyx_pf_8implicit_4_als_4least_squares_cg(CYTHON_UNUSED PyObje
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_2)) {
     PyObject *__pyx_temp[9] = {__pyx_t_6, __pyx_t_3, __pyx_t_4, __pyx_t_5, __pyx_v_X, __pyx_v_Y, __pyx_v_regularization, __pyx_v_num_threads, __pyx_v_cg_steps};
-    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_2, __pyx_temp+1-__pyx_t_7, 8+__pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 128, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_2, __pyx_temp+1-__pyx_t_7, 8+__pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 131, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -11657,7 +11848,7 @@ static PyObject *__pyx_pf_8implicit_4_als_4least_squares_cg(CYTHON_UNUSED PyObje
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_2)) {
     PyObject *__pyx_temp[9] = {__pyx_t_6, __pyx_t_3, __pyx_t_4, __pyx_t_5, __pyx_v_X, __pyx_v_Y, __pyx_v_regularization, __pyx_v_num_threads, __pyx_v_cg_steps};
-    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_2, __pyx_temp+1-__pyx_t_7, 8+__pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 128, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_2, __pyx_temp+1-__pyx_t_7, 8+__pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 131, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -11666,7 +11857,7 @@ static PyObject *__pyx_pf_8implicit_4_als_4least_squares_cg(CYTHON_UNUSED PyObje
   } else
   #endif
   {
-    __pyx_t_8 = PyTuple_New(8+__pyx_t_7); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 128, __pyx_L1_error)
+    __pyx_t_8 = PyTuple_New(8+__pyx_t_7); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 131, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
     if (__pyx_t_6) {
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_8, 0, __pyx_t_6); __pyx_t_6 = NULL;
@@ -11695,7 +11886,7 @@ static PyObject *__pyx_pf_8implicit_4_als_4least_squares_cg(CYTHON_UNUSED PyObje
     __pyx_t_3 = 0;
     __pyx_t_4 = 0;
     __pyx_t_5 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_8, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 128, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_8, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 131, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
   }
@@ -11704,7 +11895,7 @@ static PyObject *__pyx_pf_8implicit_4_als_4least_squares_cg(CYTHON_UNUSED PyObje
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "implicit/_als.pyx":127
+  /* "implicit/_als.pyx":130
  * 
  * 
  * def least_squares_cg(Cui, X, Y, regularization, num_threads=0, cg_steps=3):             # <<<<<<<<<<<<<<
@@ -11729,7 +11920,7 @@ static PyObject *__pyx_pf_8implicit_4_als_4least_squares_cg(CYTHON_UNUSED PyObje
   return __pyx_r;
 }
 
-/* "implicit/_als.pyx":134
+/* "implicit/_als.pyx":137
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _least_squares_cg(integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
@@ -11775,23 +11966,23 @@ static PyObject *__pyx_pw_8implicit_4_als_7_least_squares_cg(PyObject *__pyx_sel
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_args)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 1); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 1); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_kwargs)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 2); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 2); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_defaults)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 3); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 3); __PYX_ERR(0, 137, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__pyx_fused_cpdef") < 0)) __PYX_ERR(0, 134, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__pyx_fused_cpdef") < 0)) __PYX_ERR(0, 137, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 4) {
       goto __pyx_L5_argtuple_error;
@@ -11808,7 +11999,7 @@ static PyObject *__pyx_pw_8implicit_4_als_7_least_squares_cg(PyObject *__pyx_sel
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 134, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 137, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("implicit._als.__pyx_fused_cpdef", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -11868,7 +12059,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
   int __pyx_t_19;
   __Pyx_RefNannySetupContext("_least_squares_cg", 0);
   __Pyx_INCREF(__pyx_v_kwargs);
-  __pyx_t_1 = PyList_New(1 * 2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_1 = PyList_New(1 * 2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   { Py_ssize_t __pyx_temp;
     for (__pyx_temp=0; __pyx_temp < 2; __pyx_temp++) {
@@ -11886,7 +12077,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
     __pyx_t_2 = __pyx_t_4;
     goto __pyx_L4_bool_binop_done;
   }
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_kwargs); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_kwargs); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
   __pyx_t_3 = ((!__pyx_t_4) != 0);
   __pyx_t_2 = __pyx_t_3;
   __pyx_L4_bool_binop_done:;
@@ -11894,7 +12085,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
     __Pyx_INCREF(Py_None);
     __Pyx_DECREF_SET(__pyx_v_kwargs, Py_None);
   }
-  __pyx_t_1 = ((PyObject *)__Pyx_ImportNumPyArrayTypeIfAvailable()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_1 = ((PyObject *)__Pyx_ImportNumPyArrayTypeIfAvailable()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_ndarray = ((PyTypeObject*)__pyx_t_1);
   __pyx_t_1 = 0;
@@ -11905,14 +12096,14 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
   __pyx_v_long_is_signed = (((long)-1L) < 0);
   if (unlikely(__pyx_v_args == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 134, __pyx_L1_error)
+    __PYX_ERR(0, 137, __pyx_L1_error)
   }
-  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 137, __pyx_L1_error)
   __pyx_t_2 = ((0 < __pyx_t_5) != 0);
   if (__pyx_t_2) {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 134, __pyx_L1_error)
+      __PYX_ERR(0, 137, __pyx_L1_error)
     }
     __pyx_t_1 = PyTuple_GET_ITEM(((PyObject*)__pyx_v_args), 0);
     __Pyx_INCREF(__pyx_t_1);
@@ -11929,18 +12120,18 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
   }
   if (unlikely(__pyx_v_kwargs == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 134, __pyx_L1_error)
+    __PYX_ERR(0, 137, __pyx_L1_error)
   }
-  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_indptr, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_indptr, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
   __pyx_t_3 = (__pyx_t_4 != 0);
   __pyx_t_2 = __pyx_t_3;
   __pyx_L7_bool_binop_done:;
   if (__pyx_t_2) {
     if (unlikely(__pyx_v_kwargs == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 134, __pyx_L1_error)
+      __PYX_ERR(0, 137, __pyx_L1_error)
     }
-    __pyx_t_1 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_indptr); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_indptr); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_v_arg = __pyx_t_1;
     __pyx_t_1 = 0;
@@ -11949,12 +12140,12 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
   /*else*/ {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 134, __pyx_L1_error)
+      __PYX_ERR(0, 137, __pyx_L1_error)
     }
-    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 134, __pyx_L1_error)
-    __pyx_t_1 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_1 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_INCREF(__pyx_int_6);
     __Pyx_GIVEREF(__pyx_int_6);
@@ -11965,20 +12156,20 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
     __Pyx_GIVEREF(__pyx_t_1);
     PyTuple_SET_ITEM(__pyx_t_6, 2, __pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_GIVEREF(__pyx_t_1);
     PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_6, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_6, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_Raise(__pyx_t_1, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __PYX_ERR(0, 134, __pyx_L1_error)
+    __PYX_ERR(0, 137, __pyx_L1_error)
   }
   __pyx_L6:;
   while (1) {
@@ -11988,7 +12179,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
       __pyx_t_3 = __Pyx_TypeCheck(__pyx_v_arg, __pyx_v_ndarray); 
       __pyx_t_2 = (__pyx_t_3 != 0);
       if (__pyx_t_2) {
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __pyx_v_dtype = __pyx_t_1;
         __pyx_t_1 = 0;
@@ -11998,14 +12189,14 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
       __pyx_t_2 = __pyx_memoryview_check(__pyx_v_arg); 
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __pyx_v_arg_base = __pyx_t_1;
         __pyx_t_1 = 0;
         __pyx_t_3 = __Pyx_TypeCheck(__pyx_v_arg_base, __pyx_v_ndarray); 
         __pyx_t_2 = (__pyx_t_3 != 0);
         if (__pyx_t_2) {
-          __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
           __pyx_v_dtype = __pyx_t_1;
           __pyx_t_1 = 0;
@@ -12027,21 +12218,21 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
       __pyx_t_2 = (__pyx_v_dtype != Py_None);
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_1); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_1); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __pyx_v_itemsize = __pyx_t_5;
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_1); if (unlikely(__pyx_t_7 == (long)(Py_UCS4)-1)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_1); if (unlikely(__pyx_t_7 == (long)(Py_UCS4)-1)) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __pyx_v_kind = __pyx_t_7;
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_byteorder); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_byteorder); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __pyx_v_byteorder = __pyx_t_1;
         __pyx_t_1 = 0;
-        __pyx_t_2 = (__Pyx_PyString_Equals(__pyx_v_byteorder, __pyx_kp_s__2, Py_EQ)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_2 = (__Pyx_PyString_Equals(__pyx_v_byteorder, __pyx_kp_s__2, Py_EQ)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
         if (__pyx_t_2) {
         } else {
           __pyx_t_3 = __pyx_t_2;
@@ -12054,7 +12245,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
         if (__pyx_t_3) {
           __pyx_v_arg_is_pythran_compatible = 0;
         }
-        __pyx_t_2 = (__Pyx_PyString_Equals(__pyx_v_byteorder, __pyx_kp_s__3, Py_EQ)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_2 = (__Pyx_PyString_Equals(__pyx_v_byteorder, __pyx_kp_s__3, Py_EQ)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
         if (__pyx_t_2) {
         } else {
           __pyx_t_3 = __pyx_t_2;
@@ -12070,31 +12261,31 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
         __pyx_v_dtype_signed = (__pyx_v_kind == 'i');
         __pyx_t_3 = (__pyx_v_arg_is_pythran_compatible != 0);
         if (__pyx_t_3) {
-          __pyx_t_1 = PyInt_FromSsize_t(__pyx_v_itemsize); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_1 = PyInt_FromSsize_t(__pyx_v_itemsize); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
           __pyx_v_cur_stride = __pyx_t_1;
           __pyx_t_1 = 0;
-          __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_shape); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_shape); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
-          __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __Pyx_GIVEREF(__pyx_t_1);
           PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_1);
           __pyx_t_1 = 0;
-          __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_reversed, __pyx_t_6, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_reversed, __pyx_t_6, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_strides); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_strides); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
-          __pyx_t_9 = PyTuple_New(1); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_9 = PyTuple_New(1); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
           __Pyx_GIVEREF(__pyx_t_6);
           PyTuple_SET_ITEM(__pyx_t_9, 0, __pyx_t_6);
           __pyx_t_6 = 0;
-          __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_reversed, __pyx_t_9, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_reversed, __pyx_t_9, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
-          __pyx_t_9 = PyTuple_New(2); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_9 = PyTuple_New(2); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
           __Pyx_GIVEREF(__pyx_t_1);
           PyTuple_SET_ITEM(__pyx_t_9, 0, __pyx_t_1);
@@ -12102,16 +12293,16 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
           PyTuple_SET_ITEM(__pyx_t_9, 1, __pyx_t_6);
           __pyx_t_1 = 0;
           __pyx_t_6 = 0;
-          __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_zip, __pyx_t_9, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_zip, __pyx_t_9, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
           if (likely(PyList_CheckExact(__pyx_t_6)) || PyTuple_CheckExact(__pyx_t_6)) {
             __pyx_t_9 = __pyx_t_6; __Pyx_INCREF(__pyx_t_9); __pyx_t_5 = 0;
             __pyx_t_10 = NULL;
           } else {
-            __pyx_t_5 = -1; __pyx_t_9 = PyObject_GetIter(__pyx_t_6); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_5 = -1; __pyx_t_9 = PyObject_GetIter(__pyx_t_6); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_9);
-            __pyx_t_10 = Py_TYPE(__pyx_t_9)->tp_iternext; if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_10 = Py_TYPE(__pyx_t_9)->tp_iternext; if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 137, __pyx_L1_error)
           }
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
           for (;;) {
@@ -12119,17 +12310,17 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
               if (likely(PyList_CheckExact(__pyx_t_9))) {
                 if (__pyx_t_5 >= PyList_GET_SIZE(__pyx_t_9)) break;
                 #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-                __pyx_t_6 = PyList_GET_ITEM(__pyx_t_9, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+                __pyx_t_6 = PyList_GET_ITEM(__pyx_t_9, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
                 #else
-                __pyx_t_6 = PySequence_ITEM(__pyx_t_9, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+                __pyx_t_6 = PySequence_ITEM(__pyx_t_9, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
                 __Pyx_GOTREF(__pyx_t_6);
                 #endif
               } else {
                 if (__pyx_t_5 >= PyTuple_GET_SIZE(__pyx_t_9)) break;
                 #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-                __pyx_t_6 = PyTuple_GET_ITEM(__pyx_t_9, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+                __pyx_t_6 = PyTuple_GET_ITEM(__pyx_t_9, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
                 #else
-                __pyx_t_6 = PySequence_ITEM(__pyx_t_9, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+                __pyx_t_6 = PySequence_ITEM(__pyx_t_9, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
                 __Pyx_GOTREF(__pyx_t_6);
                 #endif
               }
@@ -12139,7 +12330,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
                 PyObject* exc_type = PyErr_Occurred();
                 if (exc_type) {
                   if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-                  else __PYX_ERR(0, 134, __pyx_L1_error)
+                  else __PYX_ERR(0, 137, __pyx_L1_error)
                 }
                 break;
               }
@@ -12155,7 +12346,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
               if (unlikely(size != 2)) {
                 if (size > 2) __Pyx_RaiseTooManyValuesError(2);
                 else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-                __PYX_ERR(0, 134, __pyx_L1_error)
+                __PYX_ERR(0, 137, __pyx_L1_error)
               }
               #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
               if (likely(PyTuple_CheckExact(sequence))) {
@@ -12168,15 +12359,15 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
               __Pyx_INCREF(__pyx_t_1);
               __Pyx_INCREF(__pyx_t_11);
               #else
-              __pyx_t_1 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+              __pyx_t_1 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_1);
-              __pyx_t_11 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 134, __pyx_L1_error)
+              __pyx_t_11 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 137, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_11);
               #endif
               __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
             } else {
               Py_ssize_t index = -1;
-              __pyx_t_12 = PyObject_GetIter(__pyx_t_6); if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 134, __pyx_L1_error)
+              __pyx_t_12 = PyObject_GetIter(__pyx_t_6); if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 137, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_12);
               __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
               __pyx_t_13 = Py_TYPE(__pyx_t_12)->tp_iternext;
@@ -12184,7 +12375,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
               __Pyx_GOTREF(__pyx_t_1);
               index = 1; __pyx_t_11 = __pyx_t_13(__pyx_t_12); if (unlikely(!__pyx_t_11)) goto __pyx_L24_unpacking_failed;
               __Pyx_GOTREF(__pyx_t_11);
-              if (__Pyx_IternextUnpackEndCheck(__pyx_t_13(__pyx_t_12), 2) < 0) __PYX_ERR(0, 134, __pyx_L1_error)
+              if (__Pyx_IternextUnpackEndCheck(__pyx_t_13(__pyx_t_12), 2) < 0) __PYX_ERR(0, 137, __pyx_L1_error)
               __pyx_t_13 = NULL;
               __Pyx_DECREF(__pyx_t_12); __pyx_t_12 = 0;
               goto __pyx_L25_unpacking_done;
@@ -12192,43 +12383,43 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
               __Pyx_DECREF(__pyx_t_12); __pyx_t_12 = 0;
               __pyx_t_13 = NULL;
               if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-              __PYX_ERR(0, 134, __pyx_L1_error)
+              __PYX_ERR(0, 137, __pyx_L1_error)
               __pyx_L25_unpacking_done:;
             }
             __Pyx_XDECREF_SET(__pyx_v_dim, __pyx_t_1);
             __pyx_t_1 = 0;
             __Pyx_XDECREF_SET(__pyx_v_stride, __pyx_t_11);
             __pyx_t_11 = 0;
-            __pyx_t_6 = PyObject_RichCompare(__pyx_v_stride, __pyx_v_cur_stride, Py_NE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
-            __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_6 = PyObject_RichCompare(__pyx_v_stride, __pyx_v_cur_stride, Py_NE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
+            __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
             if (__pyx_t_3) {
               __pyx_v_arg_is_pythran_compatible = 0;
               goto __pyx_L23_break;
             }
-            __pyx_t_6 = PyNumber_InPlaceMultiply(__pyx_v_cur_stride, __pyx_v_dim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_6 = PyNumber_InPlaceMultiply(__pyx_v_cur_stride, __pyx_v_dim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_6);
             __Pyx_DECREF_SET(__pyx_v_cur_stride, __pyx_t_6);
             __pyx_t_6 = 0;
           }
           /*else*/ {
-            __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_flags); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_flags); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_6);
-            __pyx_t_11 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_f_contiguous); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_11 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_f_contiguous); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_11);
             __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-            __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_11); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_11); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
             if (__pyx_t_2) {
             } else {
               __pyx_t_3 = __pyx_t_2;
               goto __pyx_L28_bool_binop_done;
             }
-            __pyx_t_11 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_11 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_11);
-            __pyx_t_6 = PyObject_RichCompare(__pyx_t_11, __pyx_int_1, Py_GT); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_6 = PyObject_RichCompare(__pyx_t_11, __pyx_int_1, Py_GT); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
-            __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
             __pyx_t_3 = __pyx_t_2;
             __pyx_L28_bool_binop_done:;
@@ -12246,9 +12437,9 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
             __pyx_t_3 = __pyx_t_2;
             goto __pyx_L31_bool_binop_done;
           }
-          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_9); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_9); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
           __pyx_t_2 = ((((Py_ssize_t)__pyx_t_5) == 1) != 0);
           if (__pyx_t_2) {
@@ -12260,7 +12451,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
           __pyx_t_3 = __pyx_t_2;
           __pyx_L31_bool_binop_done:;
           if (__pyx_t_3) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_short, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_short, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
             goto __pyx_L10_break;
           }
           __pyx_t_2 = (((sizeof(int)) == __pyx_v_itemsize) != 0);
@@ -12269,9 +12460,9 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
             __pyx_t_3 = __pyx_t_2;
             goto __pyx_L35_bool_binop_done;
           }
-          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_9); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_9); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
           __pyx_t_2 = ((((Py_ssize_t)__pyx_t_5) == 1) != 0);
           if (__pyx_t_2) {
@@ -12283,7 +12474,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
           __pyx_t_3 = __pyx_t_2;
           __pyx_L35_bool_binop_done:;
           if (__pyx_t_3) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_int, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_int, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
             goto __pyx_L10_break;
           }
           __pyx_t_2 = (((sizeof(long)) == __pyx_v_itemsize) != 0);
@@ -12292,9 +12483,9 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
             __pyx_t_3 = __pyx_t_2;
             goto __pyx_L39_bool_binop_done;
           }
-          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_9); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_9); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
           __pyx_t_2 = ((((Py_ssize_t)__pyx_t_5) == 1) != 0);
           if (__pyx_t_2) {
@@ -12306,7 +12497,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
           __pyx_t_3 = __pyx_t_2;
           __pyx_L39_bool_binop_done:;
           if (__pyx_t_3) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_long, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_long, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
             goto __pyx_L10_break;
           }
           break;
@@ -12335,7 +12526,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
       __pyx_t_3 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_3) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_short, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_short, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
         goto __pyx_L10_break;
       }
       /*else*/ {
@@ -12357,7 +12548,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
       __pyx_t_3 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_3) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_int, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_int, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
         goto __pyx_L10_break;
       }
       /*else*/ {
@@ -12379,27 +12570,27 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
       __pyx_t_3 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_3) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_long, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_long, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
         goto __pyx_L10_break;
       }
       /*else*/ {
         PyErr_Clear(); 
       }
     }
-    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
     goto __pyx_L10_break;
   }
   __pyx_L10_break:;
   if (unlikely(__pyx_v_args == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 134, __pyx_L1_error)
+    __PYX_ERR(0, 137, __pyx_L1_error)
   }
-  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 137, __pyx_L1_error)
   __pyx_t_3 = ((3 < __pyx_t_5) != 0);
   if (__pyx_t_3) {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 134, __pyx_L1_error)
+      __PYX_ERR(0, 137, __pyx_L1_error)
     }
     __pyx_t_9 = PyTuple_GET_ITEM(((PyObject*)__pyx_v_args), 3);
     __Pyx_INCREF(__pyx_t_9);
@@ -12416,18 +12607,18 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
   }
   if (unlikely(__pyx_v_kwargs == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 134, __pyx_L1_error)
+    __PYX_ERR(0, 137, __pyx_L1_error)
   }
-  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_X, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_X, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
   __pyx_t_2 = (__pyx_t_4 != 0);
   __pyx_t_3 = __pyx_t_2;
   __pyx_L55_bool_binop_done:;
   if (__pyx_t_3) {
     if (unlikely(__pyx_v_kwargs == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 134, __pyx_L1_error)
+      __PYX_ERR(0, 137, __pyx_L1_error)
     }
-    __pyx_t_9 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_X); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_9 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_X); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
     __Pyx_DECREF_SET(__pyx_v_arg, __pyx_t_9);
     __pyx_t_9 = 0;
@@ -12436,12 +12627,12 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
   /*else*/ {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 134, __pyx_L1_error)
+      __PYX_ERR(0, 137, __pyx_L1_error)
     }
-    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 134, __pyx_L1_error)
-    __pyx_t_9 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_9 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
-    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_INCREF(__pyx_int_6);
     __Pyx_GIVEREF(__pyx_int_6);
@@ -12452,20 +12643,20 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
     __Pyx_GIVEREF(__pyx_t_9);
     PyTuple_SET_ITEM(__pyx_t_6, 2, __pyx_t_9);
     __pyx_t_9 = 0;
-    __pyx_t_9 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_9 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_GIVEREF(__pyx_t_9);
     PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_9);
     __pyx_t_9 = 0;
-    __pyx_t_9 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_6, NULL); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_9 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_6, NULL); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_Raise(__pyx_t_9, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
-    __PYX_ERR(0, 134, __pyx_L1_error)
+    __PYX_ERR(0, 137, __pyx_L1_error)
   }
   __pyx_L54:;
   while (1) {
@@ -12475,7 +12666,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
       __pyx_t_2 = __Pyx_TypeCheck(__pyx_v_arg, __pyx_v_ndarray); 
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_9);
         __Pyx_XDECREF_SET(__pyx_v_dtype, __pyx_t_9);
         __pyx_t_9 = 0;
@@ -12485,14 +12676,14 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
       __pyx_t_3 = __pyx_memoryview_check(__pyx_v_arg); 
       __pyx_t_2 = (__pyx_t_3 != 0);
       if (__pyx_t_2) {
-        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_9);
         __Pyx_XDECREF_SET(__pyx_v_arg_base, __pyx_t_9);
         __pyx_t_9 = 0;
         __pyx_t_2 = __Pyx_TypeCheck(__pyx_v_arg_base, __pyx_v_ndarray); 
         __pyx_t_3 = (__pyx_t_2 != 0);
         if (__pyx_t_3) {
-          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
           __Pyx_XDECREF_SET(__pyx_v_dtype, __pyx_t_9);
           __pyx_t_9 = 0;
@@ -12514,21 +12705,21 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
       __pyx_t_3 = (__pyx_v_dtype != Py_None);
       __pyx_t_2 = (__pyx_t_3 != 0);
       if (__pyx_t_2) {
-        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_9);
-        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_9); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_9); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
         __pyx_v_itemsize = __pyx_t_5;
-        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_9);
-        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_9); if (unlikely(__pyx_t_7 == (long)(Py_UCS4)-1)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_9); if (unlikely(__pyx_t_7 == (long)(Py_UCS4)-1)) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
         __pyx_v_kind = __pyx_t_7;
-        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_byteorder); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_byteorder); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_9);
         __Pyx_XDECREF_SET(__pyx_v_byteorder, __pyx_t_9);
         __pyx_t_9 = 0;
-        __pyx_t_3 = (__Pyx_PyString_Equals(__pyx_v_byteorder, __pyx_kp_s__2, Py_EQ)); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_3 = (__Pyx_PyString_Equals(__pyx_v_byteorder, __pyx_kp_s__2, Py_EQ)); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
         if (__pyx_t_3) {
         } else {
           __pyx_t_2 = __pyx_t_3;
@@ -12541,7 +12732,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
         if (__pyx_t_2) {
           __pyx_v_arg_is_pythran_compatible = 0;
         }
-        __pyx_t_3 = (__Pyx_PyString_Equals(__pyx_v_byteorder, __pyx_kp_s__3, Py_EQ)); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_3 = (__Pyx_PyString_Equals(__pyx_v_byteorder, __pyx_kp_s__3, Py_EQ)); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
         if (__pyx_t_3) {
         } else {
           __pyx_t_2 = __pyx_t_3;
@@ -12557,31 +12748,31 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
         __pyx_v_dtype_signed = (__pyx_v_kind == 'i');
         __pyx_t_2 = (__pyx_v_arg_is_pythran_compatible != 0);
         if (__pyx_t_2) {
-          __pyx_t_9 = PyInt_FromSsize_t(__pyx_v_itemsize); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_9 = PyInt_FromSsize_t(__pyx_v_itemsize); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
           __Pyx_XDECREF_SET(__pyx_v_cur_stride, __pyx_t_9);
           __pyx_t_9 = 0;
-          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_shape); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_shape); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
-          __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __Pyx_GIVEREF(__pyx_t_9);
           PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_9);
           __pyx_t_9 = 0;
-          __pyx_t_9 = __Pyx_PyObject_Call(__pyx_builtin_reversed, __pyx_t_6, NULL); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_9 = __Pyx_PyObject_Call(__pyx_builtin_reversed, __pyx_t_6, NULL); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_strides); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_strides); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
-          __pyx_t_11 = PyTuple_New(1); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_11 = PyTuple_New(1); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_11);
           __Pyx_GIVEREF(__pyx_t_6);
           PyTuple_SET_ITEM(__pyx_t_11, 0, __pyx_t_6);
           __pyx_t_6 = 0;
-          __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_reversed, __pyx_t_11, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_reversed, __pyx_t_11, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
-          __pyx_t_11 = PyTuple_New(2); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_11 = PyTuple_New(2); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_11);
           __Pyx_GIVEREF(__pyx_t_9);
           PyTuple_SET_ITEM(__pyx_t_11, 0, __pyx_t_9);
@@ -12589,16 +12780,16 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
           PyTuple_SET_ITEM(__pyx_t_11, 1, __pyx_t_6);
           __pyx_t_9 = 0;
           __pyx_t_6 = 0;
-          __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_zip, __pyx_t_11, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_zip, __pyx_t_11, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
           if (likely(PyList_CheckExact(__pyx_t_6)) || PyTuple_CheckExact(__pyx_t_6)) {
             __pyx_t_11 = __pyx_t_6; __Pyx_INCREF(__pyx_t_11); __pyx_t_5 = 0;
             __pyx_t_10 = NULL;
           } else {
-            __pyx_t_5 = -1; __pyx_t_11 = PyObject_GetIter(__pyx_t_6); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_5 = -1; __pyx_t_11 = PyObject_GetIter(__pyx_t_6); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_11);
-            __pyx_t_10 = Py_TYPE(__pyx_t_11)->tp_iternext; if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_10 = Py_TYPE(__pyx_t_11)->tp_iternext; if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 137, __pyx_L1_error)
           }
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
           for (;;) {
@@ -12606,17 +12797,17 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
               if (likely(PyList_CheckExact(__pyx_t_11))) {
                 if (__pyx_t_5 >= PyList_GET_SIZE(__pyx_t_11)) break;
                 #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-                __pyx_t_6 = PyList_GET_ITEM(__pyx_t_11, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+                __pyx_t_6 = PyList_GET_ITEM(__pyx_t_11, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
                 #else
-                __pyx_t_6 = PySequence_ITEM(__pyx_t_11, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+                __pyx_t_6 = PySequence_ITEM(__pyx_t_11, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
                 __Pyx_GOTREF(__pyx_t_6);
                 #endif
               } else {
                 if (__pyx_t_5 >= PyTuple_GET_SIZE(__pyx_t_11)) break;
                 #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-                __pyx_t_6 = PyTuple_GET_ITEM(__pyx_t_11, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+                __pyx_t_6 = PyTuple_GET_ITEM(__pyx_t_11, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
                 #else
-                __pyx_t_6 = PySequence_ITEM(__pyx_t_11, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+                __pyx_t_6 = PySequence_ITEM(__pyx_t_11, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
                 __Pyx_GOTREF(__pyx_t_6);
                 #endif
               }
@@ -12626,7 +12817,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
                 PyObject* exc_type = PyErr_Occurred();
                 if (exc_type) {
                   if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-                  else __PYX_ERR(0, 134, __pyx_L1_error)
+                  else __PYX_ERR(0, 137, __pyx_L1_error)
                 }
                 break;
               }
@@ -12642,7 +12833,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
               if (unlikely(size != 2)) {
                 if (size > 2) __Pyx_RaiseTooManyValuesError(2);
                 else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-                __PYX_ERR(0, 134, __pyx_L1_error)
+                __PYX_ERR(0, 137, __pyx_L1_error)
               }
               #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
               if (likely(PyTuple_CheckExact(sequence))) {
@@ -12655,15 +12846,15 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
               __Pyx_INCREF(__pyx_t_9);
               __Pyx_INCREF(__pyx_t_1);
               #else
-              __pyx_t_9 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 134, __pyx_L1_error)
+              __pyx_t_9 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 137, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_9);
-              __pyx_t_1 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+              __pyx_t_1 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_1);
               #endif
               __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
             } else {
               Py_ssize_t index = -1;
-              __pyx_t_12 = PyObject_GetIter(__pyx_t_6); if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 134, __pyx_L1_error)
+              __pyx_t_12 = PyObject_GetIter(__pyx_t_6); if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 137, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_12);
               __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
               __pyx_t_13 = Py_TYPE(__pyx_t_12)->tp_iternext;
@@ -12671,7 +12862,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
               __Pyx_GOTREF(__pyx_t_9);
               index = 1; __pyx_t_1 = __pyx_t_13(__pyx_t_12); if (unlikely(!__pyx_t_1)) goto __pyx_L72_unpacking_failed;
               __Pyx_GOTREF(__pyx_t_1);
-              if (__Pyx_IternextUnpackEndCheck(__pyx_t_13(__pyx_t_12), 2) < 0) __PYX_ERR(0, 134, __pyx_L1_error)
+              if (__Pyx_IternextUnpackEndCheck(__pyx_t_13(__pyx_t_12), 2) < 0) __PYX_ERR(0, 137, __pyx_L1_error)
               __pyx_t_13 = NULL;
               __Pyx_DECREF(__pyx_t_12); __pyx_t_12 = 0;
               goto __pyx_L73_unpacking_done;
@@ -12679,43 +12870,43 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
               __Pyx_DECREF(__pyx_t_12); __pyx_t_12 = 0;
               __pyx_t_13 = NULL;
               if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-              __PYX_ERR(0, 134, __pyx_L1_error)
+              __PYX_ERR(0, 137, __pyx_L1_error)
               __pyx_L73_unpacking_done:;
             }
             __Pyx_XDECREF_SET(__pyx_v_dim, __pyx_t_9);
             __pyx_t_9 = 0;
             __Pyx_XDECREF_SET(__pyx_v_stride, __pyx_t_1);
             __pyx_t_1 = 0;
-            __pyx_t_6 = PyObject_RichCompare(__pyx_v_stride, __pyx_v_cur_stride, Py_NE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
-            __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_6 = PyObject_RichCompare(__pyx_v_stride, __pyx_v_cur_stride, Py_NE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
+            __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
             if (__pyx_t_2) {
               __pyx_v_arg_is_pythran_compatible = 0;
               goto __pyx_L71_break;
             }
-            __pyx_t_6 = PyNumber_InPlaceMultiply(__pyx_v_cur_stride, __pyx_v_dim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_6 = PyNumber_InPlaceMultiply(__pyx_v_cur_stride, __pyx_v_dim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_6);
             __Pyx_DECREF_SET(__pyx_v_cur_stride, __pyx_t_6);
             __pyx_t_6 = 0;
           }
           /*else*/ {
-            __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_flags); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_flags); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_6);
-            __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_f_contiguous); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_f_contiguous); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_1);
             __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-            __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
             if (__pyx_t_3) {
             } else {
               __pyx_t_2 = __pyx_t_3;
               goto __pyx_L76_bool_binop_done;
             }
-            __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_1);
-            __pyx_t_6 = PyObject_RichCompare(__pyx_t_1, __pyx_int_1, Py_GT); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_6 = PyObject_RichCompare(__pyx_t_1, __pyx_int_1, Py_GT); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-            __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+            __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
             __pyx_t_2 = __pyx_t_3;
             __pyx_L76_bool_binop_done:;
@@ -12735,15 +12926,15 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
             __pyx_t_2 = __pyx_t_3;
             goto __pyx_L79_bool_binop_done;
           }
-          __pyx_t_11 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_11 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_11);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_11); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_11); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
           __pyx_t_3 = ((((Py_ssize_t)__pyx_t_5) == 2) != 0);
           __pyx_t_2 = __pyx_t_3;
           __pyx_L79_bool_binop_done:;
           if (__pyx_t_2) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
             goto __pyx_L58_break;
           }
           __pyx_t_3 = (((sizeof(double)) == __pyx_v_itemsize) != 0);
@@ -12752,15 +12943,15 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
             __pyx_t_2 = __pyx_t_3;
             goto __pyx_L82_bool_binop_done;
           }
-          __pyx_t_11 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_11 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_11);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_11); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 134, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_11); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 137, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
           __pyx_t_3 = ((((Py_ssize_t)__pyx_t_5) == 2) != 0);
           __pyx_t_2 = __pyx_t_3;
           __pyx_L82_bool_binop_done:;
           if (__pyx_t_2) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
             goto __pyx_L58_break;
           }
           break;
@@ -12787,7 +12978,7 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
       __pyx_t_2 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_2) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
         goto __pyx_L58_break;
       }
       /*else*/ {
@@ -12809,27 +13000,27 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
       __pyx_t_2 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_2) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
         goto __pyx_L58_break;
       }
       /*else*/ {
         PyErr_Clear(); 
       }
     }
-    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
     goto __pyx_L58_break;
   }
   __pyx_L58_break:;
-  __pyx_t_11 = PyList_New(0); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_11 = PyList_New(0); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_11);
   __pyx_v_candidates = ((PyObject*)__pyx_t_11);
   __pyx_t_11 = 0;
   __pyx_t_5 = 0;
   if (unlikely(__pyx_v_signatures == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 134, __pyx_L1_error)
+    __PYX_ERR(0, 137, __pyx_L1_error)
   }
-  __pyx_t_6 = __Pyx_dict_iterator(((PyObject*)__pyx_v_signatures), 1, ((PyObject *)NULL), (&__pyx_t_15), (&__pyx_t_8)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_dict_iterator(((PyObject*)__pyx_v_signatures), 1, ((PyObject *)NULL), (&__pyx_t_15), (&__pyx_t_8)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_XDECREF(__pyx_t_11);
   __pyx_t_11 = __pyx_t_6;
@@ -12837,39 +13028,39 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
   while (1) {
     __pyx_t_16 = __Pyx_dict_iter_next(__pyx_t_11, __pyx_t_15, &__pyx_t_5, &__pyx_t_6, NULL, NULL, __pyx_t_8);
     if (unlikely(__pyx_t_16 == 0)) break;
-    if (unlikely(__pyx_t_16 == -1)) __PYX_ERR(0, 134, __pyx_L1_error)
+    if (unlikely(__pyx_t_16 == -1)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_XDECREF_SET(__pyx_v_sig, __pyx_t_6);
     __pyx_t_6 = 0;
     __pyx_v_match_found = 0;
-    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_sig, __pyx_n_s_strip); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_sig, __pyx_n_s_strip); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_tuple__11, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_tuple__11, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_split); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_split); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_tuple__12, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_tuple__12, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_XDECREF_SET(__pyx_v_src_sig, __pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_17 = PyList_GET_SIZE(__pyx_v_dest_sig); if (unlikely(__pyx_t_17 == -1)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_17 = PyList_GET_SIZE(__pyx_v_dest_sig); if (unlikely(__pyx_t_17 == -1)) __PYX_ERR(0, 137, __pyx_L1_error)
     for (__pyx_t_18 = 0; __pyx_t_18 < __pyx_t_17; __pyx_t_18+=1) {
       __pyx_v_i = __pyx_t_18;
-      __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_dest_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 1, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_dest_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 1, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_XDECREF_SET(__pyx_v_dst_type, __pyx_t_1);
       __pyx_t_1 = 0;
       __pyx_t_2 = (__pyx_v_dst_type != Py_None);
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_src_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_src_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_6 = PyObject_RichCompare(__pyx_t_1, __pyx_v_dst_type, Py_EQ); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_6 = PyObject_RichCompare(__pyx_t_1, __pyx_v_dst_type, Py_EQ); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 137, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
         if (__pyx_t_3) {
           __pyx_v_match_found = 1;
@@ -12885,35 +13076,35 @@ static PyObject *__pyx_pf_8implicit_4_als_6_least_squares_cg(CYTHON_UNUSED PyObj
     __pyx_L95_break:;
     __pyx_t_3 = (__pyx_v_match_found != 0);
     if (__pyx_t_3) {
-      __pyx_t_19 = __Pyx_PyList_Append(__pyx_v_candidates, __pyx_v_sig); if (unlikely(__pyx_t_19 == -1)) __PYX_ERR(0, 134, __pyx_L1_error)
+      __pyx_t_19 = __Pyx_PyList_Append(__pyx_v_candidates, __pyx_v_sig); if (unlikely(__pyx_t_19 == -1)) __PYX_ERR(0, 137, __pyx_L1_error)
     }
   }
   __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
   __pyx_t_3 = (__pyx_v_candidates != Py_None) && (PyList_GET_SIZE(__pyx_v_candidates) != 0);
   __pyx_t_2 = ((!__pyx_t_3) != 0);
   if (__pyx_t_2) {
-    __pyx_t_11 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__13, NULL); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_11 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__13, NULL); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_11);
     __Pyx_Raise(__pyx_t_11, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
-    __PYX_ERR(0, 134, __pyx_L1_error)
+    __PYX_ERR(0, 137, __pyx_L1_error)
   }
-  __pyx_t_15 = PyList_GET_SIZE(__pyx_v_candidates); if (unlikely(__pyx_t_15 == -1)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_15 = PyList_GET_SIZE(__pyx_v_candidates); if (unlikely(__pyx_t_15 == -1)) __PYX_ERR(0, 137, __pyx_L1_error)
   __pyx_t_2 = ((__pyx_t_15 > 1) != 0);
   if (__pyx_t_2) {
-    __pyx_t_11 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__14, NULL); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_11 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__14, NULL); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_11);
     __Pyx_Raise(__pyx_t_11, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
-    __PYX_ERR(0, 134, __pyx_L1_error)
+    __PYX_ERR(0, 137, __pyx_L1_error)
   }
   /*else*/ {
     __Pyx_XDECREF(__pyx_r);
     if (unlikely(__pyx_v_signatures == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 134, __pyx_L1_error)
+      __PYX_ERR(0, 137, __pyx_L1_error)
     }
-    __pyx_t_11 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_signatures), PyList_GET_ITEM(__pyx_v_candidates, 0)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 134, __pyx_L1_error)
+    __pyx_t_11 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_signatures), PyList_GET_ITEM(__pyx_v_candidates, 0)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_11);
     __pyx_r = __pyx_t_11;
     __pyx_t_11 = 0;
@@ -12957,11 +13148,11 @@ static PyObject *__pyx_pf_8implicit_4_als_90__defaults__(CYTHON_UNUSED PyObject 
   PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("__defaults__", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults18, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults18, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults18, __pyx_self)->__pyx_arg_cg_steps); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults18, __pyx_self)->__pyx_arg_cg_steps); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
@@ -12969,7 +13160,7 @@ static PyObject *__pyx_pf_8implicit_4_als_90__defaults__(CYTHON_UNUSED PyObject 
   PyTuple_SET_ITEM(__pyx_t_3, 1, __pyx_t_2);
   __pyx_t_1 = 0;
   __pyx_t_2 = 0;
-  __pyx_t_2 = PyTuple_New(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_3);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_3);
@@ -13045,31 +13236,31 @@ static PyObject *__pyx_fuse_0_0__pyx_pw_8implicit_4_als_27_least_squares_cg(PyOb
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indices)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 1); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 1); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_data)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 2); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 2); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_X)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 3); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 3); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
         if (likely((values[4] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_Y)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 4); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 4); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  5:
         if (likely((values[5] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_regularization)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 5); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 5); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  6:
@@ -13085,7 +13276,7 @@ static PyObject *__pyx_fuse_0_0__pyx_pw_8implicit_4_als_27_least_squares_cg(PyOb
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_least_squares_cg") < 0)) __PYX_ERR(0, 134, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_least_squares_cg") < 0)) __PYX_ERR(0, 137, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -13103,26 +13294,26 @@ static PyObject *__pyx_fuse_0_0__pyx_pw_8implicit_4_als_27_least_squares_cg(PyOb
         default: goto __pyx_L5_argtuple_error;
       }
     }
-    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_short(values[0]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_short(values[1]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[2]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[3]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 135, __pyx_L3_error)
-    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[4]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 135, __pyx_L3_error)
-    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[5]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 135, __pyx_L3_error)
+    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_short(values[0]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_short(values[1]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[2]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[3]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 138, __pyx_L3_error)
+    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[4]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 138, __pyx_L3_error)
+    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[5]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 138, __pyx_L3_error)
     if (values[6]) {
-      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[6]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 136, __pyx_L3_error)
+      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[6]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 139, __pyx_L3_error)
     } else {
       __pyx_v_num_threads = __pyx_dynamic_args->__pyx_arg_num_threads;
     }
     if (values[7]) {
-      __pyx_v_cg_steps = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_cg_steps == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 136, __pyx_L3_error)
+      __pyx_v_cg_steps = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_cg_steps == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 139, __pyx_L3_error)
     } else {
       __pyx_v_cg_steps = __pyx_dynamic_args->__pyx_arg_cg_steps;
     }
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 134, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 137, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("implicit._als._least_squares_cg", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -13199,7 +13390,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
   Py_ssize_t __pyx_t_40;
   __Pyx_RefNannySetupContext("__pyx_fuse_0_0_least_squares_cg", 0);
 
-  /* "implicit/_als.pyx":137
+  /* "implicit/_als.pyx":140
  *                       floating[:, :] X, floating[:, :] Y, float regularization,
  *                       int num_threads=0, int cg_steps=3):
  *     dtype = np.float64 if floating is double else np.float32             # <<<<<<<<<<<<<<
@@ -13207,17 +13398,17 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it
  */
   if ((0 != 0)) {
-    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_1 = __pyx_t_3;
     __pyx_t_3 = 0;
   } else {
-    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_t_1 = __pyx_t_2;
@@ -13226,7 +13417,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
   __pyx_v_dtype = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "implicit/_als.pyx":139
+  /* "implicit/_als.pyx":142
  *     dtype = np.float64 if floating is double else np.float32
  * 
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it             # <<<<<<<<<<<<<<
@@ -13237,7 +13428,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
   __pyx_v_N = (__pyx_v_X.shape[1]);
   __pyx_v_one = 1;
 
-  /* "implicit/_als.pyx":141
+  /* "implicit/_als.pyx":144
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it
  *     cdef floating confidence, temp, alpha, rsnew, rsold
  *     cdef floating zero = 0.             # <<<<<<<<<<<<<<
@@ -13246,24 +13437,24 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
   __pyx_v_zero = 0.;
 
-  /* "implicit/_als.pyx":143
+  /* "implicit/_als.pyx":146
  *     cdef floating zero = 0.
  * 
  *     cdef floating[:, :] YtY = np.dot(np.transpose(Y), Y) + regularization * np.eye(N, dtype=dtype)             # <<<<<<<<<<<<<<
  * 
  *     cdef floating * x
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_6 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -13276,14 +13467,14 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
     }
   }
   if (!__pyx_t_6) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_GOTREF(__pyx_t_2);
   } else {
     #if CYTHON_FAST_PYCALL
     if (PyFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -13292,26 +13483,26 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
     #if CYTHON_FAST_PYCCALL
     if (__Pyx_PyFastCFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     } else
     #endif
     {
-      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_6); __pyx_t_6 = NULL;
       __Pyx_GIVEREF(__pyx_t_4);
       PyTuple_SET_ITEM(__pyx_t_7, 0+1, __pyx_t_4);
       __pyx_t_4 = 0;
-      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     }
   }
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_7 = NULL;
   __pyx_t_8 = 0;
@@ -13328,7 +13519,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -13338,7 +13529,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -13346,7 +13537,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
   } else
   #endif
   {
-    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     if (__pyx_t_7) {
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -13357,49 +13548,49 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
     PyTuple_SET_ITEM(__pyx_t_4, 1+__pyx_t_8, __pyx_t_5);
     __pyx_t_2 = 0;
     __pyx_t_5 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_regularization); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_regularization); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_eye); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_eye); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_N); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_N); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_4);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_4);
   __pyx_t_4 = 0;
-  __pyx_t_4 = PyDict_New(); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = PyDict_New(); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  if (PyDict_SetItem(__pyx_t_4, __pyx_n_s_dtype, __pyx_v_dtype) < 0) __PYX_ERR(0, 143, __pyx_L1_error)
-  __pyx_t_7 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_4, __pyx_n_s_dtype, __pyx_v_dtype) < 0) __PYX_ERR(0, 146, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = PyNumber_Multiply(__pyx_t_3, __pyx_t_7); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = PyNumber_Multiply(__pyx_t_3, __pyx_t_7); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
-  __pyx_t_7 = PyNumber_Add(__pyx_t_1, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_7 = PyNumber_Add(__pyx_t_1, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(__pyx_t_7);
-  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 143, __pyx_L1_error)
+  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   __pyx_v_YtY = __pyx_t_9;
   __pyx_t_9.memview = NULL;
   __pyx_t_9.data = NULL;
 
-  /* "implicit/_als.pyx":150
+  /* "implicit/_als.pyx":153
  *     cdef floating * Ap
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -13429,7 +13620,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
                 __pyx_v_p = ((float *)1);
                 __pyx_v_r = ((float *)1);
 
-                /* "implicit/_als.pyx":153
+                /* "implicit/_als.pyx":156
  * 
  *         # allocate temp memory for each thread
  *         Ap = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -13438,7 +13629,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_Ap = ((float *)malloc(((sizeof(float)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":154
+                /* "implicit/_als.pyx":157
  *         # allocate temp memory for each thread
  *         Ap = <floating *> malloc(sizeof(floating) * N)
  *         p = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -13447,7 +13638,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_p = ((float *)malloc(((sizeof(float)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":155
+                /* "implicit/_als.pyx":158
  *         Ap = <floating *> malloc(sizeof(floating) * N)
  *         p = <floating *> malloc(sizeof(floating) * N)
  *         r = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -13456,7 +13647,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_r = ((float *)malloc(((sizeof(float)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":156
+                /* "implicit/_als.pyx":159
  *         p = <floating *> malloc(sizeof(floating) * N)
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:             # <<<<<<<<<<<<<<
@@ -13465,7 +13656,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 /*try:*/ {
 
-                  /* "implicit/_als.pyx":157
+                  /* "implicit/_als.pyx":160
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:
  *             for u in prange(users, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -13495,7 +13686,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_v_temp = ((float)__PYX_NAN());
                                   __pyx_v_x = ((float *)1);
 
-                                  /* "implicit/_als.pyx":159
+                                  /* "implicit/_als.pyx":162
  *             for u in prange(users, schedule='guided'):
  *                 # start from previous iteration
  *                 x = &X[u, 0]             # <<<<<<<<<<<<<<
@@ -13508,7 +13699,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
                                   if (__pyx_t_13 < 0) __pyx_t_13 += __pyx_v_X.shape[1];
                                   __pyx_v_x = (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_12 * __pyx_v_X.strides[0]) ) + __pyx_t_13 * __pyx_v_X.strides[1]) ))));
 
-                                  /* "implicit/_als.pyx":162
+                                  /* "implicit/_als.pyx":165
  * 
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:             # <<<<<<<<<<<<<<
@@ -13522,7 +13713,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_t_16 = (((*((short *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_14 * __pyx_v_indptr.strides[0]) ))) == (*((short *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_15 * __pyx_v_indptr.strides[0]) )))) != 0);
                                   if (__pyx_t_16) {
 
-                                    /* "implicit/_als.pyx":163
+                                    /* "implicit/_als.pyx":166
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:
  *                     memset(x, 0, sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -13531,7 +13722,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     memset(__pyx_v_x, 0, ((sizeof(float)) * __pyx_v_N));
 
-                                    /* "implicit/_als.pyx":164
+                                    /* "implicit/_als.pyx":167
  *                 if indptr[u] == indptr[u+1]:
  *                     memset(x, 0, sizeof(floating) * N)
  *                     continue             # <<<<<<<<<<<<<<
@@ -13540,7 +13731,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     goto __pyx_L15_continue;
 
-                                    /* "implicit/_als.pyx":162
+                                    /* "implicit/_als.pyx":165
  * 
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:             # <<<<<<<<<<<<<<
@@ -13549,7 +13740,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   }
 
-                                  /* "implicit/_als.pyx":167
+                                  /* "implicit/_als.pyx":170
  * 
  *                 # calculate residual r = (YtCuPu - (YtCuY.dot(Xu)
  *                 temp = -1.0             # <<<<<<<<<<<<<<
@@ -13558,7 +13749,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   __pyx_v_temp = -1.0;
 
-                                  /* "implicit/_als.pyx":168
+                                  /* "implicit/_als.pyx":171
  *                 # calculate residual r = (YtCuPu - (YtCuY.dot(Xu)
  *                 temp = -1.0
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, x, &one, &zero, r, &one)             # <<<<<<<<<<<<<<
@@ -13571,7 +13762,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
                                   if (__pyx_t_18 < 0) __pyx_t_18 += __pyx_v_YtY.shape[1];
                                   __pyx_fuse_0__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_17 * __pyx_v_YtY.strides[0]) ) + __pyx_t_18 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), __pyx_v_x, (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":170
+                                  /* "implicit/_als.pyx":173
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, x, &one, &zero, r, &one)
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -13586,32 +13777,82 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
                                   for (__pyx_t_22 = (*((short *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_21 * __pyx_v_indptr.strides[0]) ))); __pyx_t_22 < __pyx_t_20; __pyx_t_22+=1) {
                                     __pyx_v_index = __pyx_t_22;
 
-                                    /* "implicit/_als.pyx":171
+                                    /* "implicit/_als.pyx":174
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]             # <<<<<<<<<<<<<<
  *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+ * 
  */
                                     __pyx_t_23 = __pyx_v_index;
                                     if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_indices.shape[0];
                                     __pyx_v_i = (*((short *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_23 * __pyx_v_indices.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":172
+                                    /* "implicit/_als.pyx":175
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]
  *                     confidence = data[index]             # <<<<<<<<<<<<<<
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
- *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
+ * 
+ *                     if confidence > 0:
  */
                                     __pyx_t_24 = __pyx_v_index;
                                     if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_data.shape[0];
                                     __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_24 * __pyx_v_data.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":173
- *                     i = indices[index]
+                                    /* "implicit/_als.pyx":177
  *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)             # <<<<<<<<<<<<<<
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = confidence
+ *                     else:
+ */
+                                    __pyx_t_16 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_16) {
+
+                                      /* "implicit/_als.pyx":178
+ * 
+ *                     if confidence > 0:
+ *                         temp = confidence             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         temp = 0
+ */
+                                      __pyx_v_temp = __pyx_v_confidence;
+
+                                      /* "implicit/_als.pyx":177
+ *                     confidence = data[index]
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = confidence
+ *                     else:
+ */
+                                      goto __pyx_L22;
+                                    }
+
+                                    /* "implicit/_als.pyx":180
+ *                         temp = confidence
+ *                     else:
+ *                         temp = 0             # <<<<<<<<<<<<<<
+ *                         confidence = -1 * confidence
+ * 
+ */
+                                    /*else*/ {
+                                      __pyx_v_temp = 0.0;
+
+                                      /* "implicit/_als.pyx":181
+ *                     else:
+ *                         temp = 0
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+ */
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L22:;
+
+                                    /* "implicit/_als.pyx":183
+ *                         confidence = -1 * confidence
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)             # <<<<<<<<<<<<<<
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  */
@@ -13619,11 +13860,11 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_t_26 = 0;
                                     if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_Y.shape[0];
                                     if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_Y.shape[1];
-                                    __pyx_v_temp = (__pyx_v_confidence - ((__pyx_v_confidence - 1.0) * __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_25 * __pyx_v_Y.strides[0]) ) + __pyx_t_26 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one))));
+                                    __pyx_v_temp = (__pyx_v_temp - ((__pyx_v_confidence - 1.0) * __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_25 * __pyx_v_Y.strides[0]) ) + __pyx_t_26 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one))));
 
-                                    /* "implicit/_als.pyx":174
- *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+                                    /* "implicit/_als.pyx":184
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)             # <<<<<<<<<<<<<<
  * 
  *                 memcpy(p, r, sizeof(floating) * N)
@@ -13635,7 +13876,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
                                   }
 
-                                  /* "implicit/_als.pyx":176
+                                  /* "implicit/_als.pyx":186
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  *                 memcpy(p, r, sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -13644,7 +13885,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   memcpy(__pyx_v_p, __pyx_v_r, ((sizeof(float)) * __pyx_v_N));
 
-                                  /* "implicit/_als.pyx":177
+                                  /* "implicit/_als.pyx":187
  * 
  *                 memcpy(p, r, sizeof(floating) * N)
  *                 rsold = dot(&N, r, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -13653,7 +13894,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   __pyx_v_rsold = __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":179
+                                  /* "implicit/_als.pyx":189
  *                 rsold = dot(&N, r, &one, r, &one)
  * 
  *                 if rsold < 1e-20:             # <<<<<<<<<<<<<<
@@ -13663,7 +13904,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_t_16 = ((__pyx_v_rsold < 1e-20) != 0);
                                   if (__pyx_t_16) {
 
-                                    /* "implicit/_als.pyx":180
+                                    /* "implicit/_als.pyx":190
  * 
  *                 if rsold < 1e-20:
  *                     continue             # <<<<<<<<<<<<<<
@@ -13672,7 +13913,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     goto __pyx_L15_continue;
 
-                                    /* "implicit/_als.pyx":179
+                                    /* "implicit/_als.pyx":189
  *                 rsold = dot(&N, r, &one, r, &one)
  * 
  *                 if rsold < 1e-20:             # <<<<<<<<<<<<<<
@@ -13681,7 +13922,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   }
 
-                                  /* "implicit/_als.pyx":182
+                                  /* "implicit/_als.pyx":192
  *                     continue
  * 
  *                 for it in range(cg_steps):             # <<<<<<<<<<<<<<
@@ -13692,7 +13933,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
                                   for (__pyx_t_29 = 0; __pyx_t_29 < __pyx_t_22; __pyx_t_29+=1) {
                                     __pyx_v_it = __pyx_t_29;
 
-                                    /* "implicit/_als.pyx":184
+                                    /* "implicit/_als.pyx":194
  *                 for it in range(cg_steps):
  *                     # calculate Ap = YtCuYp - without actually calculating YtCuY
  *                     temp = 1.0             # <<<<<<<<<<<<<<
@@ -13701,7 +13942,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = 1.0;
 
-                                    /* "implicit/_als.pyx":185
+                                    /* "implicit/_als.pyx":195
  *                     # calculate Ap = YtCuYp - without actually calculating YtCuY
  *                     temp = 1.0
  *                     symv("U", &N, &temp, &YtY[0, 0], &N, p, &one, &zero, Ap, &one)             # <<<<<<<<<<<<<<
@@ -13714,7 +13955,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
                                     if (__pyx_t_31 < 0) __pyx_t_31 += __pyx_v_YtY.shape[1];
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_30 * __pyx_v_YtY.strides[0]) ) + __pyx_t_31 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), __pyx_v_p, (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_Ap, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":187
+                                    /* "implicit/_als.pyx":197
  *                     symv("U", &N, &temp, &YtY[0, 0], &N, p, &one, &zero, Ap, &one)
  * 
  *                     for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -13729,31 +13970,59 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
                                     for (__pyx_t_34 = (*((short *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_33 * __pyx_v_indptr.strides[0]) ))); __pyx_t_34 < __pyx_t_20; __pyx_t_34+=1) {
                                       __pyx_v_index = __pyx_t_34;
 
-                                      /* "implicit/_als.pyx":188
+                                      /* "implicit/_als.pyx":198
  * 
  *                     for index in range(indptr[u], indptr[u + 1]):
  *                         i = indices[index]             # <<<<<<<<<<<<<<
  *                         confidence = data[index]
- *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
+ * 
  */
                                       __pyx_t_35 = __pyx_v_index;
                                       if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_indices.shape[0];
                                       __pyx_v_i = (*((short *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_35 * __pyx_v_indices.strides[0]) )));
 
-                                      /* "implicit/_als.pyx":189
+                                      /* "implicit/_als.pyx":199
  *                     for index in range(indptr[u], indptr[u + 1]):
  *                         i = indices[index]
  *                         confidence = data[index]             # <<<<<<<<<<<<<<
- *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
- *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)
+ * 
+ *                         if confidence < 0:
  */
                                       __pyx_t_36 = __pyx_v_index;
                                       if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_data.shape[0];
                                       __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_36 * __pyx_v_data.strides[0]) )));
 
-                                      /* "implicit/_als.pyx":190
- *                         i = indices[index]
+                                      /* "implicit/_als.pyx":201
  *                         confidence = data[index]
+ * 
+ *                         if confidence < 0:             # <<<<<<<<<<<<<<
+ *                             confidence = -1 * confidence
+ * 
+ */
+                                      __pyx_t_16 = ((__pyx_v_confidence < 0.0) != 0);
+                                      if (__pyx_t_16) {
+
+                                        /* "implicit/_als.pyx":202
+ * 
+ *                         if confidence < 0:
+ *                             confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
+ */
+                                        __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+
+                                        /* "implicit/_als.pyx":201
+ *                         confidence = data[index]
+ * 
+ *                         if confidence < 0:             # <<<<<<<<<<<<<<
+ *                             confidence = -1 * confidence
+ * 
+ */
+                                      }
+
+                                      /* "implicit/_als.pyx":204
+ *                             confidence = -1 * confidence
+ * 
  *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)             # <<<<<<<<<<<<<<
  *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)
  * 
@@ -13764,8 +14033,8 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
                                       if (__pyx_t_38 < 0) __pyx_t_38 += __pyx_v_Y.shape[1];
                                       __pyx_v_temp = ((__pyx_v_confidence - 1.0) * __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_37 * __pyx_v_Y.strides[0]) ) + __pyx_t_38 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_p, (&__pyx_v_one)));
 
-                                      /* "implicit/_als.pyx":191
- *                         confidence = data[index]
+                                      /* "implicit/_als.pyx":205
+ * 
  *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
  *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)             # <<<<<<<<<<<<<<
  * 
@@ -13778,7 +14047,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
                                       __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_39 * __pyx_v_Y.strides[0]) ) + __pyx_t_40 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_Ap, (&__pyx_v_one));
                                     }
 
-                                    /* "implicit/_als.pyx":194
+                                    /* "implicit/_als.pyx":208
  * 
  *                     # alpha = rsold / p.dot(Ap);
  *                     alpha = rsold / dot(&N, p, &one, Ap, &one)             # <<<<<<<<<<<<<<
@@ -13787,7 +14056,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_alpha = (__pyx_v_rsold / __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_p, (&__pyx_v_one), __pyx_v_Ap, (&__pyx_v_one)));
 
-                                    /* "implicit/_als.pyx":197
+                                    /* "implicit/_als.pyx":211
  * 
  *                     # x += alpha * p
  *                     axpy(&N, &alpha, p, &one, x, &one)             # <<<<<<<<<<<<<<
@@ -13796,7 +14065,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_alpha), __pyx_v_p, (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":200
+                                    /* "implicit/_als.pyx":214
  * 
  *                     # r -= alpha * Ap
  *                     temp = alpha * -1             # <<<<<<<<<<<<<<
@@ -13805,7 +14074,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = (__pyx_v_alpha * -1.0);
 
-                                    /* "implicit/_als.pyx":201
+                                    /* "implicit/_als.pyx":215
  *                     # r -= alpha * Ap
  *                     temp = alpha * -1
  *                     axpy(&N, &temp, Ap, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -13814,7 +14083,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_Ap, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":203
+                                    /* "implicit/_als.pyx":217
  *                     axpy(&N, &temp, Ap, &one, r, &one)
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -13823,7 +14092,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_rsnew = __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":204
+                                    /* "implicit/_als.pyx":218
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:             # <<<<<<<<<<<<<<
@@ -13833,16 +14102,16 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_t_16 = ((__pyx_v_rsnew < 1e-20) != 0);
                                     if (__pyx_t_16) {
 
-                                      /* "implicit/_als.pyx":205
+                                      /* "implicit/_als.pyx":219
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:
  *                         break             # <<<<<<<<<<<<<<
  * 
  *                     # p = r + (rsnew/rsold) * p
  */
-                                      goto __pyx_L24_break;
+                                      goto __pyx_L25_break;
 
-                                      /* "implicit/_als.pyx":204
+                                      /* "implicit/_als.pyx":218
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:             # <<<<<<<<<<<<<<
@@ -13851,7 +14120,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     }
 
-                                    /* "implicit/_als.pyx":208
+                                    /* "implicit/_als.pyx":222
  * 
  *                     # p = r + (rsnew/rsold) * p
  *                     temp = rsnew / rsold             # <<<<<<<<<<<<<<
@@ -13860,7 +14129,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = (__pyx_v_rsnew / __pyx_v_rsold);
 
-                                    /* "implicit/_als.pyx":209
+                                    /* "implicit/_als.pyx":223
  *                     # p = r + (rsnew/rsold) * p
  *                     temp = rsnew / rsold
  *                     scal(&N, &temp, p, &one)             # <<<<<<<<<<<<<<
@@ -13869,7 +14138,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_scal((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_p, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":210
+                                    /* "implicit/_als.pyx":224
  *                     temp = rsnew / rsold
  *                     scal(&N, &temp, p, &one)
  *                     temp = 1.0             # <<<<<<<<<<<<<<
@@ -13878,7 +14147,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = 1.0;
 
-                                    /* "implicit/_als.pyx":211
+                                    /* "implicit/_als.pyx":225
  *                     scal(&N, &temp, p, &one)
  *                     temp = 1.0
  *                     axpy(&N, &temp, r, &one, p, &one)             # <<<<<<<<<<<<<<
@@ -13887,7 +14156,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_r, (&__pyx_v_one), __pyx_v_p, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":213
+                                    /* "implicit/_als.pyx":227
  *                     axpy(&N, &temp, r, &one, p, &one)
  * 
  *                     rsold = rsnew             # <<<<<<<<<<<<<<
@@ -13896,18 +14165,18 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_rsold = __pyx_v_rsnew;
                                   }
-                                  __pyx_L24_break:;
-                                  goto __pyx_L29;
+                                  __pyx_L25_break:;
+                                  goto __pyx_L31;
                                   __pyx_L15_continue:;
-                                  goto __pyx_L29;
-                                  __pyx_L29:;
+                                  goto __pyx_L31;
+                                  __pyx_L31:;
                               }
                           }
                       }
                   }
                 }
 
-                /* "implicit/_als.pyx":215
+                /* "implicit/_als.pyx":229
  *                     rsold = rsnew
  *         finally:
  *             free(p)             # <<<<<<<<<<<<<<
@@ -13918,7 +14187,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
                   /*normal exit:*/{
                     free(__pyx_v_p);
 
-                    /* "implicit/_als.pyx":216
+                    /* "implicit/_als.pyx":230
  *         finally:
  *             free(p)
  *             free(r)             # <<<<<<<<<<<<<<
@@ -13927,7 +14196,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
  */
                     free(__pyx_v_r);
 
-                    /* "implicit/_als.pyx":217
+                    /* "implicit/_als.pyx":231
  *             free(p)
  *             free(r)
  *             free(Ap)             # <<<<<<<<<<<<<<
@@ -13949,7 +14218,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
         #endif
       }
 
-      /* "implicit/_als.pyx":150
+      /* "implicit/_als.pyx":153
  *     cdef floating * Ap
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -13968,7 +14237,7 @@ static PyObject *__pyx_pf_8implicit_4_als_26_least_squares_cg(CYTHON_UNUSED PyOb
       }
   }
 
-  /* "implicit/_als.pyx":134
+  /* "implicit/_als.pyx":137
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _least_squares_cg(integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
@@ -14011,11 +14280,11 @@ static PyObject *__pyx_pf_8implicit_4_als_92__defaults__(CYTHON_UNUSED PyObject 
   PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("__defaults__", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults19, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults19, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults19, __pyx_self)->__pyx_arg_cg_steps); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults19, __pyx_self)->__pyx_arg_cg_steps); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
@@ -14023,7 +14292,7 @@ static PyObject *__pyx_pf_8implicit_4_als_92__defaults__(CYTHON_UNUSED PyObject 
   PyTuple_SET_ITEM(__pyx_t_3, 1, __pyx_t_2);
   __pyx_t_1 = 0;
   __pyx_t_2 = 0;
-  __pyx_t_2 = PyTuple_New(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_3);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_3);
@@ -14099,31 +14368,31 @@ static PyObject *__pyx_fuse_0_1__pyx_pw_8implicit_4_als_29_least_squares_cg(PyOb
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indices)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 1); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 1); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_data)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 2); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 2); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_X)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 3); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 3); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
         if (likely((values[4] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_Y)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 4); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 4); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  5:
         if (likely((values[5] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_regularization)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 5); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 5); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  6:
@@ -14139,7 +14408,7 @@ static PyObject *__pyx_fuse_0_1__pyx_pw_8implicit_4_als_29_least_squares_cg(PyOb
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_least_squares_cg") < 0)) __PYX_ERR(0, 134, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_least_squares_cg") < 0)) __PYX_ERR(0, 137, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -14157,26 +14426,26 @@ static PyObject *__pyx_fuse_0_1__pyx_pw_8implicit_4_als_29_least_squares_cg(PyOb
         default: goto __pyx_L5_argtuple_error;
       }
     }
-    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_short(values[0]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_short(values[1]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[2]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[3]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 135, __pyx_L3_error)
-    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[4]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 135, __pyx_L3_error)
-    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[5]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 135, __pyx_L3_error)
+    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_short(values[0]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_short(values[1]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[2]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[3]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 138, __pyx_L3_error)
+    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[4]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 138, __pyx_L3_error)
+    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[5]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 138, __pyx_L3_error)
     if (values[6]) {
-      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[6]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 136, __pyx_L3_error)
+      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[6]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 139, __pyx_L3_error)
     } else {
       __pyx_v_num_threads = __pyx_dynamic_args->__pyx_arg_num_threads;
     }
     if (values[7]) {
-      __pyx_v_cg_steps = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_cg_steps == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 136, __pyx_L3_error)
+      __pyx_v_cg_steps = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_cg_steps == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 139, __pyx_L3_error)
     } else {
       __pyx_v_cg_steps = __pyx_dynamic_args->__pyx_arg_cg_steps;
     }
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 134, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 137, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("implicit._als._least_squares_cg", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -14253,7 +14522,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
   Py_ssize_t __pyx_t_40;
   __Pyx_RefNannySetupContext("__pyx_fuse_0_1_least_squares_cg", 0);
 
-  /* "implicit/_als.pyx":137
+  /* "implicit/_als.pyx":140
  *                       floating[:, :] X, floating[:, :] Y, float regularization,
  *                       int num_threads=0, int cg_steps=3):
  *     dtype = np.float64 if floating is double else np.float32             # <<<<<<<<<<<<<<
@@ -14261,17 +14530,17 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it
  */
   if ((1 != 0)) {
-    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_1 = __pyx_t_3;
     __pyx_t_3 = 0;
   } else {
-    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_t_1 = __pyx_t_2;
@@ -14280,7 +14549,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
   __pyx_v_dtype = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "implicit/_als.pyx":139
+  /* "implicit/_als.pyx":142
  *     dtype = np.float64 if floating is double else np.float32
  * 
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it             # <<<<<<<<<<<<<<
@@ -14291,7 +14560,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
   __pyx_v_N = (__pyx_v_X.shape[1]);
   __pyx_v_one = 1;
 
-  /* "implicit/_als.pyx":141
+  /* "implicit/_als.pyx":144
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it
  *     cdef floating confidence, temp, alpha, rsnew, rsold
  *     cdef floating zero = 0.             # <<<<<<<<<<<<<<
@@ -14300,24 +14569,24 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
   __pyx_v_zero = 0.;
 
-  /* "implicit/_als.pyx":143
+  /* "implicit/_als.pyx":146
  *     cdef floating zero = 0.
  * 
  *     cdef floating[:, :] YtY = np.dot(np.transpose(Y), Y) + regularization * np.eye(N, dtype=dtype)             # <<<<<<<<<<<<<<
  * 
  *     cdef floating * x
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_6 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -14330,14 +14599,14 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
     }
   }
   if (!__pyx_t_6) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_GOTREF(__pyx_t_2);
   } else {
     #if CYTHON_FAST_PYCALL
     if (PyFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -14346,26 +14615,26 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
     #if CYTHON_FAST_PYCCALL
     if (__Pyx_PyFastCFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     } else
     #endif
     {
-      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_6); __pyx_t_6 = NULL;
       __Pyx_GIVEREF(__pyx_t_4);
       PyTuple_SET_ITEM(__pyx_t_7, 0+1, __pyx_t_4);
       __pyx_t_4 = 0;
-      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     }
   }
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_7 = NULL;
   __pyx_t_8 = 0;
@@ -14382,7 +14651,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -14392,7 +14661,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -14400,7 +14669,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
   } else
   #endif
   {
-    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     if (__pyx_t_7) {
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -14411,49 +14680,49 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
     PyTuple_SET_ITEM(__pyx_t_4, 1+__pyx_t_8, __pyx_t_5);
     __pyx_t_2 = 0;
     __pyx_t_5 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_regularization); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_regularization); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_eye); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_eye); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_N); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_N); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_4);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_4);
   __pyx_t_4 = 0;
-  __pyx_t_4 = PyDict_New(); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = PyDict_New(); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  if (PyDict_SetItem(__pyx_t_4, __pyx_n_s_dtype, __pyx_v_dtype) < 0) __PYX_ERR(0, 143, __pyx_L1_error)
-  __pyx_t_7 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_4, __pyx_n_s_dtype, __pyx_v_dtype) < 0) __PYX_ERR(0, 146, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = PyNumber_Multiply(__pyx_t_3, __pyx_t_7); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = PyNumber_Multiply(__pyx_t_3, __pyx_t_7); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
-  __pyx_t_7 = PyNumber_Add(__pyx_t_1, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_7 = PyNumber_Add(__pyx_t_1, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(__pyx_t_7);
-  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 143, __pyx_L1_error)
+  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   __pyx_v_YtY = __pyx_t_9;
   __pyx_t_9.memview = NULL;
   __pyx_t_9.data = NULL;
 
-  /* "implicit/_als.pyx":150
+  /* "implicit/_als.pyx":153
  *     cdef floating * Ap
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -14483,7 +14752,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
                 __pyx_v_p = ((double *)1);
                 __pyx_v_r = ((double *)1);
 
-                /* "implicit/_als.pyx":153
+                /* "implicit/_als.pyx":156
  * 
  *         # allocate temp memory for each thread
  *         Ap = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -14492,7 +14761,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_Ap = ((double *)malloc(((sizeof(double)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":154
+                /* "implicit/_als.pyx":157
  *         # allocate temp memory for each thread
  *         Ap = <floating *> malloc(sizeof(floating) * N)
  *         p = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -14501,7 +14770,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_p = ((double *)malloc(((sizeof(double)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":155
+                /* "implicit/_als.pyx":158
  *         Ap = <floating *> malloc(sizeof(floating) * N)
  *         p = <floating *> malloc(sizeof(floating) * N)
  *         r = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -14510,7 +14779,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_r = ((double *)malloc(((sizeof(double)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":156
+                /* "implicit/_als.pyx":159
  *         p = <floating *> malloc(sizeof(floating) * N)
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:             # <<<<<<<<<<<<<<
@@ -14519,7 +14788,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 /*try:*/ {
 
-                  /* "implicit/_als.pyx":157
+                  /* "implicit/_als.pyx":160
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:
  *             for u in prange(users, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -14549,7 +14818,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_v_temp = ((double)__PYX_NAN());
                                   __pyx_v_x = ((double *)1);
 
-                                  /* "implicit/_als.pyx":159
+                                  /* "implicit/_als.pyx":162
  *             for u in prange(users, schedule='guided'):
  *                 # start from previous iteration
  *                 x = &X[u, 0]             # <<<<<<<<<<<<<<
@@ -14562,7 +14831,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
                                   if (__pyx_t_13 < 0) __pyx_t_13 += __pyx_v_X.shape[1];
                                   __pyx_v_x = (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_12 * __pyx_v_X.strides[0]) ) + __pyx_t_13 * __pyx_v_X.strides[1]) ))));
 
-                                  /* "implicit/_als.pyx":162
+                                  /* "implicit/_als.pyx":165
  * 
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:             # <<<<<<<<<<<<<<
@@ -14576,7 +14845,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_t_16 = (((*((short *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_14 * __pyx_v_indptr.strides[0]) ))) == (*((short *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_15 * __pyx_v_indptr.strides[0]) )))) != 0);
                                   if (__pyx_t_16) {
 
-                                    /* "implicit/_als.pyx":163
+                                    /* "implicit/_als.pyx":166
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:
  *                     memset(x, 0, sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -14585,7 +14854,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     memset(__pyx_v_x, 0, ((sizeof(double)) * __pyx_v_N));
 
-                                    /* "implicit/_als.pyx":164
+                                    /* "implicit/_als.pyx":167
  *                 if indptr[u] == indptr[u+1]:
  *                     memset(x, 0, sizeof(floating) * N)
  *                     continue             # <<<<<<<<<<<<<<
@@ -14594,7 +14863,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     goto __pyx_L15_continue;
 
-                                    /* "implicit/_als.pyx":162
+                                    /* "implicit/_als.pyx":165
  * 
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:             # <<<<<<<<<<<<<<
@@ -14603,7 +14872,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   }
 
-                                  /* "implicit/_als.pyx":167
+                                  /* "implicit/_als.pyx":170
  * 
  *                 # calculate residual r = (YtCuPu - (YtCuY.dot(Xu)
  *                 temp = -1.0             # <<<<<<<<<<<<<<
@@ -14612,7 +14881,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   __pyx_v_temp = -1.0;
 
-                                  /* "implicit/_als.pyx":168
+                                  /* "implicit/_als.pyx":171
  *                 # calculate residual r = (YtCuPu - (YtCuY.dot(Xu)
  *                 temp = -1.0
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, x, &one, &zero, r, &one)             # <<<<<<<<<<<<<<
@@ -14625,7 +14894,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
                                   if (__pyx_t_18 < 0) __pyx_t_18 += __pyx_v_YtY.shape[1];
                                   __pyx_fuse_1__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_17 * __pyx_v_YtY.strides[0]) ) + __pyx_t_18 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), __pyx_v_x, (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":170
+                                  /* "implicit/_als.pyx":173
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, x, &one, &zero, r, &one)
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -14640,32 +14909,82 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
                                   for (__pyx_t_22 = (*((short *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_21 * __pyx_v_indptr.strides[0]) ))); __pyx_t_22 < __pyx_t_20; __pyx_t_22+=1) {
                                     __pyx_v_index = __pyx_t_22;
 
-                                    /* "implicit/_als.pyx":171
+                                    /* "implicit/_als.pyx":174
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]             # <<<<<<<<<<<<<<
  *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+ * 
  */
                                     __pyx_t_23 = __pyx_v_index;
                                     if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_indices.shape[0];
                                     __pyx_v_i = (*((short *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_23 * __pyx_v_indices.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":172
+                                    /* "implicit/_als.pyx":175
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]
  *                     confidence = data[index]             # <<<<<<<<<<<<<<
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
- *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
+ * 
+ *                     if confidence > 0:
  */
                                     __pyx_t_24 = __pyx_v_index;
                                     if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_data.shape[0];
                                     __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_24 * __pyx_v_data.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":173
- *                     i = indices[index]
+                                    /* "implicit/_als.pyx":177
  *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)             # <<<<<<<<<<<<<<
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = confidence
+ *                     else:
+ */
+                                    __pyx_t_16 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_16) {
+
+                                      /* "implicit/_als.pyx":178
+ * 
+ *                     if confidence > 0:
+ *                         temp = confidence             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         temp = 0
+ */
+                                      __pyx_v_temp = __pyx_v_confidence;
+
+                                      /* "implicit/_als.pyx":177
+ *                     confidence = data[index]
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = confidence
+ *                     else:
+ */
+                                      goto __pyx_L22;
+                                    }
+
+                                    /* "implicit/_als.pyx":180
+ *                         temp = confidence
+ *                     else:
+ *                         temp = 0             # <<<<<<<<<<<<<<
+ *                         confidence = -1 * confidence
+ * 
+ */
+                                    /*else*/ {
+                                      __pyx_v_temp = 0.0;
+
+                                      /* "implicit/_als.pyx":181
+ *                     else:
+ *                         temp = 0
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+ */
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L22:;
+
+                                    /* "implicit/_als.pyx":183
+ *                         confidence = -1 * confidence
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)             # <<<<<<<<<<<<<<
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  */
@@ -14673,11 +14992,11 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_t_26 = 0;
                                     if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_Y.shape[0];
                                     if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_Y.shape[1];
-                                    __pyx_v_temp = (__pyx_v_confidence - ((__pyx_v_confidence - 1.0) * __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_25 * __pyx_v_Y.strides[0]) ) + __pyx_t_26 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one))));
+                                    __pyx_v_temp = (__pyx_v_temp - ((__pyx_v_confidence - 1.0) * __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_25 * __pyx_v_Y.strides[0]) ) + __pyx_t_26 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one))));
 
-                                    /* "implicit/_als.pyx":174
- *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+                                    /* "implicit/_als.pyx":184
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)             # <<<<<<<<<<<<<<
  * 
  *                 memcpy(p, r, sizeof(floating) * N)
@@ -14689,7 +15008,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
                                   }
 
-                                  /* "implicit/_als.pyx":176
+                                  /* "implicit/_als.pyx":186
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  *                 memcpy(p, r, sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -14698,7 +15017,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   memcpy(__pyx_v_p, __pyx_v_r, ((sizeof(double)) * __pyx_v_N));
 
-                                  /* "implicit/_als.pyx":177
+                                  /* "implicit/_als.pyx":187
  * 
  *                 memcpy(p, r, sizeof(floating) * N)
  *                 rsold = dot(&N, r, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -14707,7 +15026,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   __pyx_v_rsold = __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":179
+                                  /* "implicit/_als.pyx":189
  *                 rsold = dot(&N, r, &one, r, &one)
  * 
  *                 if rsold < 1e-20:             # <<<<<<<<<<<<<<
@@ -14717,7 +15036,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_t_16 = ((__pyx_v_rsold < 1e-20) != 0);
                                   if (__pyx_t_16) {
 
-                                    /* "implicit/_als.pyx":180
+                                    /* "implicit/_als.pyx":190
  * 
  *                 if rsold < 1e-20:
  *                     continue             # <<<<<<<<<<<<<<
@@ -14726,7 +15045,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     goto __pyx_L15_continue;
 
-                                    /* "implicit/_als.pyx":179
+                                    /* "implicit/_als.pyx":189
  *                 rsold = dot(&N, r, &one, r, &one)
  * 
  *                 if rsold < 1e-20:             # <<<<<<<<<<<<<<
@@ -14735,7 +15054,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   }
 
-                                  /* "implicit/_als.pyx":182
+                                  /* "implicit/_als.pyx":192
  *                     continue
  * 
  *                 for it in range(cg_steps):             # <<<<<<<<<<<<<<
@@ -14746,7 +15065,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
                                   for (__pyx_t_29 = 0; __pyx_t_29 < __pyx_t_22; __pyx_t_29+=1) {
                                     __pyx_v_it = __pyx_t_29;
 
-                                    /* "implicit/_als.pyx":184
+                                    /* "implicit/_als.pyx":194
  *                 for it in range(cg_steps):
  *                     # calculate Ap = YtCuYp - without actually calculating YtCuY
  *                     temp = 1.0             # <<<<<<<<<<<<<<
@@ -14755,7 +15074,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = 1.0;
 
-                                    /* "implicit/_als.pyx":185
+                                    /* "implicit/_als.pyx":195
  *                     # calculate Ap = YtCuYp - without actually calculating YtCuY
  *                     temp = 1.0
  *                     symv("U", &N, &temp, &YtY[0, 0], &N, p, &one, &zero, Ap, &one)             # <<<<<<<<<<<<<<
@@ -14768,7 +15087,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
                                     if (__pyx_t_31 < 0) __pyx_t_31 += __pyx_v_YtY.shape[1];
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_30 * __pyx_v_YtY.strides[0]) ) + __pyx_t_31 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), __pyx_v_p, (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_Ap, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":187
+                                    /* "implicit/_als.pyx":197
  *                     symv("U", &N, &temp, &YtY[0, 0], &N, p, &one, &zero, Ap, &one)
  * 
  *                     for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -14783,31 +15102,59 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
                                     for (__pyx_t_34 = (*((short *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_33 * __pyx_v_indptr.strides[0]) ))); __pyx_t_34 < __pyx_t_20; __pyx_t_34+=1) {
                                       __pyx_v_index = __pyx_t_34;
 
-                                      /* "implicit/_als.pyx":188
+                                      /* "implicit/_als.pyx":198
  * 
  *                     for index in range(indptr[u], indptr[u + 1]):
  *                         i = indices[index]             # <<<<<<<<<<<<<<
  *                         confidence = data[index]
- *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
+ * 
  */
                                       __pyx_t_35 = __pyx_v_index;
                                       if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_indices.shape[0];
                                       __pyx_v_i = (*((short *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_35 * __pyx_v_indices.strides[0]) )));
 
-                                      /* "implicit/_als.pyx":189
+                                      /* "implicit/_als.pyx":199
  *                     for index in range(indptr[u], indptr[u + 1]):
  *                         i = indices[index]
  *                         confidence = data[index]             # <<<<<<<<<<<<<<
- *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
- *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)
+ * 
+ *                         if confidence < 0:
  */
                                       __pyx_t_36 = __pyx_v_index;
                                       if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_data.shape[0];
                                       __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_36 * __pyx_v_data.strides[0]) )));
 
-                                      /* "implicit/_als.pyx":190
- *                         i = indices[index]
+                                      /* "implicit/_als.pyx":201
  *                         confidence = data[index]
+ * 
+ *                         if confidence < 0:             # <<<<<<<<<<<<<<
+ *                             confidence = -1 * confidence
+ * 
+ */
+                                      __pyx_t_16 = ((__pyx_v_confidence < 0.0) != 0);
+                                      if (__pyx_t_16) {
+
+                                        /* "implicit/_als.pyx":202
+ * 
+ *                         if confidence < 0:
+ *                             confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
+ */
+                                        __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+
+                                        /* "implicit/_als.pyx":201
+ *                         confidence = data[index]
+ * 
+ *                         if confidence < 0:             # <<<<<<<<<<<<<<
+ *                             confidence = -1 * confidence
+ * 
+ */
+                                      }
+
+                                      /* "implicit/_als.pyx":204
+ *                             confidence = -1 * confidence
+ * 
  *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)             # <<<<<<<<<<<<<<
  *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)
  * 
@@ -14818,8 +15165,8 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
                                       if (__pyx_t_38 < 0) __pyx_t_38 += __pyx_v_Y.shape[1];
                                       __pyx_v_temp = ((__pyx_v_confidence - 1.0) * __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_37 * __pyx_v_Y.strides[0]) ) + __pyx_t_38 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_p, (&__pyx_v_one)));
 
-                                      /* "implicit/_als.pyx":191
- *                         confidence = data[index]
+                                      /* "implicit/_als.pyx":205
+ * 
  *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
  *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)             # <<<<<<<<<<<<<<
  * 
@@ -14832,7 +15179,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
                                       __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_39 * __pyx_v_Y.strides[0]) ) + __pyx_t_40 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_Ap, (&__pyx_v_one));
                                     }
 
-                                    /* "implicit/_als.pyx":194
+                                    /* "implicit/_als.pyx":208
  * 
  *                     # alpha = rsold / p.dot(Ap);
  *                     alpha = rsold / dot(&N, p, &one, Ap, &one)             # <<<<<<<<<<<<<<
@@ -14841,7 +15188,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_alpha = (__pyx_v_rsold / __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_p, (&__pyx_v_one), __pyx_v_Ap, (&__pyx_v_one)));
 
-                                    /* "implicit/_als.pyx":197
+                                    /* "implicit/_als.pyx":211
  * 
  *                     # x += alpha * p
  *                     axpy(&N, &alpha, p, &one, x, &one)             # <<<<<<<<<<<<<<
@@ -14850,7 +15197,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_alpha), __pyx_v_p, (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":200
+                                    /* "implicit/_als.pyx":214
  * 
  *                     # r -= alpha * Ap
  *                     temp = alpha * -1             # <<<<<<<<<<<<<<
@@ -14859,7 +15206,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = (__pyx_v_alpha * -1.0);
 
-                                    /* "implicit/_als.pyx":201
+                                    /* "implicit/_als.pyx":215
  *                     # r -= alpha * Ap
  *                     temp = alpha * -1
  *                     axpy(&N, &temp, Ap, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -14868,7 +15215,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_Ap, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":203
+                                    /* "implicit/_als.pyx":217
  *                     axpy(&N, &temp, Ap, &one, r, &one)
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -14877,7 +15224,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_rsnew = __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":204
+                                    /* "implicit/_als.pyx":218
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:             # <<<<<<<<<<<<<<
@@ -14887,16 +15234,16 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_t_16 = ((__pyx_v_rsnew < 1e-20) != 0);
                                     if (__pyx_t_16) {
 
-                                      /* "implicit/_als.pyx":205
+                                      /* "implicit/_als.pyx":219
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:
  *                         break             # <<<<<<<<<<<<<<
  * 
  *                     # p = r + (rsnew/rsold) * p
  */
-                                      goto __pyx_L24_break;
+                                      goto __pyx_L25_break;
 
-                                      /* "implicit/_als.pyx":204
+                                      /* "implicit/_als.pyx":218
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:             # <<<<<<<<<<<<<<
@@ -14905,7 +15252,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     }
 
-                                    /* "implicit/_als.pyx":208
+                                    /* "implicit/_als.pyx":222
  * 
  *                     # p = r + (rsnew/rsold) * p
  *                     temp = rsnew / rsold             # <<<<<<<<<<<<<<
@@ -14914,7 +15261,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = (__pyx_v_rsnew / __pyx_v_rsold);
 
-                                    /* "implicit/_als.pyx":209
+                                    /* "implicit/_als.pyx":223
  *                     # p = r + (rsnew/rsold) * p
  *                     temp = rsnew / rsold
  *                     scal(&N, &temp, p, &one)             # <<<<<<<<<<<<<<
@@ -14923,7 +15270,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_scal((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_p, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":210
+                                    /* "implicit/_als.pyx":224
  *                     temp = rsnew / rsold
  *                     scal(&N, &temp, p, &one)
  *                     temp = 1.0             # <<<<<<<<<<<<<<
@@ -14932,7 +15279,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = 1.0;
 
-                                    /* "implicit/_als.pyx":211
+                                    /* "implicit/_als.pyx":225
  *                     scal(&N, &temp, p, &one)
  *                     temp = 1.0
  *                     axpy(&N, &temp, r, &one, p, &one)             # <<<<<<<<<<<<<<
@@ -14941,7 +15288,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_r, (&__pyx_v_one), __pyx_v_p, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":213
+                                    /* "implicit/_als.pyx":227
  *                     axpy(&N, &temp, r, &one, p, &one)
  * 
  *                     rsold = rsnew             # <<<<<<<<<<<<<<
@@ -14950,18 +15297,18 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_rsold = __pyx_v_rsnew;
                                   }
-                                  __pyx_L24_break:;
-                                  goto __pyx_L29;
+                                  __pyx_L25_break:;
+                                  goto __pyx_L31;
                                   __pyx_L15_continue:;
-                                  goto __pyx_L29;
-                                  __pyx_L29:;
+                                  goto __pyx_L31;
+                                  __pyx_L31:;
                               }
                           }
                       }
                   }
                 }
 
-                /* "implicit/_als.pyx":215
+                /* "implicit/_als.pyx":229
  *                     rsold = rsnew
  *         finally:
  *             free(p)             # <<<<<<<<<<<<<<
@@ -14972,7 +15319,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
                   /*normal exit:*/{
                     free(__pyx_v_p);
 
-                    /* "implicit/_als.pyx":216
+                    /* "implicit/_als.pyx":230
  *         finally:
  *             free(p)
  *             free(r)             # <<<<<<<<<<<<<<
@@ -14981,7 +15328,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
  */
                     free(__pyx_v_r);
 
-                    /* "implicit/_als.pyx":217
+                    /* "implicit/_als.pyx":231
  *             free(p)
  *             free(r)
  *             free(Ap)             # <<<<<<<<<<<<<<
@@ -15003,7 +15350,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
         #endif
       }
 
-      /* "implicit/_als.pyx":150
+      /* "implicit/_als.pyx":153
  *     cdef floating * Ap
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -15022,7 +15369,7 @@ static PyObject *__pyx_pf_8implicit_4_als_28_least_squares_cg(CYTHON_UNUSED PyOb
       }
   }
 
-  /* "implicit/_als.pyx":134
+  /* "implicit/_als.pyx":137
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _least_squares_cg(integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
@@ -15065,11 +15412,11 @@ static PyObject *__pyx_pf_8implicit_4_als_94__defaults__(CYTHON_UNUSED PyObject 
   PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("__defaults__", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults20, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults20, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults20, __pyx_self)->__pyx_arg_cg_steps); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults20, __pyx_self)->__pyx_arg_cg_steps); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
@@ -15077,7 +15424,7 @@ static PyObject *__pyx_pf_8implicit_4_als_94__defaults__(CYTHON_UNUSED PyObject 
   PyTuple_SET_ITEM(__pyx_t_3, 1, __pyx_t_2);
   __pyx_t_1 = 0;
   __pyx_t_2 = 0;
-  __pyx_t_2 = PyTuple_New(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_3);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_3);
@@ -15153,31 +15500,31 @@ static PyObject *__pyx_fuse_1_0__pyx_pw_8implicit_4_als_31_least_squares_cg(PyOb
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indices)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 1); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 1); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_data)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 2); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 2); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_X)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 3); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 3); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
         if (likely((values[4] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_Y)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 4); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 4); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  5:
         if (likely((values[5] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_regularization)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 5); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 5); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  6:
@@ -15193,7 +15540,7 @@ static PyObject *__pyx_fuse_1_0__pyx_pw_8implicit_4_als_31_least_squares_cg(PyOb
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_least_squares_cg") < 0)) __PYX_ERR(0, 134, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_least_squares_cg") < 0)) __PYX_ERR(0, 137, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -15211,26 +15558,26 @@ static PyObject *__pyx_fuse_1_0__pyx_pw_8implicit_4_als_31_least_squares_cg(PyOb
         default: goto __pyx_L5_argtuple_error;
       }
     }
-    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_int(values[0]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_int(values[1]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[2]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[3]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 135, __pyx_L3_error)
-    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[4]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 135, __pyx_L3_error)
-    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[5]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 135, __pyx_L3_error)
+    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_int(values[0]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_int(values[1]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[2]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[3]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 138, __pyx_L3_error)
+    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[4]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 138, __pyx_L3_error)
+    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[5]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 138, __pyx_L3_error)
     if (values[6]) {
-      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[6]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 136, __pyx_L3_error)
+      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[6]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 139, __pyx_L3_error)
     } else {
       __pyx_v_num_threads = __pyx_dynamic_args->__pyx_arg_num_threads;
     }
     if (values[7]) {
-      __pyx_v_cg_steps = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_cg_steps == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 136, __pyx_L3_error)
+      __pyx_v_cg_steps = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_cg_steps == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 139, __pyx_L3_error)
     } else {
       __pyx_v_cg_steps = __pyx_dynamic_args->__pyx_arg_cg_steps;
     }
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 134, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 137, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("implicit._als._least_squares_cg", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -15307,7 +15654,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
   Py_ssize_t __pyx_t_40;
   __Pyx_RefNannySetupContext("__pyx_fuse_1_0_least_squares_cg", 0);
 
-  /* "implicit/_als.pyx":137
+  /* "implicit/_als.pyx":140
  *                       floating[:, :] X, floating[:, :] Y, float regularization,
  *                       int num_threads=0, int cg_steps=3):
  *     dtype = np.float64 if floating is double else np.float32             # <<<<<<<<<<<<<<
@@ -15315,17 +15662,17 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it
  */
   if ((0 != 0)) {
-    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_1 = __pyx_t_3;
     __pyx_t_3 = 0;
   } else {
-    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_t_1 = __pyx_t_2;
@@ -15334,7 +15681,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
   __pyx_v_dtype = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "implicit/_als.pyx":139
+  /* "implicit/_als.pyx":142
  *     dtype = np.float64 if floating is double else np.float32
  * 
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it             # <<<<<<<<<<<<<<
@@ -15345,7 +15692,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
   __pyx_v_N = (__pyx_v_X.shape[1]);
   __pyx_v_one = 1;
 
-  /* "implicit/_als.pyx":141
+  /* "implicit/_als.pyx":144
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it
  *     cdef floating confidence, temp, alpha, rsnew, rsold
  *     cdef floating zero = 0.             # <<<<<<<<<<<<<<
@@ -15354,24 +15701,24 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
   __pyx_v_zero = 0.;
 
-  /* "implicit/_als.pyx":143
+  /* "implicit/_als.pyx":146
  *     cdef floating zero = 0.
  * 
  *     cdef floating[:, :] YtY = np.dot(np.transpose(Y), Y) + regularization * np.eye(N, dtype=dtype)             # <<<<<<<<<<<<<<
  * 
  *     cdef floating * x
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_6 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -15384,14 +15731,14 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
     }
   }
   if (!__pyx_t_6) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_GOTREF(__pyx_t_2);
   } else {
     #if CYTHON_FAST_PYCALL
     if (PyFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -15400,26 +15747,26 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
     #if CYTHON_FAST_PYCCALL
     if (__Pyx_PyFastCFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     } else
     #endif
     {
-      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_6); __pyx_t_6 = NULL;
       __Pyx_GIVEREF(__pyx_t_4);
       PyTuple_SET_ITEM(__pyx_t_7, 0+1, __pyx_t_4);
       __pyx_t_4 = 0;
-      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     }
   }
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_7 = NULL;
   __pyx_t_8 = 0;
@@ -15436,7 +15783,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -15446,7 +15793,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -15454,7 +15801,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
   } else
   #endif
   {
-    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     if (__pyx_t_7) {
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -15465,49 +15812,49 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
     PyTuple_SET_ITEM(__pyx_t_4, 1+__pyx_t_8, __pyx_t_5);
     __pyx_t_2 = 0;
     __pyx_t_5 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_regularization); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_regularization); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_eye); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_eye); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_N); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_N); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_4);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_4);
   __pyx_t_4 = 0;
-  __pyx_t_4 = PyDict_New(); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = PyDict_New(); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  if (PyDict_SetItem(__pyx_t_4, __pyx_n_s_dtype, __pyx_v_dtype) < 0) __PYX_ERR(0, 143, __pyx_L1_error)
-  __pyx_t_7 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_4, __pyx_n_s_dtype, __pyx_v_dtype) < 0) __PYX_ERR(0, 146, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = PyNumber_Multiply(__pyx_t_3, __pyx_t_7); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = PyNumber_Multiply(__pyx_t_3, __pyx_t_7); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
-  __pyx_t_7 = PyNumber_Add(__pyx_t_1, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_7 = PyNumber_Add(__pyx_t_1, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(__pyx_t_7);
-  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 143, __pyx_L1_error)
+  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   __pyx_v_YtY = __pyx_t_9;
   __pyx_t_9.memview = NULL;
   __pyx_t_9.data = NULL;
 
-  /* "implicit/_als.pyx":150
+  /* "implicit/_als.pyx":153
  *     cdef floating * Ap
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -15537,7 +15884,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
                 __pyx_v_p = ((float *)1);
                 __pyx_v_r = ((float *)1);
 
-                /* "implicit/_als.pyx":153
+                /* "implicit/_als.pyx":156
  * 
  *         # allocate temp memory for each thread
  *         Ap = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -15546,7 +15893,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_Ap = ((float *)malloc(((sizeof(float)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":154
+                /* "implicit/_als.pyx":157
  *         # allocate temp memory for each thread
  *         Ap = <floating *> malloc(sizeof(floating) * N)
  *         p = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -15555,7 +15902,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_p = ((float *)malloc(((sizeof(float)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":155
+                /* "implicit/_als.pyx":158
  *         Ap = <floating *> malloc(sizeof(floating) * N)
  *         p = <floating *> malloc(sizeof(floating) * N)
  *         r = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -15564,7 +15911,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_r = ((float *)malloc(((sizeof(float)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":156
+                /* "implicit/_als.pyx":159
  *         p = <floating *> malloc(sizeof(floating) * N)
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:             # <<<<<<<<<<<<<<
@@ -15573,7 +15920,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 /*try:*/ {
 
-                  /* "implicit/_als.pyx":157
+                  /* "implicit/_als.pyx":160
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:
  *             for u in prange(users, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -15603,7 +15950,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_v_temp = ((float)__PYX_NAN());
                                   __pyx_v_x = ((float *)1);
 
-                                  /* "implicit/_als.pyx":159
+                                  /* "implicit/_als.pyx":162
  *             for u in prange(users, schedule='guided'):
  *                 # start from previous iteration
  *                 x = &X[u, 0]             # <<<<<<<<<<<<<<
@@ -15616,7 +15963,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
                                   if (__pyx_t_13 < 0) __pyx_t_13 += __pyx_v_X.shape[1];
                                   __pyx_v_x = (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_12 * __pyx_v_X.strides[0]) ) + __pyx_t_13 * __pyx_v_X.strides[1]) ))));
 
-                                  /* "implicit/_als.pyx":162
+                                  /* "implicit/_als.pyx":165
  * 
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:             # <<<<<<<<<<<<<<
@@ -15630,7 +15977,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_t_16 = (((*((int *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_14 * __pyx_v_indptr.strides[0]) ))) == (*((int *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_15 * __pyx_v_indptr.strides[0]) )))) != 0);
                                   if (__pyx_t_16) {
 
-                                    /* "implicit/_als.pyx":163
+                                    /* "implicit/_als.pyx":166
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:
  *                     memset(x, 0, sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -15639,7 +15986,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     memset(__pyx_v_x, 0, ((sizeof(float)) * __pyx_v_N));
 
-                                    /* "implicit/_als.pyx":164
+                                    /* "implicit/_als.pyx":167
  *                 if indptr[u] == indptr[u+1]:
  *                     memset(x, 0, sizeof(floating) * N)
  *                     continue             # <<<<<<<<<<<<<<
@@ -15648,7 +15995,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     goto __pyx_L15_continue;
 
-                                    /* "implicit/_als.pyx":162
+                                    /* "implicit/_als.pyx":165
  * 
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:             # <<<<<<<<<<<<<<
@@ -15657,7 +16004,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   }
 
-                                  /* "implicit/_als.pyx":167
+                                  /* "implicit/_als.pyx":170
  * 
  *                 # calculate residual r = (YtCuPu - (YtCuY.dot(Xu)
  *                 temp = -1.0             # <<<<<<<<<<<<<<
@@ -15666,7 +16013,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   __pyx_v_temp = -1.0;
 
-                                  /* "implicit/_als.pyx":168
+                                  /* "implicit/_als.pyx":171
  *                 # calculate residual r = (YtCuPu - (YtCuY.dot(Xu)
  *                 temp = -1.0
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, x, &one, &zero, r, &one)             # <<<<<<<<<<<<<<
@@ -15679,7 +16026,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
                                   if (__pyx_t_18 < 0) __pyx_t_18 += __pyx_v_YtY.shape[1];
                                   __pyx_fuse_0__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_17 * __pyx_v_YtY.strides[0]) ) + __pyx_t_18 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), __pyx_v_x, (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":170
+                                  /* "implicit/_als.pyx":173
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, x, &one, &zero, r, &one)
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -15694,32 +16041,82 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
                                   for (__pyx_t_22 = (*((int *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_21 * __pyx_v_indptr.strides[0]) ))); __pyx_t_22 < __pyx_t_20; __pyx_t_22+=1) {
                                     __pyx_v_index = __pyx_t_22;
 
-                                    /* "implicit/_als.pyx":171
+                                    /* "implicit/_als.pyx":174
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]             # <<<<<<<<<<<<<<
  *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+ * 
  */
                                     __pyx_t_23 = __pyx_v_index;
                                     if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_indices.shape[0];
                                     __pyx_v_i = (*((int *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_23 * __pyx_v_indices.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":172
+                                    /* "implicit/_als.pyx":175
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]
  *                     confidence = data[index]             # <<<<<<<<<<<<<<
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
- *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
+ * 
+ *                     if confidence > 0:
  */
                                     __pyx_t_24 = __pyx_v_index;
                                     if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_data.shape[0];
                                     __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_24 * __pyx_v_data.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":173
- *                     i = indices[index]
+                                    /* "implicit/_als.pyx":177
  *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)             # <<<<<<<<<<<<<<
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = confidence
+ *                     else:
+ */
+                                    __pyx_t_16 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_16) {
+
+                                      /* "implicit/_als.pyx":178
+ * 
+ *                     if confidence > 0:
+ *                         temp = confidence             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         temp = 0
+ */
+                                      __pyx_v_temp = __pyx_v_confidence;
+
+                                      /* "implicit/_als.pyx":177
+ *                     confidence = data[index]
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = confidence
+ *                     else:
+ */
+                                      goto __pyx_L22;
+                                    }
+
+                                    /* "implicit/_als.pyx":180
+ *                         temp = confidence
+ *                     else:
+ *                         temp = 0             # <<<<<<<<<<<<<<
+ *                         confidence = -1 * confidence
+ * 
+ */
+                                    /*else*/ {
+                                      __pyx_v_temp = 0.0;
+
+                                      /* "implicit/_als.pyx":181
+ *                     else:
+ *                         temp = 0
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+ */
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L22:;
+
+                                    /* "implicit/_als.pyx":183
+ *                         confidence = -1 * confidence
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)             # <<<<<<<<<<<<<<
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  */
@@ -15727,11 +16124,11 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_t_26 = 0;
                                     if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_Y.shape[0];
                                     if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_Y.shape[1];
-                                    __pyx_v_temp = (__pyx_v_confidence - ((__pyx_v_confidence - 1.0) * __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_25 * __pyx_v_Y.strides[0]) ) + __pyx_t_26 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one))));
+                                    __pyx_v_temp = (__pyx_v_temp - ((__pyx_v_confidence - 1.0) * __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_25 * __pyx_v_Y.strides[0]) ) + __pyx_t_26 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one))));
 
-                                    /* "implicit/_als.pyx":174
- *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+                                    /* "implicit/_als.pyx":184
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)             # <<<<<<<<<<<<<<
  * 
  *                 memcpy(p, r, sizeof(floating) * N)
@@ -15743,7 +16140,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
                                   }
 
-                                  /* "implicit/_als.pyx":176
+                                  /* "implicit/_als.pyx":186
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  *                 memcpy(p, r, sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -15752,7 +16149,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   memcpy(__pyx_v_p, __pyx_v_r, ((sizeof(float)) * __pyx_v_N));
 
-                                  /* "implicit/_als.pyx":177
+                                  /* "implicit/_als.pyx":187
  * 
  *                 memcpy(p, r, sizeof(floating) * N)
  *                 rsold = dot(&N, r, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -15761,7 +16158,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   __pyx_v_rsold = __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":179
+                                  /* "implicit/_als.pyx":189
  *                 rsold = dot(&N, r, &one, r, &one)
  * 
  *                 if rsold < 1e-20:             # <<<<<<<<<<<<<<
@@ -15771,7 +16168,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_t_16 = ((__pyx_v_rsold < 1e-20) != 0);
                                   if (__pyx_t_16) {
 
-                                    /* "implicit/_als.pyx":180
+                                    /* "implicit/_als.pyx":190
  * 
  *                 if rsold < 1e-20:
  *                     continue             # <<<<<<<<<<<<<<
@@ -15780,7 +16177,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     goto __pyx_L15_continue;
 
-                                    /* "implicit/_als.pyx":179
+                                    /* "implicit/_als.pyx":189
  *                 rsold = dot(&N, r, &one, r, &one)
  * 
  *                 if rsold < 1e-20:             # <<<<<<<<<<<<<<
@@ -15789,7 +16186,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   }
 
-                                  /* "implicit/_als.pyx":182
+                                  /* "implicit/_als.pyx":192
  *                     continue
  * 
  *                 for it in range(cg_steps):             # <<<<<<<<<<<<<<
@@ -15800,7 +16197,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
                                   for (__pyx_t_22 = 0; __pyx_t_22 < __pyx_t_20; __pyx_t_22+=1) {
                                     __pyx_v_it = __pyx_t_22;
 
-                                    /* "implicit/_als.pyx":184
+                                    /* "implicit/_als.pyx":194
  *                 for it in range(cg_steps):
  *                     # calculate Ap = YtCuYp - without actually calculating YtCuY
  *                     temp = 1.0             # <<<<<<<<<<<<<<
@@ -15809,7 +16206,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = 1.0;
 
-                                    /* "implicit/_als.pyx":185
+                                    /* "implicit/_als.pyx":195
  *                     # calculate Ap = YtCuYp - without actually calculating YtCuY
  *                     temp = 1.0
  *                     symv("U", &N, &temp, &YtY[0, 0], &N, p, &one, &zero, Ap, &one)             # <<<<<<<<<<<<<<
@@ -15822,7 +16219,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
                                     if (__pyx_t_30 < 0) __pyx_t_30 += __pyx_v_YtY.shape[1];
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_29 * __pyx_v_YtY.strides[0]) ) + __pyx_t_30 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), __pyx_v_p, (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_Ap, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":187
+                                    /* "implicit/_als.pyx":197
  *                     symv("U", &N, &temp, &YtY[0, 0], &N, p, &one, &zero, Ap, &one)
  * 
  *                     for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -15837,31 +16234,59 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
                                     for (__pyx_t_34 = (*((int *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_33 * __pyx_v_indptr.strides[0]) ))); __pyx_t_34 < __pyx_t_32; __pyx_t_34+=1) {
                                       __pyx_v_index = __pyx_t_34;
 
-                                      /* "implicit/_als.pyx":188
+                                      /* "implicit/_als.pyx":198
  * 
  *                     for index in range(indptr[u], indptr[u + 1]):
  *                         i = indices[index]             # <<<<<<<<<<<<<<
  *                         confidence = data[index]
- *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
+ * 
  */
                                       __pyx_t_35 = __pyx_v_index;
                                       if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_indices.shape[0];
                                       __pyx_v_i = (*((int *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_35 * __pyx_v_indices.strides[0]) )));
 
-                                      /* "implicit/_als.pyx":189
+                                      /* "implicit/_als.pyx":199
  *                     for index in range(indptr[u], indptr[u + 1]):
  *                         i = indices[index]
  *                         confidence = data[index]             # <<<<<<<<<<<<<<
- *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
- *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)
+ * 
+ *                         if confidence < 0:
  */
                                       __pyx_t_36 = __pyx_v_index;
                                       if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_data.shape[0];
                                       __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_36 * __pyx_v_data.strides[0]) )));
 
-                                      /* "implicit/_als.pyx":190
- *                         i = indices[index]
+                                      /* "implicit/_als.pyx":201
  *                         confidence = data[index]
+ * 
+ *                         if confidence < 0:             # <<<<<<<<<<<<<<
+ *                             confidence = -1 * confidence
+ * 
+ */
+                                      __pyx_t_16 = ((__pyx_v_confidence < 0.0) != 0);
+                                      if (__pyx_t_16) {
+
+                                        /* "implicit/_als.pyx":202
+ * 
+ *                         if confidence < 0:
+ *                             confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
+ */
+                                        __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+
+                                        /* "implicit/_als.pyx":201
+ *                         confidence = data[index]
+ * 
+ *                         if confidence < 0:             # <<<<<<<<<<<<<<
+ *                             confidence = -1 * confidence
+ * 
+ */
+                                      }
+
+                                      /* "implicit/_als.pyx":204
+ *                             confidence = -1 * confidence
+ * 
  *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)             # <<<<<<<<<<<<<<
  *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)
  * 
@@ -15872,8 +16297,8 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
                                       if (__pyx_t_38 < 0) __pyx_t_38 += __pyx_v_Y.shape[1];
                                       __pyx_v_temp = ((__pyx_v_confidence - 1.0) * __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_37 * __pyx_v_Y.strides[0]) ) + __pyx_t_38 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_p, (&__pyx_v_one)));
 
-                                      /* "implicit/_als.pyx":191
- *                         confidence = data[index]
+                                      /* "implicit/_als.pyx":205
+ * 
  *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
  *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)             # <<<<<<<<<<<<<<
  * 
@@ -15886,7 +16311,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
                                       __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_39 * __pyx_v_Y.strides[0]) ) + __pyx_t_40 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_Ap, (&__pyx_v_one));
                                     }
 
-                                    /* "implicit/_als.pyx":194
+                                    /* "implicit/_als.pyx":208
  * 
  *                     # alpha = rsold / p.dot(Ap);
  *                     alpha = rsold / dot(&N, p, &one, Ap, &one)             # <<<<<<<<<<<<<<
@@ -15895,7 +16320,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_alpha = (__pyx_v_rsold / __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_p, (&__pyx_v_one), __pyx_v_Ap, (&__pyx_v_one)));
 
-                                    /* "implicit/_als.pyx":197
+                                    /* "implicit/_als.pyx":211
  * 
  *                     # x += alpha * p
  *                     axpy(&N, &alpha, p, &one, x, &one)             # <<<<<<<<<<<<<<
@@ -15904,7 +16329,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_alpha), __pyx_v_p, (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":200
+                                    /* "implicit/_als.pyx":214
  * 
  *                     # r -= alpha * Ap
  *                     temp = alpha * -1             # <<<<<<<<<<<<<<
@@ -15913,7 +16338,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = (__pyx_v_alpha * -1.0);
 
-                                    /* "implicit/_als.pyx":201
+                                    /* "implicit/_als.pyx":215
  *                     # r -= alpha * Ap
  *                     temp = alpha * -1
  *                     axpy(&N, &temp, Ap, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -15922,7 +16347,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_Ap, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":203
+                                    /* "implicit/_als.pyx":217
  *                     axpy(&N, &temp, Ap, &one, r, &one)
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -15931,7 +16356,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_rsnew = __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":204
+                                    /* "implicit/_als.pyx":218
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:             # <<<<<<<<<<<<<<
@@ -15941,16 +16366,16 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_t_16 = ((__pyx_v_rsnew < 1e-20) != 0);
                                     if (__pyx_t_16) {
 
-                                      /* "implicit/_als.pyx":205
+                                      /* "implicit/_als.pyx":219
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:
  *                         break             # <<<<<<<<<<<<<<
  * 
  *                     # p = r + (rsnew/rsold) * p
  */
-                                      goto __pyx_L24_break;
+                                      goto __pyx_L25_break;
 
-                                      /* "implicit/_als.pyx":204
+                                      /* "implicit/_als.pyx":218
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:             # <<<<<<<<<<<<<<
@@ -15959,7 +16384,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     }
 
-                                    /* "implicit/_als.pyx":208
+                                    /* "implicit/_als.pyx":222
  * 
  *                     # p = r + (rsnew/rsold) * p
  *                     temp = rsnew / rsold             # <<<<<<<<<<<<<<
@@ -15968,7 +16393,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = (__pyx_v_rsnew / __pyx_v_rsold);
 
-                                    /* "implicit/_als.pyx":209
+                                    /* "implicit/_als.pyx":223
  *                     # p = r + (rsnew/rsold) * p
  *                     temp = rsnew / rsold
  *                     scal(&N, &temp, p, &one)             # <<<<<<<<<<<<<<
@@ -15977,7 +16402,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_scal((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_p, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":210
+                                    /* "implicit/_als.pyx":224
  *                     temp = rsnew / rsold
  *                     scal(&N, &temp, p, &one)
  *                     temp = 1.0             # <<<<<<<<<<<<<<
@@ -15986,7 +16411,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = 1.0;
 
-                                    /* "implicit/_als.pyx":211
+                                    /* "implicit/_als.pyx":225
  *                     scal(&N, &temp, p, &one)
  *                     temp = 1.0
  *                     axpy(&N, &temp, r, &one, p, &one)             # <<<<<<<<<<<<<<
@@ -15995,7 +16420,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_r, (&__pyx_v_one), __pyx_v_p, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":213
+                                    /* "implicit/_als.pyx":227
  *                     axpy(&N, &temp, r, &one, p, &one)
  * 
  *                     rsold = rsnew             # <<<<<<<<<<<<<<
@@ -16004,18 +16429,18 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_rsold = __pyx_v_rsnew;
                                   }
-                                  __pyx_L24_break:;
-                                  goto __pyx_L29;
+                                  __pyx_L25_break:;
+                                  goto __pyx_L31;
                                   __pyx_L15_continue:;
-                                  goto __pyx_L29;
-                                  __pyx_L29:;
+                                  goto __pyx_L31;
+                                  __pyx_L31:;
                               }
                           }
                       }
                   }
                 }
 
-                /* "implicit/_als.pyx":215
+                /* "implicit/_als.pyx":229
  *                     rsold = rsnew
  *         finally:
  *             free(p)             # <<<<<<<<<<<<<<
@@ -16026,7 +16451,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
                   /*normal exit:*/{
                     free(__pyx_v_p);
 
-                    /* "implicit/_als.pyx":216
+                    /* "implicit/_als.pyx":230
  *         finally:
  *             free(p)
  *             free(r)             # <<<<<<<<<<<<<<
@@ -16035,7 +16460,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
  */
                     free(__pyx_v_r);
 
-                    /* "implicit/_als.pyx":217
+                    /* "implicit/_als.pyx":231
  *             free(p)
  *             free(r)
  *             free(Ap)             # <<<<<<<<<<<<<<
@@ -16057,7 +16482,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
         #endif
       }
 
-      /* "implicit/_als.pyx":150
+      /* "implicit/_als.pyx":153
  *     cdef floating * Ap
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -16076,7 +16501,7 @@ static PyObject *__pyx_pf_8implicit_4_als_30_least_squares_cg(CYTHON_UNUSED PyOb
       }
   }
 
-  /* "implicit/_als.pyx":134
+  /* "implicit/_als.pyx":137
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _least_squares_cg(integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
@@ -16119,11 +16544,11 @@ static PyObject *__pyx_pf_8implicit_4_als_96__defaults__(CYTHON_UNUSED PyObject 
   PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("__defaults__", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults21, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults21, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults21, __pyx_self)->__pyx_arg_cg_steps); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults21, __pyx_self)->__pyx_arg_cg_steps); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
@@ -16131,7 +16556,7 @@ static PyObject *__pyx_pf_8implicit_4_als_96__defaults__(CYTHON_UNUSED PyObject 
   PyTuple_SET_ITEM(__pyx_t_3, 1, __pyx_t_2);
   __pyx_t_1 = 0;
   __pyx_t_2 = 0;
-  __pyx_t_2 = PyTuple_New(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_3);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_3);
@@ -16207,31 +16632,31 @@ static PyObject *__pyx_fuse_1_1__pyx_pw_8implicit_4_als_33_least_squares_cg(PyOb
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indices)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 1); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 1); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_data)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 2); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 2); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_X)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 3); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 3); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
         if (likely((values[4] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_Y)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 4); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 4); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  5:
         if (likely((values[5] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_regularization)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 5); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 5); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  6:
@@ -16247,7 +16672,7 @@ static PyObject *__pyx_fuse_1_1__pyx_pw_8implicit_4_als_33_least_squares_cg(PyOb
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_least_squares_cg") < 0)) __PYX_ERR(0, 134, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_least_squares_cg") < 0)) __PYX_ERR(0, 137, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -16265,26 +16690,26 @@ static PyObject *__pyx_fuse_1_1__pyx_pw_8implicit_4_als_33_least_squares_cg(PyOb
         default: goto __pyx_L5_argtuple_error;
       }
     }
-    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_int(values[0]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_int(values[1]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[2]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[3]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 135, __pyx_L3_error)
-    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[4]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 135, __pyx_L3_error)
-    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[5]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 135, __pyx_L3_error)
+    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_int(values[0]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_int(values[1]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[2]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[3]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 138, __pyx_L3_error)
+    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[4]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 138, __pyx_L3_error)
+    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[5]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 138, __pyx_L3_error)
     if (values[6]) {
-      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[6]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 136, __pyx_L3_error)
+      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[6]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 139, __pyx_L3_error)
     } else {
       __pyx_v_num_threads = __pyx_dynamic_args->__pyx_arg_num_threads;
     }
     if (values[7]) {
-      __pyx_v_cg_steps = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_cg_steps == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 136, __pyx_L3_error)
+      __pyx_v_cg_steps = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_cg_steps == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 139, __pyx_L3_error)
     } else {
       __pyx_v_cg_steps = __pyx_dynamic_args->__pyx_arg_cg_steps;
     }
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 134, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 137, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("implicit._als._least_squares_cg", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -16361,7 +16786,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
   Py_ssize_t __pyx_t_40;
   __Pyx_RefNannySetupContext("__pyx_fuse_1_1_least_squares_cg", 0);
 
-  /* "implicit/_als.pyx":137
+  /* "implicit/_als.pyx":140
  *                       floating[:, :] X, floating[:, :] Y, float regularization,
  *                       int num_threads=0, int cg_steps=3):
  *     dtype = np.float64 if floating is double else np.float32             # <<<<<<<<<<<<<<
@@ -16369,17 +16794,17 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it
  */
   if ((1 != 0)) {
-    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_1 = __pyx_t_3;
     __pyx_t_3 = 0;
   } else {
-    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_t_1 = __pyx_t_2;
@@ -16388,7 +16813,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
   __pyx_v_dtype = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "implicit/_als.pyx":139
+  /* "implicit/_als.pyx":142
  *     dtype = np.float64 if floating is double else np.float32
  * 
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it             # <<<<<<<<<<<<<<
@@ -16399,7 +16824,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
   __pyx_v_N = (__pyx_v_X.shape[1]);
   __pyx_v_one = 1;
 
-  /* "implicit/_als.pyx":141
+  /* "implicit/_als.pyx":144
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it
  *     cdef floating confidence, temp, alpha, rsnew, rsold
  *     cdef floating zero = 0.             # <<<<<<<<<<<<<<
@@ -16408,24 +16833,24 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
   __pyx_v_zero = 0.;
 
-  /* "implicit/_als.pyx":143
+  /* "implicit/_als.pyx":146
  *     cdef floating zero = 0.
  * 
  *     cdef floating[:, :] YtY = np.dot(np.transpose(Y), Y) + regularization * np.eye(N, dtype=dtype)             # <<<<<<<<<<<<<<
  * 
  *     cdef floating * x
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_6 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -16438,14 +16863,14 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
     }
   }
   if (!__pyx_t_6) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_GOTREF(__pyx_t_2);
   } else {
     #if CYTHON_FAST_PYCALL
     if (PyFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -16454,26 +16879,26 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
     #if CYTHON_FAST_PYCCALL
     if (__Pyx_PyFastCFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     } else
     #endif
     {
-      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_6); __pyx_t_6 = NULL;
       __Pyx_GIVEREF(__pyx_t_4);
       PyTuple_SET_ITEM(__pyx_t_7, 0+1, __pyx_t_4);
       __pyx_t_4 = 0;
-      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     }
   }
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_7 = NULL;
   __pyx_t_8 = 0;
@@ -16490,7 +16915,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -16500,7 +16925,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -16508,7 +16933,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
   } else
   #endif
   {
-    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     if (__pyx_t_7) {
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -16519,49 +16944,49 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
     PyTuple_SET_ITEM(__pyx_t_4, 1+__pyx_t_8, __pyx_t_5);
     __pyx_t_2 = 0;
     __pyx_t_5 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_regularization); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_regularization); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_eye); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_eye); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_N); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_N); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_4);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_4);
   __pyx_t_4 = 0;
-  __pyx_t_4 = PyDict_New(); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = PyDict_New(); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  if (PyDict_SetItem(__pyx_t_4, __pyx_n_s_dtype, __pyx_v_dtype) < 0) __PYX_ERR(0, 143, __pyx_L1_error)
-  __pyx_t_7 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_4, __pyx_n_s_dtype, __pyx_v_dtype) < 0) __PYX_ERR(0, 146, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = PyNumber_Multiply(__pyx_t_3, __pyx_t_7); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = PyNumber_Multiply(__pyx_t_3, __pyx_t_7); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
-  __pyx_t_7 = PyNumber_Add(__pyx_t_1, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_7 = PyNumber_Add(__pyx_t_1, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(__pyx_t_7);
-  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 143, __pyx_L1_error)
+  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   __pyx_v_YtY = __pyx_t_9;
   __pyx_t_9.memview = NULL;
   __pyx_t_9.data = NULL;
 
-  /* "implicit/_als.pyx":150
+  /* "implicit/_als.pyx":153
  *     cdef floating * Ap
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -16591,7 +17016,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
                 __pyx_v_p = ((double *)1);
                 __pyx_v_r = ((double *)1);
 
-                /* "implicit/_als.pyx":153
+                /* "implicit/_als.pyx":156
  * 
  *         # allocate temp memory for each thread
  *         Ap = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -16600,7 +17025,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_Ap = ((double *)malloc(((sizeof(double)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":154
+                /* "implicit/_als.pyx":157
  *         # allocate temp memory for each thread
  *         Ap = <floating *> malloc(sizeof(floating) * N)
  *         p = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -16609,7 +17034,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_p = ((double *)malloc(((sizeof(double)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":155
+                /* "implicit/_als.pyx":158
  *         Ap = <floating *> malloc(sizeof(floating) * N)
  *         p = <floating *> malloc(sizeof(floating) * N)
  *         r = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -16618,7 +17043,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_r = ((double *)malloc(((sizeof(double)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":156
+                /* "implicit/_als.pyx":159
  *         p = <floating *> malloc(sizeof(floating) * N)
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:             # <<<<<<<<<<<<<<
@@ -16627,7 +17052,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 /*try:*/ {
 
-                  /* "implicit/_als.pyx":157
+                  /* "implicit/_als.pyx":160
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:
  *             for u in prange(users, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -16657,7 +17082,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_v_temp = ((double)__PYX_NAN());
                                   __pyx_v_x = ((double *)1);
 
-                                  /* "implicit/_als.pyx":159
+                                  /* "implicit/_als.pyx":162
  *             for u in prange(users, schedule='guided'):
  *                 # start from previous iteration
  *                 x = &X[u, 0]             # <<<<<<<<<<<<<<
@@ -16670,7 +17095,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
                                   if (__pyx_t_13 < 0) __pyx_t_13 += __pyx_v_X.shape[1];
                                   __pyx_v_x = (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_12 * __pyx_v_X.strides[0]) ) + __pyx_t_13 * __pyx_v_X.strides[1]) ))));
 
-                                  /* "implicit/_als.pyx":162
+                                  /* "implicit/_als.pyx":165
  * 
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:             # <<<<<<<<<<<<<<
@@ -16684,7 +17109,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_t_16 = (((*((int *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_14 * __pyx_v_indptr.strides[0]) ))) == (*((int *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_15 * __pyx_v_indptr.strides[0]) )))) != 0);
                                   if (__pyx_t_16) {
 
-                                    /* "implicit/_als.pyx":163
+                                    /* "implicit/_als.pyx":166
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:
  *                     memset(x, 0, sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -16693,7 +17118,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     memset(__pyx_v_x, 0, ((sizeof(double)) * __pyx_v_N));
 
-                                    /* "implicit/_als.pyx":164
+                                    /* "implicit/_als.pyx":167
  *                 if indptr[u] == indptr[u+1]:
  *                     memset(x, 0, sizeof(floating) * N)
  *                     continue             # <<<<<<<<<<<<<<
@@ -16702,7 +17127,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     goto __pyx_L15_continue;
 
-                                    /* "implicit/_als.pyx":162
+                                    /* "implicit/_als.pyx":165
  * 
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:             # <<<<<<<<<<<<<<
@@ -16711,7 +17136,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   }
 
-                                  /* "implicit/_als.pyx":167
+                                  /* "implicit/_als.pyx":170
  * 
  *                 # calculate residual r = (YtCuPu - (YtCuY.dot(Xu)
  *                 temp = -1.0             # <<<<<<<<<<<<<<
@@ -16720,7 +17145,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   __pyx_v_temp = -1.0;
 
-                                  /* "implicit/_als.pyx":168
+                                  /* "implicit/_als.pyx":171
  *                 # calculate residual r = (YtCuPu - (YtCuY.dot(Xu)
  *                 temp = -1.0
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, x, &one, &zero, r, &one)             # <<<<<<<<<<<<<<
@@ -16733,7 +17158,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
                                   if (__pyx_t_18 < 0) __pyx_t_18 += __pyx_v_YtY.shape[1];
                                   __pyx_fuse_1__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_17 * __pyx_v_YtY.strides[0]) ) + __pyx_t_18 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), __pyx_v_x, (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":170
+                                  /* "implicit/_als.pyx":173
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, x, &one, &zero, r, &one)
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -16748,32 +17173,82 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
                                   for (__pyx_t_22 = (*((int *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_21 * __pyx_v_indptr.strides[0]) ))); __pyx_t_22 < __pyx_t_20; __pyx_t_22+=1) {
                                     __pyx_v_index = __pyx_t_22;
 
-                                    /* "implicit/_als.pyx":171
+                                    /* "implicit/_als.pyx":174
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]             # <<<<<<<<<<<<<<
  *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+ * 
  */
                                     __pyx_t_23 = __pyx_v_index;
                                     if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_indices.shape[0];
                                     __pyx_v_i = (*((int *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_23 * __pyx_v_indices.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":172
+                                    /* "implicit/_als.pyx":175
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]
  *                     confidence = data[index]             # <<<<<<<<<<<<<<
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
- *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
+ * 
+ *                     if confidence > 0:
  */
                                     __pyx_t_24 = __pyx_v_index;
                                     if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_data.shape[0];
                                     __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_24 * __pyx_v_data.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":173
- *                     i = indices[index]
+                                    /* "implicit/_als.pyx":177
  *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)             # <<<<<<<<<<<<<<
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = confidence
+ *                     else:
+ */
+                                    __pyx_t_16 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_16) {
+
+                                      /* "implicit/_als.pyx":178
+ * 
+ *                     if confidence > 0:
+ *                         temp = confidence             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         temp = 0
+ */
+                                      __pyx_v_temp = __pyx_v_confidence;
+
+                                      /* "implicit/_als.pyx":177
+ *                     confidence = data[index]
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = confidence
+ *                     else:
+ */
+                                      goto __pyx_L22;
+                                    }
+
+                                    /* "implicit/_als.pyx":180
+ *                         temp = confidence
+ *                     else:
+ *                         temp = 0             # <<<<<<<<<<<<<<
+ *                         confidence = -1 * confidence
+ * 
+ */
+                                    /*else*/ {
+                                      __pyx_v_temp = 0.0;
+
+                                      /* "implicit/_als.pyx":181
+ *                     else:
+ *                         temp = 0
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+ */
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L22:;
+
+                                    /* "implicit/_als.pyx":183
+ *                         confidence = -1 * confidence
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)             # <<<<<<<<<<<<<<
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  */
@@ -16781,11 +17256,11 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_t_26 = 0;
                                     if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_Y.shape[0];
                                     if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_Y.shape[1];
-                                    __pyx_v_temp = (__pyx_v_confidence - ((__pyx_v_confidence - 1.0) * __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_25 * __pyx_v_Y.strides[0]) ) + __pyx_t_26 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one))));
+                                    __pyx_v_temp = (__pyx_v_temp - ((__pyx_v_confidence - 1.0) * __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_25 * __pyx_v_Y.strides[0]) ) + __pyx_t_26 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one))));
 
-                                    /* "implicit/_als.pyx":174
- *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+                                    /* "implicit/_als.pyx":184
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)             # <<<<<<<<<<<<<<
  * 
  *                 memcpy(p, r, sizeof(floating) * N)
@@ -16797,7 +17272,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
                                   }
 
-                                  /* "implicit/_als.pyx":176
+                                  /* "implicit/_als.pyx":186
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  *                 memcpy(p, r, sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -16806,7 +17281,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   memcpy(__pyx_v_p, __pyx_v_r, ((sizeof(double)) * __pyx_v_N));
 
-                                  /* "implicit/_als.pyx":177
+                                  /* "implicit/_als.pyx":187
  * 
  *                 memcpy(p, r, sizeof(floating) * N)
  *                 rsold = dot(&N, r, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -16815,7 +17290,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   __pyx_v_rsold = __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":179
+                                  /* "implicit/_als.pyx":189
  *                 rsold = dot(&N, r, &one, r, &one)
  * 
  *                 if rsold < 1e-20:             # <<<<<<<<<<<<<<
@@ -16825,7 +17300,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_t_16 = ((__pyx_v_rsold < 1e-20) != 0);
                                   if (__pyx_t_16) {
 
-                                    /* "implicit/_als.pyx":180
+                                    /* "implicit/_als.pyx":190
  * 
  *                 if rsold < 1e-20:
  *                     continue             # <<<<<<<<<<<<<<
@@ -16834,7 +17309,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     goto __pyx_L15_continue;
 
-                                    /* "implicit/_als.pyx":179
+                                    /* "implicit/_als.pyx":189
  *                 rsold = dot(&N, r, &one, r, &one)
  * 
  *                 if rsold < 1e-20:             # <<<<<<<<<<<<<<
@@ -16843,7 +17318,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   }
 
-                                  /* "implicit/_als.pyx":182
+                                  /* "implicit/_als.pyx":192
  *                     continue
  * 
  *                 for it in range(cg_steps):             # <<<<<<<<<<<<<<
@@ -16854,7 +17329,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
                                   for (__pyx_t_22 = 0; __pyx_t_22 < __pyx_t_20; __pyx_t_22+=1) {
                                     __pyx_v_it = __pyx_t_22;
 
-                                    /* "implicit/_als.pyx":184
+                                    /* "implicit/_als.pyx":194
  *                 for it in range(cg_steps):
  *                     # calculate Ap = YtCuYp - without actually calculating YtCuY
  *                     temp = 1.0             # <<<<<<<<<<<<<<
@@ -16863,7 +17338,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = 1.0;
 
-                                    /* "implicit/_als.pyx":185
+                                    /* "implicit/_als.pyx":195
  *                     # calculate Ap = YtCuYp - without actually calculating YtCuY
  *                     temp = 1.0
  *                     symv("U", &N, &temp, &YtY[0, 0], &N, p, &one, &zero, Ap, &one)             # <<<<<<<<<<<<<<
@@ -16876,7 +17351,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
                                     if (__pyx_t_30 < 0) __pyx_t_30 += __pyx_v_YtY.shape[1];
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_29 * __pyx_v_YtY.strides[0]) ) + __pyx_t_30 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), __pyx_v_p, (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_Ap, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":187
+                                    /* "implicit/_als.pyx":197
  *                     symv("U", &N, &temp, &YtY[0, 0], &N, p, &one, &zero, Ap, &one)
  * 
  *                     for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -16891,31 +17366,59 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
                                     for (__pyx_t_34 = (*((int *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_33 * __pyx_v_indptr.strides[0]) ))); __pyx_t_34 < __pyx_t_32; __pyx_t_34+=1) {
                                       __pyx_v_index = __pyx_t_34;
 
-                                      /* "implicit/_als.pyx":188
+                                      /* "implicit/_als.pyx":198
  * 
  *                     for index in range(indptr[u], indptr[u + 1]):
  *                         i = indices[index]             # <<<<<<<<<<<<<<
  *                         confidence = data[index]
- *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
+ * 
  */
                                       __pyx_t_35 = __pyx_v_index;
                                       if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_indices.shape[0];
                                       __pyx_v_i = (*((int *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_35 * __pyx_v_indices.strides[0]) )));
 
-                                      /* "implicit/_als.pyx":189
+                                      /* "implicit/_als.pyx":199
  *                     for index in range(indptr[u], indptr[u + 1]):
  *                         i = indices[index]
  *                         confidence = data[index]             # <<<<<<<<<<<<<<
- *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
- *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)
+ * 
+ *                         if confidence < 0:
  */
                                       __pyx_t_36 = __pyx_v_index;
                                       if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_data.shape[0];
                                       __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_36 * __pyx_v_data.strides[0]) )));
 
-                                      /* "implicit/_als.pyx":190
- *                         i = indices[index]
+                                      /* "implicit/_als.pyx":201
  *                         confidence = data[index]
+ * 
+ *                         if confidence < 0:             # <<<<<<<<<<<<<<
+ *                             confidence = -1 * confidence
+ * 
+ */
+                                      __pyx_t_16 = ((__pyx_v_confidence < 0.0) != 0);
+                                      if (__pyx_t_16) {
+
+                                        /* "implicit/_als.pyx":202
+ * 
+ *                         if confidence < 0:
+ *                             confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
+ */
+                                        __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+
+                                        /* "implicit/_als.pyx":201
+ *                         confidence = data[index]
+ * 
+ *                         if confidence < 0:             # <<<<<<<<<<<<<<
+ *                             confidence = -1 * confidence
+ * 
+ */
+                                      }
+
+                                      /* "implicit/_als.pyx":204
+ *                             confidence = -1 * confidence
+ * 
  *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)             # <<<<<<<<<<<<<<
  *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)
  * 
@@ -16926,8 +17429,8 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
                                       if (__pyx_t_38 < 0) __pyx_t_38 += __pyx_v_Y.shape[1];
                                       __pyx_v_temp = ((__pyx_v_confidence - 1.0) * __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_37 * __pyx_v_Y.strides[0]) ) + __pyx_t_38 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_p, (&__pyx_v_one)));
 
-                                      /* "implicit/_als.pyx":191
- *                         confidence = data[index]
+                                      /* "implicit/_als.pyx":205
+ * 
  *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
  *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)             # <<<<<<<<<<<<<<
  * 
@@ -16940,7 +17443,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
                                       __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_39 * __pyx_v_Y.strides[0]) ) + __pyx_t_40 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_Ap, (&__pyx_v_one));
                                     }
 
-                                    /* "implicit/_als.pyx":194
+                                    /* "implicit/_als.pyx":208
  * 
  *                     # alpha = rsold / p.dot(Ap);
  *                     alpha = rsold / dot(&N, p, &one, Ap, &one)             # <<<<<<<<<<<<<<
@@ -16949,7 +17452,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_alpha = (__pyx_v_rsold / __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_p, (&__pyx_v_one), __pyx_v_Ap, (&__pyx_v_one)));
 
-                                    /* "implicit/_als.pyx":197
+                                    /* "implicit/_als.pyx":211
  * 
  *                     # x += alpha * p
  *                     axpy(&N, &alpha, p, &one, x, &one)             # <<<<<<<<<<<<<<
@@ -16958,7 +17461,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_alpha), __pyx_v_p, (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":200
+                                    /* "implicit/_als.pyx":214
  * 
  *                     # r -= alpha * Ap
  *                     temp = alpha * -1             # <<<<<<<<<<<<<<
@@ -16967,7 +17470,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = (__pyx_v_alpha * -1.0);
 
-                                    /* "implicit/_als.pyx":201
+                                    /* "implicit/_als.pyx":215
  *                     # r -= alpha * Ap
  *                     temp = alpha * -1
  *                     axpy(&N, &temp, Ap, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -16976,7 +17479,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_Ap, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":203
+                                    /* "implicit/_als.pyx":217
  *                     axpy(&N, &temp, Ap, &one, r, &one)
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -16985,7 +17488,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_rsnew = __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":204
+                                    /* "implicit/_als.pyx":218
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:             # <<<<<<<<<<<<<<
@@ -16995,16 +17498,16 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_t_16 = ((__pyx_v_rsnew < 1e-20) != 0);
                                     if (__pyx_t_16) {
 
-                                      /* "implicit/_als.pyx":205
+                                      /* "implicit/_als.pyx":219
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:
  *                         break             # <<<<<<<<<<<<<<
  * 
  *                     # p = r + (rsnew/rsold) * p
  */
-                                      goto __pyx_L24_break;
+                                      goto __pyx_L25_break;
 
-                                      /* "implicit/_als.pyx":204
+                                      /* "implicit/_als.pyx":218
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:             # <<<<<<<<<<<<<<
@@ -17013,7 +17516,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     }
 
-                                    /* "implicit/_als.pyx":208
+                                    /* "implicit/_als.pyx":222
  * 
  *                     # p = r + (rsnew/rsold) * p
  *                     temp = rsnew / rsold             # <<<<<<<<<<<<<<
@@ -17022,7 +17525,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = (__pyx_v_rsnew / __pyx_v_rsold);
 
-                                    /* "implicit/_als.pyx":209
+                                    /* "implicit/_als.pyx":223
  *                     # p = r + (rsnew/rsold) * p
  *                     temp = rsnew / rsold
  *                     scal(&N, &temp, p, &one)             # <<<<<<<<<<<<<<
@@ -17031,7 +17534,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_scal((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_p, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":210
+                                    /* "implicit/_als.pyx":224
  *                     temp = rsnew / rsold
  *                     scal(&N, &temp, p, &one)
  *                     temp = 1.0             # <<<<<<<<<<<<<<
@@ -17040,7 +17543,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = 1.0;
 
-                                    /* "implicit/_als.pyx":211
+                                    /* "implicit/_als.pyx":225
  *                     scal(&N, &temp, p, &one)
  *                     temp = 1.0
  *                     axpy(&N, &temp, r, &one, p, &one)             # <<<<<<<<<<<<<<
@@ -17049,7 +17552,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_r, (&__pyx_v_one), __pyx_v_p, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":213
+                                    /* "implicit/_als.pyx":227
  *                     axpy(&N, &temp, r, &one, p, &one)
  * 
  *                     rsold = rsnew             # <<<<<<<<<<<<<<
@@ -17058,18 +17561,18 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_rsold = __pyx_v_rsnew;
                                   }
-                                  __pyx_L24_break:;
-                                  goto __pyx_L29;
+                                  __pyx_L25_break:;
+                                  goto __pyx_L31;
                                   __pyx_L15_continue:;
-                                  goto __pyx_L29;
-                                  __pyx_L29:;
+                                  goto __pyx_L31;
+                                  __pyx_L31:;
                               }
                           }
                       }
                   }
                 }
 
-                /* "implicit/_als.pyx":215
+                /* "implicit/_als.pyx":229
  *                     rsold = rsnew
  *         finally:
  *             free(p)             # <<<<<<<<<<<<<<
@@ -17080,7 +17583,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
                   /*normal exit:*/{
                     free(__pyx_v_p);
 
-                    /* "implicit/_als.pyx":216
+                    /* "implicit/_als.pyx":230
  *         finally:
  *             free(p)
  *             free(r)             # <<<<<<<<<<<<<<
@@ -17089,7 +17592,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
  */
                     free(__pyx_v_r);
 
-                    /* "implicit/_als.pyx":217
+                    /* "implicit/_als.pyx":231
  *             free(p)
  *             free(r)
  *             free(Ap)             # <<<<<<<<<<<<<<
@@ -17111,7 +17614,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
         #endif
       }
 
-      /* "implicit/_als.pyx":150
+      /* "implicit/_als.pyx":153
  *     cdef floating * Ap
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -17130,7 +17633,7 @@ static PyObject *__pyx_pf_8implicit_4_als_32_least_squares_cg(CYTHON_UNUSED PyOb
       }
   }
 
-  /* "implicit/_als.pyx":134
+  /* "implicit/_als.pyx":137
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _least_squares_cg(integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
@@ -17173,11 +17676,11 @@ static PyObject *__pyx_pf_8implicit_4_als_98__defaults__(CYTHON_UNUSED PyObject 
   PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("__defaults__", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults22, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults22, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults22, __pyx_self)->__pyx_arg_cg_steps); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults22, __pyx_self)->__pyx_arg_cg_steps); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
@@ -17185,7 +17688,7 @@ static PyObject *__pyx_pf_8implicit_4_als_98__defaults__(CYTHON_UNUSED PyObject 
   PyTuple_SET_ITEM(__pyx_t_3, 1, __pyx_t_2);
   __pyx_t_1 = 0;
   __pyx_t_2 = 0;
-  __pyx_t_2 = PyTuple_New(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_3);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_3);
@@ -17261,31 +17764,31 @@ static PyObject *__pyx_fuse_2_0__pyx_pw_8implicit_4_als_35_least_squares_cg(PyOb
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indices)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 1); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 1); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_data)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 2); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 2); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_X)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 3); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 3); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
         if (likely((values[4] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_Y)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 4); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 4); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  5:
         if (likely((values[5] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_regularization)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 5); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 5); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  6:
@@ -17301,7 +17804,7 @@ static PyObject *__pyx_fuse_2_0__pyx_pw_8implicit_4_als_35_least_squares_cg(PyOb
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_least_squares_cg") < 0)) __PYX_ERR(0, 134, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_least_squares_cg") < 0)) __PYX_ERR(0, 137, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -17319,26 +17822,26 @@ static PyObject *__pyx_fuse_2_0__pyx_pw_8implicit_4_als_35_least_squares_cg(PyOb
         default: goto __pyx_L5_argtuple_error;
       }
     }
-    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_long(values[0]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_long(values[1]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[2]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[3]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 135, __pyx_L3_error)
-    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[4]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 135, __pyx_L3_error)
-    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[5]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 135, __pyx_L3_error)
+    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_long(values[0]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_long(values[1]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[2]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[3]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 138, __pyx_L3_error)
+    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[4]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 138, __pyx_L3_error)
+    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[5]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 138, __pyx_L3_error)
     if (values[6]) {
-      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[6]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 136, __pyx_L3_error)
+      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[6]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 139, __pyx_L3_error)
     } else {
       __pyx_v_num_threads = __pyx_dynamic_args->__pyx_arg_num_threads;
     }
     if (values[7]) {
-      __pyx_v_cg_steps = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_cg_steps == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 136, __pyx_L3_error)
+      __pyx_v_cg_steps = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_cg_steps == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 139, __pyx_L3_error)
     } else {
       __pyx_v_cg_steps = __pyx_dynamic_args->__pyx_arg_cg_steps;
     }
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 134, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 137, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("implicit._als._least_squares_cg", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -17415,7 +17918,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
   Py_ssize_t __pyx_t_40;
   __Pyx_RefNannySetupContext("__pyx_fuse_2_0_least_squares_cg", 0);
 
-  /* "implicit/_als.pyx":137
+  /* "implicit/_als.pyx":140
  *                       floating[:, :] X, floating[:, :] Y, float regularization,
  *                       int num_threads=0, int cg_steps=3):
  *     dtype = np.float64 if floating is double else np.float32             # <<<<<<<<<<<<<<
@@ -17423,17 +17926,17 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it
  */
   if ((0 != 0)) {
-    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_1 = __pyx_t_3;
     __pyx_t_3 = 0;
   } else {
-    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_t_1 = __pyx_t_2;
@@ -17442,7 +17945,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
   __pyx_v_dtype = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "implicit/_als.pyx":139
+  /* "implicit/_als.pyx":142
  *     dtype = np.float64 if floating is double else np.float32
  * 
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it             # <<<<<<<<<<<<<<
@@ -17453,7 +17956,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
   __pyx_v_N = (__pyx_v_X.shape[1]);
   __pyx_v_one = 1;
 
-  /* "implicit/_als.pyx":141
+  /* "implicit/_als.pyx":144
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it
  *     cdef floating confidence, temp, alpha, rsnew, rsold
  *     cdef floating zero = 0.             # <<<<<<<<<<<<<<
@@ -17462,24 +17965,24 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
   __pyx_v_zero = 0.;
 
-  /* "implicit/_als.pyx":143
+  /* "implicit/_als.pyx":146
  *     cdef floating zero = 0.
  * 
  *     cdef floating[:, :] YtY = np.dot(np.transpose(Y), Y) + regularization * np.eye(N, dtype=dtype)             # <<<<<<<<<<<<<<
  * 
  *     cdef floating * x
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_6 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -17492,14 +17995,14 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
     }
   }
   if (!__pyx_t_6) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_GOTREF(__pyx_t_2);
   } else {
     #if CYTHON_FAST_PYCALL
     if (PyFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -17508,26 +18011,26 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
     #if CYTHON_FAST_PYCCALL
     if (__Pyx_PyFastCFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     } else
     #endif
     {
-      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_6); __pyx_t_6 = NULL;
       __Pyx_GIVEREF(__pyx_t_4);
       PyTuple_SET_ITEM(__pyx_t_7, 0+1, __pyx_t_4);
       __pyx_t_4 = 0;
-      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     }
   }
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_7 = NULL;
   __pyx_t_8 = 0;
@@ -17544,7 +18047,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -17554,7 +18057,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -17562,7 +18065,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
   } else
   #endif
   {
-    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     if (__pyx_t_7) {
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -17573,49 +18076,49 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
     PyTuple_SET_ITEM(__pyx_t_4, 1+__pyx_t_8, __pyx_t_5);
     __pyx_t_2 = 0;
     __pyx_t_5 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_regularization); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_regularization); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_eye); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_eye); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_N); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_N); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_4);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_4);
   __pyx_t_4 = 0;
-  __pyx_t_4 = PyDict_New(); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = PyDict_New(); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  if (PyDict_SetItem(__pyx_t_4, __pyx_n_s_dtype, __pyx_v_dtype) < 0) __PYX_ERR(0, 143, __pyx_L1_error)
-  __pyx_t_7 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_4, __pyx_n_s_dtype, __pyx_v_dtype) < 0) __PYX_ERR(0, 146, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = PyNumber_Multiply(__pyx_t_3, __pyx_t_7); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = PyNumber_Multiply(__pyx_t_3, __pyx_t_7); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
-  __pyx_t_7 = PyNumber_Add(__pyx_t_1, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_7 = PyNumber_Add(__pyx_t_1, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(__pyx_t_7);
-  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 143, __pyx_L1_error)
+  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   __pyx_v_YtY = __pyx_t_9;
   __pyx_t_9.memview = NULL;
   __pyx_t_9.data = NULL;
 
-  /* "implicit/_als.pyx":150
+  /* "implicit/_als.pyx":153
  *     cdef floating * Ap
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -17645,7 +18148,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
                 __pyx_v_p = ((float *)1);
                 __pyx_v_r = ((float *)1);
 
-                /* "implicit/_als.pyx":153
+                /* "implicit/_als.pyx":156
  * 
  *         # allocate temp memory for each thread
  *         Ap = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -17654,7 +18157,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_Ap = ((float *)malloc(((sizeof(float)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":154
+                /* "implicit/_als.pyx":157
  *         # allocate temp memory for each thread
  *         Ap = <floating *> malloc(sizeof(floating) * N)
  *         p = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -17663,7 +18166,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_p = ((float *)malloc(((sizeof(float)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":155
+                /* "implicit/_als.pyx":158
  *         Ap = <floating *> malloc(sizeof(floating) * N)
  *         p = <floating *> malloc(sizeof(floating) * N)
  *         r = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -17672,7 +18175,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_r = ((float *)malloc(((sizeof(float)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":156
+                /* "implicit/_als.pyx":159
  *         p = <floating *> malloc(sizeof(floating) * N)
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:             # <<<<<<<<<<<<<<
@@ -17681,7 +18184,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 /*try:*/ {
 
-                  /* "implicit/_als.pyx":157
+                  /* "implicit/_als.pyx":160
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:
  *             for u in prange(users, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -17711,7 +18214,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_v_temp = ((float)__PYX_NAN());
                                   __pyx_v_x = ((float *)1);
 
-                                  /* "implicit/_als.pyx":159
+                                  /* "implicit/_als.pyx":162
  *             for u in prange(users, schedule='guided'):
  *                 # start from previous iteration
  *                 x = &X[u, 0]             # <<<<<<<<<<<<<<
@@ -17724,7 +18227,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
                                   if (__pyx_t_13 < 0) __pyx_t_13 += __pyx_v_X.shape[1];
                                   __pyx_v_x = (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_12 * __pyx_v_X.strides[0]) ) + __pyx_t_13 * __pyx_v_X.strides[1]) ))));
 
-                                  /* "implicit/_als.pyx":162
+                                  /* "implicit/_als.pyx":165
  * 
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:             # <<<<<<<<<<<<<<
@@ -17738,7 +18241,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_t_16 = (((*((long *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_14 * __pyx_v_indptr.strides[0]) ))) == (*((long *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_15 * __pyx_v_indptr.strides[0]) )))) != 0);
                                   if (__pyx_t_16) {
 
-                                    /* "implicit/_als.pyx":163
+                                    /* "implicit/_als.pyx":166
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:
  *                     memset(x, 0, sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -17747,7 +18250,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     memset(__pyx_v_x, 0, ((sizeof(float)) * __pyx_v_N));
 
-                                    /* "implicit/_als.pyx":164
+                                    /* "implicit/_als.pyx":167
  *                 if indptr[u] == indptr[u+1]:
  *                     memset(x, 0, sizeof(floating) * N)
  *                     continue             # <<<<<<<<<<<<<<
@@ -17756,7 +18259,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     goto __pyx_L15_continue;
 
-                                    /* "implicit/_als.pyx":162
+                                    /* "implicit/_als.pyx":165
  * 
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:             # <<<<<<<<<<<<<<
@@ -17765,7 +18268,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   }
 
-                                  /* "implicit/_als.pyx":167
+                                  /* "implicit/_als.pyx":170
  * 
  *                 # calculate residual r = (YtCuPu - (YtCuY.dot(Xu)
  *                 temp = -1.0             # <<<<<<<<<<<<<<
@@ -17774,7 +18277,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   __pyx_v_temp = -1.0;
 
-                                  /* "implicit/_als.pyx":168
+                                  /* "implicit/_als.pyx":171
  *                 # calculate residual r = (YtCuPu - (YtCuY.dot(Xu)
  *                 temp = -1.0
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, x, &one, &zero, r, &one)             # <<<<<<<<<<<<<<
@@ -17787,7 +18290,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
                                   if (__pyx_t_18 < 0) __pyx_t_18 += __pyx_v_YtY.shape[1];
                                   __pyx_fuse_0__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_17 * __pyx_v_YtY.strides[0]) ) + __pyx_t_18 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), __pyx_v_x, (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":170
+                                  /* "implicit/_als.pyx":173
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, x, &one, &zero, r, &one)
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -17802,32 +18305,82 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
                                   for (__pyx_t_22 = (*((long *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_21 * __pyx_v_indptr.strides[0]) ))); __pyx_t_22 < __pyx_t_20; __pyx_t_22+=1) {
                                     __pyx_v_index = __pyx_t_22;
 
-                                    /* "implicit/_als.pyx":171
+                                    /* "implicit/_als.pyx":174
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]             # <<<<<<<<<<<<<<
  *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+ * 
  */
                                     __pyx_t_23 = __pyx_v_index;
                                     if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_indices.shape[0];
                                     __pyx_v_i = (*((long *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_23 * __pyx_v_indices.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":172
+                                    /* "implicit/_als.pyx":175
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]
  *                     confidence = data[index]             # <<<<<<<<<<<<<<
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
- *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
+ * 
+ *                     if confidence > 0:
  */
                                     __pyx_t_24 = __pyx_v_index;
                                     if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_data.shape[0];
                                     __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_24 * __pyx_v_data.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":173
- *                     i = indices[index]
+                                    /* "implicit/_als.pyx":177
  *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)             # <<<<<<<<<<<<<<
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = confidence
+ *                     else:
+ */
+                                    __pyx_t_16 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_16) {
+
+                                      /* "implicit/_als.pyx":178
+ * 
+ *                     if confidence > 0:
+ *                         temp = confidence             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         temp = 0
+ */
+                                      __pyx_v_temp = __pyx_v_confidence;
+
+                                      /* "implicit/_als.pyx":177
+ *                     confidence = data[index]
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = confidence
+ *                     else:
+ */
+                                      goto __pyx_L22;
+                                    }
+
+                                    /* "implicit/_als.pyx":180
+ *                         temp = confidence
+ *                     else:
+ *                         temp = 0             # <<<<<<<<<<<<<<
+ *                         confidence = -1 * confidence
+ * 
+ */
+                                    /*else*/ {
+                                      __pyx_v_temp = 0.0;
+
+                                      /* "implicit/_als.pyx":181
+ *                     else:
+ *                         temp = 0
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+ */
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L22:;
+
+                                    /* "implicit/_als.pyx":183
+ *                         confidence = -1 * confidence
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)             # <<<<<<<<<<<<<<
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  */
@@ -17835,11 +18388,11 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_t_26 = 0;
                                     if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_Y.shape[0];
                                     if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_Y.shape[1];
-                                    __pyx_v_temp = (__pyx_v_confidence - ((__pyx_v_confidence - 1.0) * __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_25 * __pyx_v_Y.strides[0]) ) + __pyx_t_26 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one))));
+                                    __pyx_v_temp = (__pyx_v_temp - ((__pyx_v_confidence - 1.0) * __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_25 * __pyx_v_Y.strides[0]) ) + __pyx_t_26 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one))));
 
-                                    /* "implicit/_als.pyx":174
- *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+                                    /* "implicit/_als.pyx":184
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)             # <<<<<<<<<<<<<<
  * 
  *                 memcpy(p, r, sizeof(floating) * N)
@@ -17851,7 +18404,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
                                   }
 
-                                  /* "implicit/_als.pyx":176
+                                  /* "implicit/_als.pyx":186
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  *                 memcpy(p, r, sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -17860,7 +18413,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   memcpy(__pyx_v_p, __pyx_v_r, ((sizeof(float)) * __pyx_v_N));
 
-                                  /* "implicit/_als.pyx":177
+                                  /* "implicit/_als.pyx":187
  * 
  *                 memcpy(p, r, sizeof(floating) * N)
  *                 rsold = dot(&N, r, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -17869,7 +18422,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   __pyx_v_rsold = __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":179
+                                  /* "implicit/_als.pyx":189
  *                 rsold = dot(&N, r, &one, r, &one)
  * 
  *                 if rsold < 1e-20:             # <<<<<<<<<<<<<<
@@ -17879,7 +18432,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_t_16 = ((__pyx_v_rsold < 1e-20) != 0);
                                   if (__pyx_t_16) {
 
-                                    /* "implicit/_als.pyx":180
+                                    /* "implicit/_als.pyx":190
  * 
  *                 if rsold < 1e-20:
  *                     continue             # <<<<<<<<<<<<<<
@@ -17888,7 +18441,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     goto __pyx_L15_continue;
 
-                                    /* "implicit/_als.pyx":179
+                                    /* "implicit/_als.pyx":189
  *                 rsold = dot(&N, r, &one, r, &one)
  * 
  *                 if rsold < 1e-20:             # <<<<<<<<<<<<<<
@@ -17897,7 +18450,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   }
 
-                                  /* "implicit/_als.pyx":182
+                                  /* "implicit/_als.pyx":192
  *                     continue
  * 
  *                 for it in range(cg_steps):             # <<<<<<<<<<<<<<
@@ -17908,7 +18461,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
                                   for (__pyx_t_29 = 0; __pyx_t_29 < __pyx_t_22; __pyx_t_29+=1) {
                                     __pyx_v_it = __pyx_t_29;
 
-                                    /* "implicit/_als.pyx":184
+                                    /* "implicit/_als.pyx":194
  *                 for it in range(cg_steps):
  *                     # calculate Ap = YtCuYp - without actually calculating YtCuY
  *                     temp = 1.0             # <<<<<<<<<<<<<<
@@ -17917,7 +18470,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = 1.0;
 
-                                    /* "implicit/_als.pyx":185
+                                    /* "implicit/_als.pyx":195
  *                     # calculate Ap = YtCuYp - without actually calculating YtCuY
  *                     temp = 1.0
  *                     symv("U", &N, &temp, &YtY[0, 0], &N, p, &one, &zero, Ap, &one)             # <<<<<<<<<<<<<<
@@ -17930,7 +18483,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
                                     if (__pyx_t_31 < 0) __pyx_t_31 += __pyx_v_YtY.shape[1];
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_30 * __pyx_v_YtY.strides[0]) ) + __pyx_t_31 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), __pyx_v_p, (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_Ap, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":187
+                                    /* "implicit/_als.pyx":197
  *                     symv("U", &N, &temp, &YtY[0, 0], &N, p, &one, &zero, Ap, &one)
  * 
  *                     for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -17945,31 +18498,59 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
                                     for (__pyx_t_34 = (*((long *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_33 * __pyx_v_indptr.strides[0]) ))); __pyx_t_34 < __pyx_t_20; __pyx_t_34+=1) {
                                       __pyx_v_index = __pyx_t_34;
 
-                                      /* "implicit/_als.pyx":188
+                                      /* "implicit/_als.pyx":198
  * 
  *                     for index in range(indptr[u], indptr[u + 1]):
  *                         i = indices[index]             # <<<<<<<<<<<<<<
  *                         confidence = data[index]
- *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
+ * 
  */
                                       __pyx_t_35 = __pyx_v_index;
                                       if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_indices.shape[0];
                                       __pyx_v_i = (*((long *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_35 * __pyx_v_indices.strides[0]) )));
 
-                                      /* "implicit/_als.pyx":189
+                                      /* "implicit/_als.pyx":199
  *                     for index in range(indptr[u], indptr[u + 1]):
  *                         i = indices[index]
  *                         confidence = data[index]             # <<<<<<<<<<<<<<
- *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
- *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)
+ * 
+ *                         if confidence < 0:
  */
                                       __pyx_t_36 = __pyx_v_index;
                                       if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_data.shape[0];
                                       __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_36 * __pyx_v_data.strides[0]) )));
 
-                                      /* "implicit/_als.pyx":190
- *                         i = indices[index]
+                                      /* "implicit/_als.pyx":201
  *                         confidence = data[index]
+ * 
+ *                         if confidence < 0:             # <<<<<<<<<<<<<<
+ *                             confidence = -1 * confidence
+ * 
+ */
+                                      __pyx_t_16 = ((__pyx_v_confidence < 0.0) != 0);
+                                      if (__pyx_t_16) {
+
+                                        /* "implicit/_als.pyx":202
+ * 
+ *                         if confidence < 0:
+ *                             confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
+ */
+                                        __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+
+                                        /* "implicit/_als.pyx":201
+ *                         confidence = data[index]
+ * 
+ *                         if confidence < 0:             # <<<<<<<<<<<<<<
+ *                             confidence = -1 * confidence
+ * 
+ */
+                                      }
+
+                                      /* "implicit/_als.pyx":204
+ *                             confidence = -1 * confidence
+ * 
  *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)             # <<<<<<<<<<<<<<
  *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)
  * 
@@ -17980,8 +18561,8 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
                                       if (__pyx_t_38 < 0) __pyx_t_38 += __pyx_v_Y.shape[1];
                                       __pyx_v_temp = ((__pyx_v_confidence - 1.0) * __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_37 * __pyx_v_Y.strides[0]) ) + __pyx_t_38 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_p, (&__pyx_v_one)));
 
-                                      /* "implicit/_als.pyx":191
- *                         confidence = data[index]
+                                      /* "implicit/_als.pyx":205
+ * 
  *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
  *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)             # <<<<<<<<<<<<<<
  * 
@@ -17994,7 +18575,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
                                       __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_39 * __pyx_v_Y.strides[0]) ) + __pyx_t_40 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_Ap, (&__pyx_v_one));
                                     }
 
-                                    /* "implicit/_als.pyx":194
+                                    /* "implicit/_als.pyx":208
  * 
  *                     # alpha = rsold / p.dot(Ap);
  *                     alpha = rsold / dot(&N, p, &one, Ap, &one)             # <<<<<<<<<<<<<<
@@ -18003,7 +18584,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_alpha = (__pyx_v_rsold / __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_p, (&__pyx_v_one), __pyx_v_Ap, (&__pyx_v_one)));
 
-                                    /* "implicit/_als.pyx":197
+                                    /* "implicit/_als.pyx":211
  * 
  *                     # x += alpha * p
  *                     axpy(&N, &alpha, p, &one, x, &one)             # <<<<<<<<<<<<<<
@@ -18012,7 +18593,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_alpha), __pyx_v_p, (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":200
+                                    /* "implicit/_als.pyx":214
  * 
  *                     # r -= alpha * Ap
  *                     temp = alpha * -1             # <<<<<<<<<<<<<<
@@ -18021,7 +18602,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = (__pyx_v_alpha * -1.0);
 
-                                    /* "implicit/_als.pyx":201
+                                    /* "implicit/_als.pyx":215
  *                     # r -= alpha * Ap
  *                     temp = alpha * -1
  *                     axpy(&N, &temp, Ap, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -18030,7 +18611,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_Ap, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":203
+                                    /* "implicit/_als.pyx":217
  *                     axpy(&N, &temp, Ap, &one, r, &one)
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -18039,7 +18620,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_rsnew = __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":204
+                                    /* "implicit/_als.pyx":218
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:             # <<<<<<<<<<<<<<
@@ -18049,16 +18630,16 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_t_16 = ((__pyx_v_rsnew < 1e-20) != 0);
                                     if (__pyx_t_16) {
 
-                                      /* "implicit/_als.pyx":205
+                                      /* "implicit/_als.pyx":219
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:
  *                         break             # <<<<<<<<<<<<<<
  * 
  *                     # p = r + (rsnew/rsold) * p
  */
-                                      goto __pyx_L24_break;
+                                      goto __pyx_L25_break;
 
-                                      /* "implicit/_als.pyx":204
+                                      /* "implicit/_als.pyx":218
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:             # <<<<<<<<<<<<<<
@@ -18067,7 +18648,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     }
 
-                                    /* "implicit/_als.pyx":208
+                                    /* "implicit/_als.pyx":222
  * 
  *                     # p = r + (rsnew/rsold) * p
  *                     temp = rsnew / rsold             # <<<<<<<<<<<<<<
@@ -18076,7 +18657,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = (__pyx_v_rsnew / __pyx_v_rsold);
 
-                                    /* "implicit/_als.pyx":209
+                                    /* "implicit/_als.pyx":223
  *                     # p = r + (rsnew/rsold) * p
  *                     temp = rsnew / rsold
  *                     scal(&N, &temp, p, &one)             # <<<<<<<<<<<<<<
@@ -18085,7 +18666,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_scal((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_p, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":210
+                                    /* "implicit/_als.pyx":224
  *                     temp = rsnew / rsold
  *                     scal(&N, &temp, p, &one)
  *                     temp = 1.0             # <<<<<<<<<<<<<<
@@ -18094,7 +18675,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = 1.0;
 
-                                    /* "implicit/_als.pyx":211
+                                    /* "implicit/_als.pyx":225
  *                     scal(&N, &temp, p, &one)
  *                     temp = 1.0
  *                     axpy(&N, &temp, r, &one, p, &one)             # <<<<<<<<<<<<<<
@@ -18103,7 +18684,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_r, (&__pyx_v_one), __pyx_v_p, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":213
+                                    /* "implicit/_als.pyx":227
  *                     axpy(&N, &temp, r, &one, p, &one)
  * 
  *                     rsold = rsnew             # <<<<<<<<<<<<<<
@@ -18112,18 +18693,18 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_rsold = __pyx_v_rsnew;
                                   }
-                                  __pyx_L24_break:;
-                                  goto __pyx_L29;
+                                  __pyx_L25_break:;
+                                  goto __pyx_L31;
                                   __pyx_L15_continue:;
-                                  goto __pyx_L29;
-                                  __pyx_L29:;
+                                  goto __pyx_L31;
+                                  __pyx_L31:;
                               }
                           }
                       }
                   }
                 }
 
-                /* "implicit/_als.pyx":215
+                /* "implicit/_als.pyx":229
  *                     rsold = rsnew
  *         finally:
  *             free(p)             # <<<<<<<<<<<<<<
@@ -18134,7 +18715,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
                   /*normal exit:*/{
                     free(__pyx_v_p);
 
-                    /* "implicit/_als.pyx":216
+                    /* "implicit/_als.pyx":230
  *         finally:
  *             free(p)
  *             free(r)             # <<<<<<<<<<<<<<
@@ -18143,7 +18724,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
  */
                     free(__pyx_v_r);
 
-                    /* "implicit/_als.pyx":217
+                    /* "implicit/_als.pyx":231
  *             free(p)
  *             free(r)
  *             free(Ap)             # <<<<<<<<<<<<<<
@@ -18165,7 +18746,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
         #endif
       }
 
-      /* "implicit/_als.pyx":150
+      /* "implicit/_als.pyx":153
  *     cdef floating * Ap
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -18184,7 +18765,7 @@ static PyObject *__pyx_pf_8implicit_4_als_34_least_squares_cg(CYTHON_UNUSED PyOb
       }
   }
 
-  /* "implicit/_als.pyx":134
+  /* "implicit/_als.pyx":137
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _least_squares_cg(integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
@@ -18227,11 +18808,11 @@ static PyObject *__pyx_pf_8implicit_4_als_100__defaults__(CYTHON_UNUSED PyObject
   PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("__defaults__", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults23, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults23, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults23, __pyx_self)->__pyx_arg_cg_steps); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults23, __pyx_self)->__pyx_arg_cg_steps); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
@@ -18239,7 +18820,7 @@ static PyObject *__pyx_pf_8implicit_4_als_100__defaults__(CYTHON_UNUSED PyObject
   PyTuple_SET_ITEM(__pyx_t_3, 1, __pyx_t_2);
   __pyx_t_1 = 0;
   __pyx_t_2 = 0;
-  __pyx_t_2 = PyTuple_New(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_3);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_3);
@@ -18315,31 +18896,31 @@ static PyObject *__pyx_fuse_2_1__pyx_pw_8implicit_4_als_37_least_squares_cg(PyOb
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indices)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 1); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 1); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_data)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 2); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 2); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_X)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 3); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 3); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
         if (likely((values[4] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_Y)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 4); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 4); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  5:
         if (likely((values[5] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_regularization)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 5); __PYX_ERR(0, 134, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, 5); __PYX_ERR(0, 137, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  6:
@@ -18355,7 +18936,7 @@ static PyObject *__pyx_fuse_2_1__pyx_pw_8implicit_4_als_37_least_squares_cg(PyOb
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_least_squares_cg") < 0)) __PYX_ERR(0, 134, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_least_squares_cg") < 0)) __PYX_ERR(0, 137, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -18373,26 +18954,26 @@ static PyObject *__pyx_fuse_2_1__pyx_pw_8implicit_4_als_37_least_squares_cg(PyOb
         default: goto __pyx_L5_argtuple_error;
       }
     }
-    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_long(values[0]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_long(values[1]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[2]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 134, __pyx_L3_error)
-    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[3]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 135, __pyx_L3_error)
-    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[4]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 135, __pyx_L3_error)
-    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[5]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 135, __pyx_L3_error)
+    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_long(values[0]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_long(values[1]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[2]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 137, __pyx_L3_error)
+    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[3]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 138, __pyx_L3_error)
+    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[4]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 138, __pyx_L3_error)
+    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[5]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 138, __pyx_L3_error)
     if (values[6]) {
-      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[6]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 136, __pyx_L3_error)
+      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[6]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 139, __pyx_L3_error)
     } else {
       __pyx_v_num_threads = __pyx_dynamic_args->__pyx_arg_num_threads;
     }
     if (values[7]) {
-      __pyx_v_cg_steps = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_cg_steps == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 136, __pyx_L3_error)
+      __pyx_v_cg_steps = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_cg_steps == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 139, __pyx_L3_error)
     } else {
       __pyx_v_cg_steps = __pyx_dynamic_args->__pyx_arg_cg_steps;
     }
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 134, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("_least_squares_cg", 0, 6, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 137, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("implicit._als._least_squares_cg", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -18469,7 +19050,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
   Py_ssize_t __pyx_t_40;
   __Pyx_RefNannySetupContext("__pyx_fuse_2_1_least_squares_cg", 0);
 
-  /* "implicit/_als.pyx":137
+  /* "implicit/_als.pyx":140
  *                       floating[:, :] X, floating[:, :] Y, float regularization,
  *                       int num_threads=0, int cg_steps=3):
  *     dtype = np.float64 if floating is double else np.float32             # <<<<<<<<<<<<<<
@@ -18477,17 +19058,17 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it
  */
   if ((1 != 0)) {
-    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_1 = __pyx_t_3;
     __pyx_t_3 = 0;
   } else {
-    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 137, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 140, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_t_1 = __pyx_t_2;
@@ -18496,7 +19077,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
   __pyx_v_dtype = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "implicit/_als.pyx":139
+  /* "implicit/_als.pyx":142
  *     dtype = np.float64 if floating is double else np.float32
  * 
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it             # <<<<<<<<<<<<<<
@@ -18507,7 +19088,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
   __pyx_v_N = (__pyx_v_X.shape[1]);
   __pyx_v_one = 1;
 
-  /* "implicit/_als.pyx":141
+  /* "implicit/_als.pyx":144
  *     cdef int users = X.shape[0], N = X.shape[1], u, i, index, one = 1, it
  *     cdef floating confidence, temp, alpha, rsnew, rsold
  *     cdef floating zero = 0.             # <<<<<<<<<<<<<<
@@ -18516,24 +19097,24 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
   __pyx_v_zero = 0.;
 
-  /* "implicit/_als.pyx":143
+  /* "implicit/_als.pyx":146
  *     cdef floating zero = 0.
  * 
  *     cdef floating[:, :] YtY = np.dot(np.transpose(Y), Y) + regularization * np.eye(N, dtype=dtype)             # <<<<<<<<<<<<<<
  * 
  *     cdef floating * x
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_6 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -18546,14 +19127,14 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
     }
   }
   if (!__pyx_t_6) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_GOTREF(__pyx_t_2);
   } else {
     #if CYTHON_FAST_PYCALL
     if (PyFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -18562,26 +19143,26 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
     #if CYTHON_FAST_PYCCALL
     if (__Pyx_PyFastCFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     } else
     #endif
     {
-      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_6); __pyx_t_6 = NULL;
       __Pyx_GIVEREF(__pyx_t_4);
       PyTuple_SET_ITEM(__pyx_t_7, 0+1, __pyx_t_4);
       __pyx_t_4 = 0;
-      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     }
   }
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_7 = NULL;
   __pyx_t_8 = 0;
@@ -18598,7 +19179,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -18608,7 +19189,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -18616,7 +19197,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
   } else
   #endif
   {
-    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     if (__pyx_t_7) {
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -18627,49 +19208,49 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
     PyTuple_SET_ITEM(__pyx_t_4, 1+__pyx_t_8, __pyx_t_5);
     __pyx_t_2 = 0;
     __pyx_t_5 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 143, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 146, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_regularization); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_regularization); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_eye); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_eye); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_N); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_From_int(__pyx_v_N); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_4);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_4);
   __pyx_t_4 = 0;
-  __pyx_t_4 = PyDict_New(); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = PyDict_New(); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  if (PyDict_SetItem(__pyx_t_4, __pyx_n_s_dtype, __pyx_v_dtype) < 0) __PYX_ERR(0, 143, __pyx_L1_error)
-  __pyx_t_7 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_4, __pyx_n_s_dtype, __pyx_v_dtype) < 0) __PYX_ERR(0, 146, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = PyNumber_Multiply(__pyx_t_3, __pyx_t_7); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_4 = PyNumber_Multiply(__pyx_t_3, __pyx_t_7); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
-  __pyx_t_7 = PyNumber_Add(__pyx_t_1, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 143, __pyx_L1_error)
+  __pyx_t_7 = PyNumber_Add(__pyx_t_1, __pyx_t_4); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(__pyx_t_7);
-  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 143, __pyx_L1_error)
+  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 146, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   __pyx_v_YtY = __pyx_t_9;
   __pyx_t_9.memview = NULL;
   __pyx_t_9.data = NULL;
 
-  /* "implicit/_als.pyx":150
+  /* "implicit/_als.pyx":153
  *     cdef floating * Ap
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -18699,7 +19280,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
                 __pyx_v_p = ((double *)1);
                 __pyx_v_r = ((double *)1);
 
-                /* "implicit/_als.pyx":153
+                /* "implicit/_als.pyx":156
  * 
  *         # allocate temp memory for each thread
  *         Ap = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -18708,7 +19289,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_Ap = ((double *)malloc(((sizeof(double)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":154
+                /* "implicit/_als.pyx":157
  *         # allocate temp memory for each thread
  *         Ap = <floating *> malloc(sizeof(floating) * N)
  *         p = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -18717,7 +19298,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_p = ((double *)malloc(((sizeof(double)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":155
+                /* "implicit/_als.pyx":158
  *         Ap = <floating *> malloc(sizeof(floating) * N)
  *         p = <floating *> malloc(sizeof(floating) * N)
  *         r = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -18726,7 +19307,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 __pyx_v_r = ((double *)malloc(((sizeof(double)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":156
+                /* "implicit/_als.pyx":159
  *         p = <floating *> malloc(sizeof(floating) * N)
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:             # <<<<<<<<<<<<<<
@@ -18735,7 +19316,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                 /*try:*/ {
 
-                  /* "implicit/_als.pyx":157
+                  /* "implicit/_als.pyx":160
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:
  *             for u in prange(users, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -18765,7 +19346,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_v_temp = ((double)__PYX_NAN());
                                   __pyx_v_x = ((double *)1);
 
-                                  /* "implicit/_als.pyx":159
+                                  /* "implicit/_als.pyx":162
  *             for u in prange(users, schedule='guided'):
  *                 # start from previous iteration
  *                 x = &X[u, 0]             # <<<<<<<<<<<<<<
@@ -18778,7 +19359,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
                                   if (__pyx_t_13 < 0) __pyx_t_13 += __pyx_v_X.shape[1];
                                   __pyx_v_x = (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_12 * __pyx_v_X.strides[0]) ) + __pyx_t_13 * __pyx_v_X.strides[1]) ))));
 
-                                  /* "implicit/_als.pyx":162
+                                  /* "implicit/_als.pyx":165
  * 
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:             # <<<<<<<<<<<<<<
@@ -18792,7 +19373,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_t_16 = (((*((long *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_14 * __pyx_v_indptr.strides[0]) ))) == (*((long *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_15 * __pyx_v_indptr.strides[0]) )))) != 0);
                                   if (__pyx_t_16) {
 
-                                    /* "implicit/_als.pyx":163
+                                    /* "implicit/_als.pyx":166
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:
  *                     memset(x, 0, sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -18801,7 +19382,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     memset(__pyx_v_x, 0, ((sizeof(double)) * __pyx_v_N));
 
-                                    /* "implicit/_als.pyx":164
+                                    /* "implicit/_als.pyx":167
  *                 if indptr[u] == indptr[u+1]:
  *                     memset(x, 0, sizeof(floating) * N)
  *                     continue             # <<<<<<<<<<<<<<
@@ -18810,7 +19391,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     goto __pyx_L15_continue;
 
-                                    /* "implicit/_als.pyx":162
+                                    /* "implicit/_als.pyx":165
  * 
  *                 # if we have no items for this user, skip and set to zero
  *                 if indptr[u] == indptr[u+1]:             # <<<<<<<<<<<<<<
@@ -18819,7 +19400,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   }
 
-                                  /* "implicit/_als.pyx":167
+                                  /* "implicit/_als.pyx":170
  * 
  *                 # calculate residual r = (YtCuPu - (YtCuY.dot(Xu)
  *                 temp = -1.0             # <<<<<<<<<<<<<<
@@ -18828,7 +19409,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   __pyx_v_temp = -1.0;
 
-                                  /* "implicit/_als.pyx":168
+                                  /* "implicit/_als.pyx":171
  *                 # calculate residual r = (YtCuPu - (YtCuY.dot(Xu)
  *                 temp = -1.0
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, x, &one, &zero, r, &one)             # <<<<<<<<<<<<<<
@@ -18841,7 +19422,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
                                   if (__pyx_t_18 < 0) __pyx_t_18 += __pyx_v_YtY.shape[1];
                                   __pyx_fuse_1__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_17 * __pyx_v_YtY.strides[0]) ) + __pyx_t_18 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), __pyx_v_x, (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":170
+                                  /* "implicit/_als.pyx":173
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, x, &one, &zero, r, &one)
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -18856,32 +19437,82 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
                                   for (__pyx_t_22 = (*((long *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_21 * __pyx_v_indptr.strides[0]) ))); __pyx_t_22 < __pyx_t_20; __pyx_t_22+=1) {
                                     __pyx_v_index = __pyx_t_22;
 
-                                    /* "implicit/_als.pyx":171
+                                    /* "implicit/_als.pyx":174
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]             # <<<<<<<<<<<<<<
  *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+ * 
  */
                                     __pyx_t_23 = __pyx_v_index;
                                     if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_indices.shape[0];
                                     __pyx_v_i = (*((long *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_23 * __pyx_v_indices.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":172
+                                    /* "implicit/_als.pyx":175
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]
  *                     confidence = data[index]             # <<<<<<<<<<<<<<
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
- *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
+ * 
+ *                     if confidence > 0:
  */
                                     __pyx_t_24 = __pyx_v_index;
                                     if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_data.shape[0];
                                     __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_24 * __pyx_v_data.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":173
- *                     i = indices[index]
+                                    /* "implicit/_als.pyx":177
  *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)             # <<<<<<<<<<<<<<
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = confidence
+ *                     else:
+ */
+                                    __pyx_t_16 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_16) {
+
+                                      /* "implicit/_als.pyx":178
+ * 
+ *                     if confidence > 0:
+ *                         temp = confidence             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         temp = 0
+ */
+                                      __pyx_v_temp = __pyx_v_confidence;
+
+                                      /* "implicit/_als.pyx":177
+ *                     confidence = data[index]
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = confidence
+ *                     else:
+ */
+                                      goto __pyx_L22;
+                                    }
+
+                                    /* "implicit/_als.pyx":180
+ *                         temp = confidence
+ *                     else:
+ *                         temp = 0             # <<<<<<<<<<<<<<
+ *                         confidence = -1 * confidence
+ * 
+ */
+                                    /*else*/ {
+                                      __pyx_v_temp = 0.0;
+
+                                      /* "implicit/_als.pyx":181
+ *                     else:
+ *                         temp = 0
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+ */
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L22:;
+
+                                    /* "implicit/_als.pyx":183
+ *                         confidence = -1 * confidence
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)             # <<<<<<<<<<<<<<
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  */
@@ -18889,11 +19520,11 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_t_26 = 0;
                                     if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_Y.shape[0];
                                     if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_Y.shape[1];
-                                    __pyx_v_temp = (__pyx_v_confidence - ((__pyx_v_confidence - 1.0) * __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_25 * __pyx_v_Y.strides[0]) ) + __pyx_t_26 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one))));
+                                    __pyx_v_temp = (__pyx_v_temp - ((__pyx_v_confidence - 1.0) * __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_25 * __pyx_v_Y.strides[0]) ) + __pyx_t_26 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one))));
 
-                                    /* "implicit/_als.pyx":174
- *                     confidence = data[index]
- *                     temp = confidence - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
+                                    /* "implicit/_als.pyx":184
+ * 
+ *                     temp = temp - (confidence - 1) * dot(&N, &Y[i, 0], &one, x, &one)
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)             # <<<<<<<<<<<<<<
  * 
  *                 memcpy(p, r, sizeof(floating) * N)
@@ -18905,7 +19536,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
                                   }
 
-                                  /* "implicit/_als.pyx":176
+                                  /* "implicit/_als.pyx":186
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  *                 memcpy(p, r, sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -18914,7 +19545,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   memcpy(__pyx_v_p, __pyx_v_r, ((sizeof(double)) * __pyx_v_N));
 
-                                  /* "implicit/_als.pyx":177
+                                  /* "implicit/_als.pyx":187
  * 
  *                 memcpy(p, r, sizeof(floating) * N)
  *                 rsold = dot(&N, r, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -18923,7 +19554,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   __pyx_v_rsold = __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":179
+                                  /* "implicit/_als.pyx":189
  *                 rsold = dot(&N, r, &one, r, &one)
  * 
  *                 if rsold < 1e-20:             # <<<<<<<<<<<<<<
@@ -18933,7 +19564,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
                                   __pyx_t_16 = ((__pyx_v_rsold < 1e-20) != 0);
                                   if (__pyx_t_16) {
 
-                                    /* "implicit/_als.pyx":180
+                                    /* "implicit/_als.pyx":190
  * 
  *                 if rsold < 1e-20:
  *                     continue             # <<<<<<<<<<<<<<
@@ -18942,7 +19573,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     goto __pyx_L15_continue;
 
-                                    /* "implicit/_als.pyx":179
+                                    /* "implicit/_als.pyx":189
  *                 rsold = dot(&N, r, &one, r, &one)
  * 
  *                 if rsold < 1e-20:             # <<<<<<<<<<<<<<
@@ -18951,7 +19582,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                   }
 
-                                  /* "implicit/_als.pyx":182
+                                  /* "implicit/_als.pyx":192
  *                     continue
  * 
  *                 for it in range(cg_steps):             # <<<<<<<<<<<<<<
@@ -18962,7 +19593,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
                                   for (__pyx_t_29 = 0; __pyx_t_29 < __pyx_t_22; __pyx_t_29+=1) {
                                     __pyx_v_it = __pyx_t_29;
 
-                                    /* "implicit/_als.pyx":184
+                                    /* "implicit/_als.pyx":194
  *                 for it in range(cg_steps):
  *                     # calculate Ap = YtCuYp - without actually calculating YtCuY
  *                     temp = 1.0             # <<<<<<<<<<<<<<
@@ -18971,7 +19602,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = 1.0;
 
-                                    /* "implicit/_als.pyx":185
+                                    /* "implicit/_als.pyx":195
  *                     # calculate Ap = YtCuYp - without actually calculating YtCuY
  *                     temp = 1.0
  *                     symv("U", &N, &temp, &YtY[0, 0], &N, p, &one, &zero, Ap, &one)             # <<<<<<<<<<<<<<
@@ -18984,7 +19615,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
                                     if (__pyx_t_31 < 0) __pyx_t_31 += __pyx_v_YtY.shape[1];
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_30 * __pyx_v_YtY.strides[0]) ) + __pyx_t_31 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), __pyx_v_p, (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_Ap, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":187
+                                    /* "implicit/_als.pyx":197
  *                     symv("U", &N, &temp, &YtY[0, 0], &N, p, &one, &zero, Ap, &one)
  * 
  *                     for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -18999,31 +19630,59 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
                                     for (__pyx_t_34 = (*((long *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_33 * __pyx_v_indptr.strides[0]) ))); __pyx_t_34 < __pyx_t_20; __pyx_t_34+=1) {
                                       __pyx_v_index = __pyx_t_34;
 
-                                      /* "implicit/_als.pyx":188
+                                      /* "implicit/_als.pyx":198
  * 
  *                     for index in range(indptr[u], indptr[u + 1]):
  *                         i = indices[index]             # <<<<<<<<<<<<<<
  *                         confidence = data[index]
- *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
+ * 
  */
                                       __pyx_t_35 = __pyx_v_index;
                                       if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_indices.shape[0];
                                       __pyx_v_i = (*((long *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_35 * __pyx_v_indices.strides[0]) )));
 
-                                      /* "implicit/_als.pyx":189
+                                      /* "implicit/_als.pyx":199
  *                     for index in range(indptr[u], indptr[u + 1]):
  *                         i = indices[index]
  *                         confidence = data[index]             # <<<<<<<<<<<<<<
- *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
- *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)
+ * 
+ *                         if confidence < 0:
  */
                                       __pyx_t_36 = __pyx_v_index;
                                       if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_data.shape[0];
                                       __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_36 * __pyx_v_data.strides[0]) )));
 
-                                      /* "implicit/_als.pyx":190
- *                         i = indices[index]
+                                      /* "implicit/_als.pyx":201
  *                         confidence = data[index]
+ * 
+ *                         if confidence < 0:             # <<<<<<<<<<<<<<
+ *                             confidence = -1 * confidence
+ * 
+ */
+                                      __pyx_t_16 = ((__pyx_v_confidence < 0.0) != 0);
+                                      if (__pyx_t_16) {
+
+                                        /* "implicit/_als.pyx":202
+ * 
+ *                         if confidence < 0:
+ *                             confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
+ */
+                                        __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+
+                                        /* "implicit/_als.pyx":201
+ *                         confidence = data[index]
+ * 
+ *                         if confidence < 0:             # <<<<<<<<<<<<<<
+ *                             confidence = -1 * confidence
+ * 
+ */
+                                      }
+
+                                      /* "implicit/_als.pyx":204
+ *                             confidence = -1 * confidence
+ * 
  *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)             # <<<<<<<<<<<<<<
  *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)
  * 
@@ -19034,8 +19693,8 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
                                       if (__pyx_t_38 < 0) __pyx_t_38 += __pyx_v_Y.shape[1];
                                       __pyx_v_temp = ((__pyx_v_confidence - 1.0) * __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_37 * __pyx_v_Y.strides[0]) ) + __pyx_t_38 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_p, (&__pyx_v_one)));
 
-                                      /* "implicit/_als.pyx":191
- *                         confidence = data[index]
+                                      /* "implicit/_als.pyx":205
+ * 
  *                         temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, p, &one)
  *                         axpy(&N, &temp, &Y[i, 0], &one, Ap, &one)             # <<<<<<<<<<<<<<
  * 
@@ -19048,7 +19707,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
                                       __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_39 * __pyx_v_Y.strides[0]) ) + __pyx_t_40 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_Ap, (&__pyx_v_one));
                                     }
 
-                                    /* "implicit/_als.pyx":194
+                                    /* "implicit/_als.pyx":208
  * 
  *                     # alpha = rsold / p.dot(Ap);
  *                     alpha = rsold / dot(&N, p, &one, Ap, &one)             # <<<<<<<<<<<<<<
@@ -19057,7 +19716,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_alpha = (__pyx_v_rsold / __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_p, (&__pyx_v_one), __pyx_v_Ap, (&__pyx_v_one)));
 
-                                    /* "implicit/_als.pyx":197
+                                    /* "implicit/_als.pyx":211
  * 
  *                     # x += alpha * p
  *                     axpy(&N, &alpha, p, &one, x, &one)             # <<<<<<<<<<<<<<
@@ -19066,7 +19725,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_alpha), __pyx_v_p, (&__pyx_v_one), __pyx_v_x, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":200
+                                    /* "implicit/_als.pyx":214
  * 
  *                     # r -= alpha * Ap
  *                     temp = alpha * -1             # <<<<<<<<<<<<<<
@@ -19075,7 +19734,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = (__pyx_v_alpha * -1.0);
 
-                                    /* "implicit/_als.pyx":201
+                                    /* "implicit/_als.pyx":215
  *                     # r -= alpha * Ap
  *                     temp = alpha * -1
  *                     axpy(&N, &temp, Ap, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -19084,7 +19743,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_Ap, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":203
+                                    /* "implicit/_als.pyx":217
  *                     axpy(&N, &temp, Ap, &one, r, &one)
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)             # <<<<<<<<<<<<<<
@@ -19093,7 +19752,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_rsnew = __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":204
+                                    /* "implicit/_als.pyx":218
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:             # <<<<<<<<<<<<<<
@@ -19103,16 +19762,16 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
                                     __pyx_t_16 = ((__pyx_v_rsnew < 1e-20) != 0);
                                     if (__pyx_t_16) {
 
-                                      /* "implicit/_als.pyx":205
+                                      /* "implicit/_als.pyx":219
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:
  *                         break             # <<<<<<<<<<<<<<
  * 
  *                     # p = r + (rsnew/rsold) * p
  */
-                                      goto __pyx_L24_break;
+                                      goto __pyx_L25_break;
 
-                                      /* "implicit/_als.pyx":204
+                                      /* "implicit/_als.pyx":218
  * 
  *                     rsnew = dot(&N, r, &one, r, &one)
  *                     if rsnew < 1e-20:             # <<<<<<<<<<<<<<
@@ -19121,7 +19780,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     }
 
-                                    /* "implicit/_als.pyx":208
+                                    /* "implicit/_als.pyx":222
  * 
  *                     # p = r + (rsnew/rsold) * p
  *                     temp = rsnew / rsold             # <<<<<<<<<<<<<<
@@ -19130,7 +19789,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = (__pyx_v_rsnew / __pyx_v_rsold);
 
-                                    /* "implicit/_als.pyx":209
+                                    /* "implicit/_als.pyx":223
  *                     # p = r + (rsnew/rsold) * p
  *                     temp = rsnew / rsold
  *                     scal(&N, &temp, p, &one)             # <<<<<<<<<<<<<<
@@ -19139,7 +19798,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_scal((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_p, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":210
+                                    /* "implicit/_als.pyx":224
  *                     temp = rsnew / rsold
  *                     scal(&N, &temp, p, &one)
  *                     temp = 1.0             # <<<<<<<<<<<<<<
@@ -19148,7 +19807,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_temp = 1.0;
 
-                                    /* "implicit/_als.pyx":211
+                                    /* "implicit/_als.pyx":225
  *                     scal(&N, &temp, p, &one)
  *                     temp = 1.0
  *                     axpy(&N, &temp, r, &one, p, &one)             # <<<<<<<<<<<<<<
@@ -19157,7 +19816,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), __pyx_v_r, (&__pyx_v_one), __pyx_v_p, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":213
+                                    /* "implicit/_als.pyx":227
  *                     axpy(&N, &temp, r, &one, p, &one)
  * 
  *                     rsold = rsnew             # <<<<<<<<<<<<<<
@@ -19166,18 +19825,18 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                                     __pyx_v_rsold = __pyx_v_rsnew;
                                   }
-                                  __pyx_L24_break:;
-                                  goto __pyx_L29;
+                                  __pyx_L25_break:;
+                                  goto __pyx_L31;
                                   __pyx_L15_continue:;
-                                  goto __pyx_L29;
-                                  __pyx_L29:;
+                                  goto __pyx_L31;
+                                  __pyx_L31:;
                               }
                           }
                       }
                   }
                 }
 
-                /* "implicit/_als.pyx":215
+                /* "implicit/_als.pyx":229
  *                     rsold = rsnew
  *         finally:
  *             free(p)             # <<<<<<<<<<<<<<
@@ -19188,7 +19847,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
                   /*normal exit:*/{
                     free(__pyx_v_p);
 
-                    /* "implicit/_als.pyx":216
+                    /* "implicit/_als.pyx":230
  *         finally:
  *             free(p)
  *             free(r)             # <<<<<<<<<<<<<<
@@ -19197,7 +19856,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
  */
                     free(__pyx_v_r);
 
-                    /* "implicit/_als.pyx":217
+                    /* "implicit/_als.pyx":231
  *             free(p)
  *             free(r)
  *             free(Ap)             # <<<<<<<<<<<<<<
@@ -19219,7 +19878,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
         #endif
       }
 
-      /* "implicit/_als.pyx":150
+      /* "implicit/_als.pyx":153
  *     cdef floating * Ap
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -19238,7 +19897,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
       }
   }
 
-  /* "implicit/_als.pyx":134
+  /* "implicit/_als.pyx":137
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _least_squares_cg(integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
@@ -19273,7 +19932,7 @@ static PyObject *__pyx_pf_8implicit_4_als_36_least_squares_cg(CYTHON_UNUSED PyOb
   return __pyx_r;
 }
 
-/* "implicit/_als.pyx":220
+/* "implicit/_als.pyx":234
  * 
  * 
  * def calculate_loss(Cui, X, Y, regularization, num_threads=0):             # <<<<<<<<<<<<<<
@@ -19323,19 +19982,19 @@ static PyObject *__pyx_pw_8implicit_4_als_9calculate_loss(PyObject *__pyx_self, 
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_X)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("calculate_loss", 0, 4, 5, 1); __PYX_ERR(0, 220, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("calculate_loss", 0, 4, 5, 1); __PYX_ERR(0, 234, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_Y)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("calculate_loss", 0, 4, 5, 2); __PYX_ERR(0, 220, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("calculate_loss", 0, 4, 5, 2); __PYX_ERR(0, 234, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_regularization)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("calculate_loss", 0, 4, 5, 3); __PYX_ERR(0, 220, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("calculate_loss", 0, 4, 5, 3); __PYX_ERR(0, 234, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
@@ -19345,7 +20004,7 @@ static PyObject *__pyx_pw_8implicit_4_als_9calculate_loss(PyObject *__pyx_self, 
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "calculate_loss") < 0)) __PYX_ERR(0, 220, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "calculate_loss") < 0)) __PYX_ERR(0, 234, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -19367,7 +20026,7 @@ static PyObject *__pyx_pw_8implicit_4_als_9calculate_loss(PyObject *__pyx_self, 
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("calculate_loss", 0, 4, 5, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 220, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("calculate_loss", 0, 4, 5, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 234, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("implicit._als.calculate_loss", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -19393,7 +20052,7 @@ static PyObject *__pyx_pf_8implicit_4_als_8calculate_loss(CYTHON_UNUSED PyObject
   PyObject *__pyx_t_8 = NULL;
   __Pyx_RefNannySetupContext("calculate_loss", 0);
 
-  /* "implicit/_als.pyx":221
+  /* "implicit/_als.pyx":235
  * 
  * def calculate_loss(Cui, X, Y, regularization, num_threads=0):
  *     return _calculate_loss(Cui, Cui.indptr, Cui.indices, Cui.data.astype('float32'),             # <<<<<<<<<<<<<<
@@ -19401,22 +20060,22 @@ static PyObject *__pyx_pf_8implicit_4_als_8calculate_loss(CYTHON_UNUSED PyObject
  * 
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_calculate_loss); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 221, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_calculate_loss); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_indptr); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 221, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_indptr); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 235, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_indices); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 221, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_indices); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_data); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 221, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_data); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 235, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_astype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 221, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_astype); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 235, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_tuple__15, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 221, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_tuple__15, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 235, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
 
-  /* "implicit/_als.pyx":222
+  /* "implicit/_als.pyx":236
  * def calculate_loss(Cui, X, Y, regularization, num_threads=0):
  *     return _calculate_loss(Cui, Cui.indptr, Cui.indices, Cui.data.astype('float32'),
  *                            X, Y, regularization, num_threads)             # <<<<<<<<<<<<<<
@@ -19438,7 +20097,7 @@ static PyObject *__pyx_pf_8implicit_4_als_8calculate_loss(CYTHON_UNUSED PyObject
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_2)) {
     PyObject *__pyx_temp[9] = {__pyx_t_6, __pyx_v_Cui, __pyx_t_3, __pyx_t_4, __pyx_t_5, __pyx_v_X, __pyx_v_Y, __pyx_v_regularization, __pyx_v_num_threads};
-    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_2, __pyx_temp+1-__pyx_t_7, 8+__pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 221, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_2, __pyx_temp+1-__pyx_t_7, 8+__pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -19449,7 +20108,7 @@ static PyObject *__pyx_pf_8implicit_4_als_8calculate_loss(CYTHON_UNUSED PyObject
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_2)) {
     PyObject *__pyx_temp[9] = {__pyx_t_6, __pyx_v_Cui, __pyx_t_3, __pyx_t_4, __pyx_t_5, __pyx_v_X, __pyx_v_Y, __pyx_v_regularization, __pyx_v_num_threads};
-    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_2, __pyx_temp+1-__pyx_t_7, 8+__pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 221, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_2, __pyx_temp+1-__pyx_t_7, 8+__pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -19458,7 +20117,7 @@ static PyObject *__pyx_pf_8implicit_4_als_8calculate_loss(CYTHON_UNUSED PyObject
   } else
   #endif
   {
-    __pyx_t_8 = PyTuple_New(8+__pyx_t_7); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 221, __pyx_L1_error)
+    __pyx_t_8 = PyTuple_New(8+__pyx_t_7); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 235, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
     if (__pyx_t_6) {
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_8, 0, __pyx_t_6); __pyx_t_6 = NULL;
@@ -19487,7 +20146,7 @@ static PyObject *__pyx_pf_8implicit_4_als_8calculate_loss(CYTHON_UNUSED PyObject
     __pyx_t_3 = 0;
     __pyx_t_4 = 0;
     __pyx_t_5 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_8, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 221, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_8, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
   }
@@ -19496,7 +20155,7 @@ static PyObject *__pyx_pf_8implicit_4_als_8calculate_loss(CYTHON_UNUSED PyObject
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "implicit/_als.pyx":220
+  /* "implicit/_als.pyx":234
  * 
  * 
  * def calculate_loss(Cui, X, Y, regularization, num_threads=0):             # <<<<<<<<<<<<<<
@@ -19521,7 +20180,7 @@ static PyObject *__pyx_pf_8implicit_4_als_8calculate_loss(CYTHON_UNUSED PyObject
   return __pyx_r;
 }
 
-/* "implicit/_als.pyx":227
+/* "implicit/_als.pyx":241
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _calculate_loss(Cui, integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
@@ -19567,23 +20226,23 @@ static PyObject *__pyx_pw_8implicit_4_als_11_calculate_loss(PyObject *__pyx_self
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_args)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 1); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 1); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_kwargs)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 2); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 2); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_defaults)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 3); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, 3); __PYX_ERR(0, 241, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__pyx_fused_cpdef") < 0)) __PYX_ERR(0, 227, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__pyx_fused_cpdef") < 0)) __PYX_ERR(0, 241, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 4) {
       goto __pyx_L5_argtuple_error;
@@ -19600,7 +20259,7 @@ static PyObject *__pyx_pw_8implicit_4_als_11_calculate_loss(PyObject *__pyx_self
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 227, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__pyx_fused_cpdef", 1, 4, 4, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 241, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("implicit._als.__pyx_fused_cpdef", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -19660,7 +20319,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
   int __pyx_t_19;
   __Pyx_RefNannySetupContext("_calculate_loss", 0);
   __Pyx_INCREF(__pyx_v_kwargs);
-  __pyx_t_1 = PyList_New(1 * 2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_1 = PyList_New(1 * 2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   { Py_ssize_t __pyx_temp;
     for (__pyx_temp=0; __pyx_temp < 2; __pyx_temp++) {
@@ -19678,7 +20337,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
     __pyx_t_2 = __pyx_t_4;
     goto __pyx_L4_bool_binop_done;
   }
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_kwargs); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_kwargs); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
   __pyx_t_3 = ((!__pyx_t_4) != 0);
   __pyx_t_2 = __pyx_t_3;
   __pyx_L4_bool_binop_done:;
@@ -19686,7 +20345,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
     __Pyx_INCREF(Py_None);
     __Pyx_DECREF_SET(__pyx_v_kwargs, Py_None);
   }
-  __pyx_t_1 = ((PyObject *)__Pyx_ImportNumPyArrayTypeIfAvailable()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_1 = ((PyObject *)__Pyx_ImportNumPyArrayTypeIfAvailable()); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_ndarray = ((PyTypeObject*)__pyx_t_1);
   __pyx_t_1 = 0;
@@ -19697,14 +20356,14 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_long_is_signed = (((long)-1L) < 0);
   if (unlikely(__pyx_v_args == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 227, __pyx_L1_error)
+    __PYX_ERR(0, 241, __pyx_L1_error)
   }
-  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __pyx_t_2 = ((1 < __pyx_t_5) != 0);
   if (__pyx_t_2) {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 227, __pyx_L1_error)
+      __PYX_ERR(0, 241, __pyx_L1_error)
     }
     __pyx_t_1 = PyTuple_GET_ITEM(((PyObject*)__pyx_v_args), 1);
     __Pyx_INCREF(__pyx_t_1);
@@ -19721,18 +20380,18 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
   }
   if (unlikely(__pyx_v_kwargs == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 227, __pyx_L1_error)
+    __PYX_ERR(0, 241, __pyx_L1_error)
   }
-  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_indptr, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_indptr, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
   __pyx_t_3 = (__pyx_t_4 != 0);
   __pyx_t_2 = __pyx_t_3;
   __pyx_L7_bool_binop_done:;
   if (__pyx_t_2) {
     if (unlikely(__pyx_v_kwargs == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 227, __pyx_L1_error)
+      __PYX_ERR(0, 241, __pyx_L1_error)
     }
-    __pyx_t_1 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_indptr); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_indptr); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_v_arg = __pyx_t_1;
     __pyx_t_1 = 0;
@@ -19741,12 +20400,12 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
   /*else*/ {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 227, __pyx_L1_error)
+      __PYX_ERR(0, 241, __pyx_L1_error)
     }
-    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 227, __pyx_L1_error)
-    __pyx_t_1 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 241, __pyx_L1_error)
+    __pyx_t_1 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_INCREF(__pyx_int_7);
     __Pyx_GIVEREF(__pyx_int_7);
@@ -19757,20 +20416,20 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
     __Pyx_GIVEREF(__pyx_t_1);
     PyTuple_SET_ITEM(__pyx_t_6, 2, __pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_GIVEREF(__pyx_t_1);
     PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_6, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_6, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_Raise(__pyx_t_1, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __PYX_ERR(0, 227, __pyx_L1_error)
+    __PYX_ERR(0, 241, __pyx_L1_error)
   }
   __pyx_L6:;
   while (1) {
@@ -19780,7 +20439,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
       __pyx_t_3 = __Pyx_TypeCheck(__pyx_v_arg, __pyx_v_ndarray); 
       __pyx_t_2 = (__pyx_t_3 != 0);
       if (__pyx_t_2) {
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __pyx_v_dtype = __pyx_t_1;
         __pyx_t_1 = 0;
@@ -19790,14 +20449,14 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
       __pyx_t_2 = __pyx_memoryview_check(__pyx_v_arg); 
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __pyx_v_arg_base = __pyx_t_1;
         __pyx_t_1 = 0;
         __pyx_t_3 = __Pyx_TypeCheck(__pyx_v_arg_base, __pyx_v_ndarray); 
         __pyx_t_2 = (__pyx_t_3 != 0);
         if (__pyx_t_2) {
-          __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
           __pyx_v_dtype = __pyx_t_1;
           __pyx_t_1 = 0;
@@ -19819,21 +20478,21 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
       __pyx_t_2 = (__pyx_v_dtype != Py_None);
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_1); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_1); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __pyx_v_itemsize = __pyx_t_5;
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_1); if (unlikely(__pyx_t_7 == (long)(Py_UCS4)-1)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_1); if (unlikely(__pyx_t_7 == (long)(Py_UCS4)-1)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __pyx_v_kind = __pyx_t_7;
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_byteorder); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_byteorder); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __pyx_v_byteorder = __pyx_t_1;
         __pyx_t_1 = 0;
-        __pyx_t_2 = (__Pyx_PyString_Equals(__pyx_v_byteorder, __pyx_kp_s__2, Py_EQ)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_2 = (__Pyx_PyString_Equals(__pyx_v_byteorder, __pyx_kp_s__2, Py_EQ)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
         if (__pyx_t_2) {
         } else {
           __pyx_t_3 = __pyx_t_2;
@@ -19846,7 +20505,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
         if (__pyx_t_3) {
           __pyx_v_arg_is_pythran_compatible = 0;
         }
-        __pyx_t_2 = (__Pyx_PyString_Equals(__pyx_v_byteorder, __pyx_kp_s__3, Py_EQ)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_2 = (__Pyx_PyString_Equals(__pyx_v_byteorder, __pyx_kp_s__3, Py_EQ)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
         if (__pyx_t_2) {
         } else {
           __pyx_t_3 = __pyx_t_2;
@@ -19862,31 +20521,31 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
         __pyx_v_dtype_signed = (__pyx_v_kind == 'i');
         __pyx_t_3 = (__pyx_v_arg_is_pythran_compatible != 0);
         if (__pyx_t_3) {
-          __pyx_t_1 = PyInt_FromSsize_t(__pyx_v_itemsize); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_1 = PyInt_FromSsize_t(__pyx_v_itemsize); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
           __pyx_v_cur_stride = __pyx_t_1;
           __pyx_t_1 = 0;
-          __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_shape); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_shape); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
-          __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __Pyx_GIVEREF(__pyx_t_1);
           PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_1);
           __pyx_t_1 = 0;
-          __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_reversed, __pyx_t_6, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_PyObject_Call(__pyx_builtin_reversed, __pyx_t_6, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_strides); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_strides); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
-          __pyx_t_9 = PyTuple_New(1); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_9 = PyTuple_New(1); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
           __Pyx_GIVEREF(__pyx_t_6);
           PyTuple_SET_ITEM(__pyx_t_9, 0, __pyx_t_6);
           __pyx_t_6 = 0;
-          __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_reversed, __pyx_t_9, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_reversed, __pyx_t_9, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
-          __pyx_t_9 = PyTuple_New(2); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_9 = PyTuple_New(2); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
           __Pyx_GIVEREF(__pyx_t_1);
           PyTuple_SET_ITEM(__pyx_t_9, 0, __pyx_t_1);
@@ -19894,16 +20553,16 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
           PyTuple_SET_ITEM(__pyx_t_9, 1, __pyx_t_6);
           __pyx_t_1 = 0;
           __pyx_t_6 = 0;
-          __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_zip, __pyx_t_9, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_zip, __pyx_t_9, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
           if (likely(PyList_CheckExact(__pyx_t_6)) || PyTuple_CheckExact(__pyx_t_6)) {
             __pyx_t_9 = __pyx_t_6; __Pyx_INCREF(__pyx_t_9); __pyx_t_5 = 0;
             __pyx_t_10 = NULL;
           } else {
-            __pyx_t_5 = -1; __pyx_t_9 = PyObject_GetIter(__pyx_t_6); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_5 = -1; __pyx_t_9 = PyObject_GetIter(__pyx_t_6); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_9);
-            __pyx_t_10 = Py_TYPE(__pyx_t_9)->tp_iternext; if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_10 = Py_TYPE(__pyx_t_9)->tp_iternext; if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 241, __pyx_L1_error)
           }
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
           for (;;) {
@@ -19911,17 +20570,17 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
               if (likely(PyList_CheckExact(__pyx_t_9))) {
                 if (__pyx_t_5 >= PyList_GET_SIZE(__pyx_t_9)) break;
                 #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-                __pyx_t_6 = PyList_GET_ITEM(__pyx_t_9, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+                __pyx_t_6 = PyList_GET_ITEM(__pyx_t_9, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
                 #else
-                __pyx_t_6 = PySequence_ITEM(__pyx_t_9, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+                __pyx_t_6 = PySequence_ITEM(__pyx_t_9, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
                 __Pyx_GOTREF(__pyx_t_6);
                 #endif
               } else {
                 if (__pyx_t_5 >= PyTuple_GET_SIZE(__pyx_t_9)) break;
                 #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-                __pyx_t_6 = PyTuple_GET_ITEM(__pyx_t_9, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+                __pyx_t_6 = PyTuple_GET_ITEM(__pyx_t_9, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
                 #else
-                __pyx_t_6 = PySequence_ITEM(__pyx_t_9, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+                __pyx_t_6 = PySequence_ITEM(__pyx_t_9, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
                 __Pyx_GOTREF(__pyx_t_6);
                 #endif
               }
@@ -19931,7 +20590,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
                 PyObject* exc_type = PyErr_Occurred();
                 if (exc_type) {
                   if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-                  else __PYX_ERR(0, 227, __pyx_L1_error)
+                  else __PYX_ERR(0, 241, __pyx_L1_error)
                 }
                 break;
               }
@@ -19947,7 +20606,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
               if (unlikely(size != 2)) {
                 if (size > 2) __Pyx_RaiseTooManyValuesError(2);
                 else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-                __PYX_ERR(0, 227, __pyx_L1_error)
+                __PYX_ERR(0, 241, __pyx_L1_error)
               }
               #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
               if (likely(PyTuple_CheckExact(sequence))) {
@@ -19960,15 +20619,15 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
               __Pyx_INCREF(__pyx_t_1);
               __Pyx_INCREF(__pyx_t_11);
               #else
-              __pyx_t_1 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+              __pyx_t_1 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_1);
-              __pyx_t_11 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+              __pyx_t_11 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_11);
               #endif
               __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
             } else {
               Py_ssize_t index = -1;
-              __pyx_t_12 = PyObject_GetIter(__pyx_t_6); if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 227, __pyx_L1_error)
+              __pyx_t_12 = PyObject_GetIter(__pyx_t_6); if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 241, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_12);
               __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
               __pyx_t_13 = Py_TYPE(__pyx_t_12)->tp_iternext;
@@ -19976,7 +20635,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
               __Pyx_GOTREF(__pyx_t_1);
               index = 1; __pyx_t_11 = __pyx_t_13(__pyx_t_12); if (unlikely(!__pyx_t_11)) goto __pyx_L24_unpacking_failed;
               __Pyx_GOTREF(__pyx_t_11);
-              if (__Pyx_IternextUnpackEndCheck(__pyx_t_13(__pyx_t_12), 2) < 0) __PYX_ERR(0, 227, __pyx_L1_error)
+              if (__Pyx_IternextUnpackEndCheck(__pyx_t_13(__pyx_t_12), 2) < 0) __PYX_ERR(0, 241, __pyx_L1_error)
               __pyx_t_13 = NULL;
               __Pyx_DECREF(__pyx_t_12); __pyx_t_12 = 0;
               goto __pyx_L25_unpacking_done;
@@ -19984,43 +20643,43 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
               __Pyx_DECREF(__pyx_t_12); __pyx_t_12 = 0;
               __pyx_t_13 = NULL;
               if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-              __PYX_ERR(0, 227, __pyx_L1_error)
+              __PYX_ERR(0, 241, __pyx_L1_error)
               __pyx_L25_unpacking_done:;
             }
             __Pyx_XDECREF_SET(__pyx_v_dim, __pyx_t_1);
             __pyx_t_1 = 0;
             __Pyx_XDECREF_SET(__pyx_v_stride, __pyx_t_11);
             __pyx_t_11 = 0;
-            __pyx_t_6 = PyObject_RichCompare(__pyx_v_stride, __pyx_v_cur_stride, Py_NE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
-            __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_6 = PyObject_RichCompare(__pyx_v_stride, __pyx_v_cur_stride, Py_NE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
+            __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
             if (__pyx_t_3) {
               __pyx_v_arg_is_pythran_compatible = 0;
               goto __pyx_L23_break;
             }
-            __pyx_t_6 = PyNumber_InPlaceMultiply(__pyx_v_cur_stride, __pyx_v_dim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_6 = PyNumber_InPlaceMultiply(__pyx_v_cur_stride, __pyx_v_dim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_6);
             __Pyx_DECREF_SET(__pyx_v_cur_stride, __pyx_t_6);
             __pyx_t_6 = 0;
           }
           /*else*/ {
-            __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_flags); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_flags); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_6);
-            __pyx_t_11 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_f_contiguous); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_11 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_f_contiguous); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_11);
             __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-            __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_11); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_11); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
             if (__pyx_t_2) {
             } else {
               __pyx_t_3 = __pyx_t_2;
               goto __pyx_L28_bool_binop_done;
             }
-            __pyx_t_11 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_11 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_11);
-            __pyx_t_6 = PyObject_RichCompare(__pyx_t_11, __pyx_int_1, Py_GT); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_6 = PyObject_RichCompare(__pyx_t_11, __pyx_int_1, Py_GT); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
-            __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
             __pyx_t_3 = __pyx_t_2;
             __pyx_L28_bool_binop_done:;
@@ -20038,9 +20697,9 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
             __pyx_t_3 = __pyx_t_2;
             goto __pyx_L31_bool_binop_done;
           }
-          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_9); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_9); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
           __pyx_t_2 = ((((Py_ssize_t)__pyx_t_5) == 1) != 0);
           if (__pyx_t_2) {
@@ -20052,7 +20711,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
           __pyx_t_3 = __pyx_t_2;
           __pyx_L31_bool_binop_done:;
           if (__pyx_t_3) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_short, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_short, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
             goto __pyx_L10_break;
           }
           __pyx_t_2 = (((sizeof(int)) == __pyx_v_itemsize) != 0);
@@ -20061,9 +20720,9 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
             __pyx_t_3 = __pyx_t_2;
             goto __pyx_L35_bool_binop_done;
           }
-          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_9); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_9); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
           __pyx_t_2 = ((((Py_ssize_t)__pyx_t_5) == 1) != 0);
           if (__pyx_t_2) {
@@ -20075,7 +20734,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
           __pyx_t_3 = __pyx_t_2;
           __pyx_L35_bool_binop_done:;
           if (__pyx_t_3) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_int, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_int, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
             goto __pyx_L10_break;
           }
           __pyx_t_2 = (((sizeof(long)) == __pyx_v_itemsize) != 0);
@@ -20084,9 +20743,9 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
             __pyx_t_3 = __pyx_t_2;
             goto __pyx_L39_bool_binop_done;
           }
-          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_9); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_9); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
           __pyx_t_2 = ((((Py_ssize_t)__pyx_t_5) == 1) != 0);
           if (__pyx_t_2) {
@@ -20098,7 +20757,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
           __pyx_t_3 = __pyx_t_2;
           __pyx_L39_bool_binop_done:;
           if (__pyx_t_3) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_long, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_long, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
             goto __pyx_L10_break;
           }
           break;
@@ -20127,7 +20786,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
       __pyx_t_3 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_3) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_short, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_short, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
         goto __pyx_L10_break;
       }
       /*else*/ {
@@ -20149,7 +20808,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
       __pyx_t_3 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_3) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_int, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_int, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
         goto __pyx_L10_break;
       }
       /*else*/ {
@@ -20171,27 +20830,27 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
       __pyx_t_3 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_3) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_long, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, __pyx_n_s_long, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
         goto __pyx_L10_break;
       }
       /*else*/ {
         PyErr_Clear(); 
       }
     }
-    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
     goto __pyx_L10_break;
   }
   __pyx_L10_break:;
   if (unlikely(__pyx_v_args == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 227, __pyx_L1_error)
+    __PYX_ERR(0, 241, __pyx_L1_error)
   }
-  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __pyx_t_3 = ((4 < __pyx_t_5) != 0);
   if (__pyx_t_3) {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 227, __pyx_L1_error)
+      __PYX_ERR(0, 241, __pyx_L1_error)
     }
     __pyx_t_9 = PyTuple_GET_ITEM(((PyObject*)__pyx_v_args), 4);
     __Pyx_INCREF(__pyx_t_9);
@@ -20208,18 +20867,18 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
   }
   if (unlikely(__pyx_v_kwargs == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 227, __pyx_L1_error)
+    __PYX_ERR(0, 241, __pyx_L1_error)
   }
-  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_X, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_4 = (__Pyx_PyDict_ContainsTF(__pyx_n_s_X, ((PyObject*)__pyx_v_kwargs), Py_EQ)); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
   __pyx_t_2 = (__pyx_t_4 != 0);
   __pyx_t_3 = __pyx_t_2;
   __pyx_L55_bool_binop_done:;
   if (__pyx_t_3) {
     if (unlikely(__pyx_v_kwargs == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 227, __pyx_L1_error)
+      __PYX_ERR(0, 241, __pyx_L1_error)
     }
-    __pyx_t_9 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_X); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_9 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_kwargs), __pyx_n_s_X); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
     __Pyx_DECREF_SET(__pyx_v_arg, __pyx_t_9);
     __pyx_t_9 = 0;
@@ -20228,12 +20887,12 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
   /*else*/ {
     if (unlikely(__pyx_v_args == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 227, __pyx_L1_error)
+      __PYX_ERR(0, 241, __pyx_L1_error)
     }
-    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 227, __pyx_L1_error)
-    __pyx_t_9 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_5 = PyTuple_GET_SIZE(((PyObject*)__pyx_v_args)); if (unlikely(__pyx_t_5 == -1)) __PYX_ERR(0, 241, __pyx_L1_error)
+    __pyx_t_9 = PyInt_FromSsize_t(__pyx_t_5); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
-    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_6 = PyTuple_New(3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_INCREF(__pyx_int_7);
     __Pyx_GIVEREF(__pyx_int_7);
@@ -20244,20 +20903,20 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
     __Pyx_GIVEREF(__pyx_t_9);
     PyTuple_SET_ITEM(__pyx_t_6, 2, __pyx_t_9);
     __pyx_t_9 = 0;
-    __pyx_t_9 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_9 = __Pyx_PyString_Format(__pyx_kp_s_Expected_at_least_d_argument_s_g, __pyx_t_6); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_GIVEREF(__pyx_t_9);
     PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_9);
     __pyx_t_9 = 0;
-    __pyx_t_9 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_6, NULL); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_9 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_6, NULL); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_Raise(__pyx_t_9, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
-    __PYX_ERR(0, 227, __pyx_L1_error)
+    __PYX_ERR(0, 241, __pyx_L1_error)
   }
   __pyx_L54:;
   while (1) {
@@ -20267,7 +20926,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
       __pyx_t_2 = __Pyx_TypeCheck(__pyx_v_arg, __pyx_v_ndarray); 
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_dtype); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_9);
         __Pyx_XDECREF_SET(__pyx_v_dtype, __pyx_t_9);
         __pyx_t_9 = 0;
@@ -20277,14 +20936,14 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
       __pyx_t_3 = __pyx_memoryview_check(__pyx_v_arg); 
       __pyx_t_2 = (__pyx_t_3 != 0);
       if (__pyx_t_2) {
-        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_base); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_9);
         __Pyx_XDECREF_SET(__pyx_v_arg_base, __pyx_t_9);
         __pyx_t_9 = 0;
         __pyx_t_2 = __Pyx_TypeCheck(__pyx_v_arg_base, __pyx_v_ndarray); 
         __pyx_t_3 = (__pyx_t_2 != 0);
         if (__pyx_t_3) {
-          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg_base, __pyx_n_s_dtype); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
           __Pyx_XDECREF_SET(__pyx_v_dtype, __pyx_t_9);
           __pyx_t_9 = 0;
@@ -20306,21 +20965,21 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
       __pyx_t_3 = (__pyx_v_dtype != Py_None);
       __pyx_t_2 = (__pyx_t_3 != 0);
       if (__pyx_t_2) {
-        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_itemsize); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_9);
-        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_9); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_9); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
         __pyx_v_itemsize = __pyx_t_5;
-        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_kind); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_9);
-        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_9); if (unlikely(__pyx_t_7 == (long)(Py_UCS4)-1)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_7 = __Pyx_PyObject_Ord(__pyx_t_9); if (unlikely(__pyx_t_7 == (long)(Py_UCS4)-1)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
         __pyx_v_kind = __pyx_t_7;
-        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_byteorder); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_dtype, __pyx_n_s_byteorder); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_9);
         __Pyx_XDECREF_SET(__pyx_v_byteorder, __pyx_t_9);
         __pyx_t_9 = 0;
-        __pyx_t_3 = (__Pyx_PyString_Equals(__pyx_v_byteorder, __pyx_kp_s__2, Py_EQ)); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_3 = (__Pyx_PyString_Equals(__pyx_v_byteorder, __pyx_kp_s__2, Py_EQ)); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
         if (__pyx_t_3) {
         } else {
           __pyx_t_2 = __pyx_t_3;
@@ -20333,7 +20992,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
         if (__pyx_t_2) {
           __pyx_v_arg_is_pythran_compatible = 0;
         }
-        __pyx_t_3 = (__Pyx_PyString_Equals(__pyx_v_byteorder, __pyx_kp_s__3, Py_EQ)); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_3 = (__Pyx_PyString_Equals(__pyx_v_byteorder, __pyx_kp_s__3, Py_EQ)); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
         if (__pyx_t_3) {
         } else {
           __pyx_t_2 = __pyx_t_3;
@@ -20349,31 +21008,31 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
         __pyx_v_dtype_signed = (__pyx_v_kind == 'i');
         __pyx_t_2 = (__pyx_v_arg_is_pythran_compatible != 0);
         if (__pyx_t_2) {
-          __pyx_t_9 = PyInt_FromSsize_t(__pyx_v_itemsize); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_9 = PyInt_FromSsize_t(__pyx_v_itemsize); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
           __Pyx_XDECREF_SET(__pyx_v_cur_stride, __pyx_t_9);
           __pyx_t_9 = 0;
-          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_shape); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_shape); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
-          __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __Pyx_GIVEREF(__pyx_t_9);
           PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_9);
           __pyx_t_9 = 0;
-          __pyx_t_9 = __Pyx_PyObject_Call(__pyx_builtin_reversed, __pyx_t_6, NULL); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_9 = __Pyx_PyObject_Call(__pyx_builtin_reversed, __pyx_t_6, NULL); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_strides); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_strides); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
-          __pyx_t_11 = PyTuple_New(1); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_11 = PyTuple_New(1); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_11);
           __Pyx_GIVEREF(__pyx_t_6);
           PyTuple_SET_ITEM(__pyx_t_11, 0, __pyx_t_6);
           __pyx_t_6 = 0;
-          __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_reversed, __pyx_t_11, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_reversed, __pyx_t_11, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
-          __pyx_t_11 = PyTuple_New(2); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_11 = PyTuple_New(2); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_11);
           __Pyx_GIVEREF(__pyx_t_9);
           PyTuple_SET_ITEM(__pyx_t_11, 0, __pyx_t_9);
@@ -20381,16 +21040,16 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
           PyTuple_SET_ITEM(__pyx_t_11, 1, __pyx_t_6);
           __pyx_t_9 = 0;
           __pyx_t_6 = 0;
-          __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_zip, __pyx_t_11, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_zip, __pyx_t_11, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_6);
           __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
           if (likely(PyList_CheckExact(__pyx_t_6)) || PyTuple_CheckExact(__pyx_t_6)) {
             __pyx_t_11 = __pyx_t_6; __Pyx_INCREF(__pyx_t_11); __pyx_t_5 = 0;
             __pyx_t_10 = NULL;
           } else {
-            __pyx_t_5 = -1; __pyx_t_11 = PyObject_GetIter(__pyx_t_6); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_5 = -1; __pyx_t_11 = PyObject_GetIter(__pyx_t_6); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_11);
-            __pyx_t_10 = Py_TYPE(__pyx_t_11)->tp_iternext; if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_10 = Py_TYPE(__pyx_t_11)->tp_iternext; if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 241, __pyx_L1_error)
           }
           __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
           for (;;) {
@@ -20398,17 +21057,17 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
               if (likely(PyList_CheckExact(__pyx_t_11))) {
                 if (__pyx_t_5 >= PyList_GET_SIZE(__pyx_t_11)) break;
                 #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-                __pyx_t_6 = PyList_GET_ITEM(__pyx_t_11, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+                __pyx_t_6 = PyList_GET_ITEM(__pyx_t_11, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
                 #else
-                __pyx_t_6 = PySequence_ITEM(__pyx_t_11, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+                __pyx_t_6 = PySequence_ITEM(__pyx_t_11, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
                 __Pyx_GOTREF(__pyx_t_6);
                 #endif
               } else {
                 if (__pyx_t_5 >= PyTuple_GET_SIZE(__pyx_t_11)) break;
                 #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-                __pyx_t_6 = PyTuple_GET_ITEM(__pyx_t_11, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+                __pyx_t_6 = PyTuple_GET_ITEM(__pyx_t_11, __pyx_t_5); __Pyx_INCREF(__pyx_t_6); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
                 #else
-                __pyx_t_6 = PySequence_ITEM(__pyx_t_11, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+                __pyx_t_6 = PySequence_ITEM(__pyx_t_11, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
                 __Pyx_GOTREF(__pyx_t_6);
                 #endif
               }
@@ -20418,7 +21077,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
                 PyObject* exc_type = PyErr_Occurred();
                 if (exc_type) {
                   if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-                  else __PYX_ERR(0, 227, __pyx_L1_error)
+                  else __PYX_ERR(0, 241, __pyx_L1_error)
                 }
                 break;
               }
@@ -20434,7 +21093,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
               if (unlikely(size != 2)) {
                 if (size > 2) __Pyx_RaiseTooManyValuesError(2);
                 else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-                __PYX_ERR(0, 227, __pyx_L1_error)
+                __PYX_ERR(0, 241, __pyx_L1_error)
               }
               #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
               if (likely(PyTuple_CheckExact(sequence))) {
@@ -20447,15 +21106,15 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
               __Pyx_INCREF(__pyx_t_9);
               __Pyx_INCREF(__pyx_t_1);
               #else
-              __pyx_t_9 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+              __pyx_t_9 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_9);
-              __pyx_t_1 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+              __pyx_t_1 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_1);
               #endif
               __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
             } else {
               Py_ssize_t index = -1;
-              __pyx_t_12 = PyObject_GetIter(__pyx_t_6); if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 227, __pyx_L1_error)
+              __pyx_t_12 = PyObject_GetIter(__pyx_t_6); if (unlikely(!__pyx_t_12)) __PYX_ERR(0, 241, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_12);
               __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
               __pyx_t_13 = Py_TYPE(__pyx_t_12)->tp_iternext;
@@ -20463,7 +21122,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
               __Pyx_GOTREF(__pyx_t_9);
               index = 1; __pyx_t_1 = __pyx_t_13(__pyx_t_12); if (unlikely(!__pyx_t_1)) goto __pyx_L72_unpacking_failed;
               __Pyx_GOTREF(__pyx_t_1);
-              if (__Pyx_IternextUnpackEndCheck(__pyx_t_13(__pyx_t_12), 2) < 0) __PYX_ERR(0, 227, __pyx_L1_error)
+              if (__Pyx_IternextUnpackEndCheck(__pyx_t_13(__pyx_t_12), 2) < 0) __PYX_ERR(0, 241, __pyx_L1_error)
               __pyx_t_13 = NULL;
               __Pyx_DECREF(__pyx_t_12); __pyx_t_12 = 0;
               goto __pyx_L73_unpacking_done;
@@ -20471,43 +21130,43 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
               __Pyx_DECREF(__pyx_t_12); __pyx_t_12 = 0;
               __pyx_t_13 = NULL;
               if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-              __PYX_ERR(0, 227, __pyx_L1_error)
+              __PYX_ERR(0, 241, __pyx_L1_error)
               __pyx_L73_unpacking_done:;
             }
             __Pyx_XDECREF_SET(__pyx_v_dim, __pyx_t_9);
             __pyx_t_9 = 0;
             __Pyx_XDECREF_SET(__pyx_v_stride, __pyx_t_1);
             __pyx_t_1 = 0;
-            __pyx_t_6 = PyObject_RichCompare(__pyx_v_stride, __pyx_v_cur_stride, Py_NE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
-            __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_6 = PyObject_RichCompare(__pyx_v_stride, __pyx_v_cur_stride, Py_NE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
+            __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
             if (__pyx_t_2) {
               __pyx_v_arg_is_pythran_compatible = 0;
               goto __pyx_L71_break;
             }
-            __pyx_t_6 = PyNumber_InPlaceMultiply(__pyx_v_cur_stride, __pyx_v_dim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_6 = PyNumber_InPlaceMultiply(__pyx_v_cur_stride, __pyx_v_dim); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_6);
             __Pyx_DECREF_SET(__pyx_v_cur_stride, __pyx_t_6);
             __pyx_t_6 = 0;
           }
           /*else*/ {
-            __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_flags); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_flags); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_6);
-            __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_f_contiguous); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_f_contiguous); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_1);
             __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-            __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
             if (__pyx_t_3) {
             } else {
               __pyx_t_2 = __pyx_t_3;
               goto __pyx_L76_bool_binop_done;
             }
-            __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_1);
-            __pyx_t_6 = PyObject_RichCompare(__pyx_t_1, __pyx_int_1, Py_GT); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_6 = PyObject_RichCompare(__pyx_t_1, __pyx_int_1, Py_GT); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-            __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+            __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
             __pyx_t_2 = __pyx_t_3;
             __pyx_L76_bool_binop_done:;
@@ -20527,15 +21186,15 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
             __pyx_t_2 = __pyx_t_3;
             goto __pyx_L79_bool_binop_done;
           }
-          __pyx_t_11 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_11 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_11);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_11); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_11); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
           __pyx_t_3 = ((((Py_ssize_t)__pyx_t_5) == 2) != 0);
           __pyx_t_2 = __pyx_t_3;
           __pyx_L79_bool_binop_done:;
           if (__pyx_t_2) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
             goto __pyx_L58_break;
           }
           __pyx_t_3 = (((sizeof(double)) == __pyx_v_itemsize) != 0);
@@ -20544,15 +21203,15 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
             __pyx_t_2 = __pyx_t_3;
             goto __pyx_L82_bool_binop_done;
           }
-          __pyx_t_11 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_11 = __Pyx_PyObject_GetAttrStr(__pyx_v_arg, __pyx_n_s_ndim); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_11);
-          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_11); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 227, __pyx_L1_error)
+          __pyx_t_5 = __Pyx_PyIndex_AsSsize_t(__pyx_t_11); if (unlikely((__pyx_t_5 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 241, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
           __pyx_t_3 = ((((Py_ssize_t)__pyx_t_5) == 2) != 0);
           __pyx_t_2 = __pyx_t_3;
           __pyx_L82_bool_binop_done:;
           if (__pyx_t_2) {
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
             goto __pyx_L58_break;
           }
           break;
@@ -20579,7 +21238,7 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
       __pyx_t_2 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_2) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, __pyx_n_s_float, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
         goto __pyx_L58_break;
       }
       /*else*/ {
@@ -20601,27 +21260,27 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
       __pyx_t_2 = (__pyx_v_memslice.memview != 0);
       if (__pyx_t_2) {
         __PYX_XDEC_MEMVIEW((&__pyx_v_memslice), 1); 
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, __pyx_n_s_double, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
         goto __pyx_L58_break;
       }
       /*else*/ {
         PyErr_Clear(); 
       }
     }
-    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+    if (unlikely(__Pyx_SetItemInt(__pyx_v_dest_sig, 1, Py_None, long, 1, __Pyx_PyInt_From_long, 1, 0, 0) < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
     goto __pyx_L58_break;
   }
   __pyx_L58_break:;
-  __pyx_t_11 = PyList_New(0); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_11 = PyList_New(0); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_11);
   __pyx_v_candidates = ((PyObject*)__pyx_t_11);
   __pyx_t_11 = 0;
   __pyx_t_5 = 0;
   if (unlikely(__pyx_v_signatures == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 227, __pyx_L1_error)
+    __PYX_ERR(0, 241, __pyx_L1_error)
   }
-  __pyx_t_6 = __Pyx_dict_iterator(((PyObject*)__pyx_v_signatures), 1, ((PyObject *)NULL), (&__pyx_t_15), (&__pyx_t_8)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_dict_iterator(((PyObject*)__pyx_v_signatures), 1, ((PyObject *)NULL), (&__pyx_t_15), (&__pyx_t_8)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_XDECREF(__pyx_t_11);
   __pyx_t_11 = __pyx_t_6;
@@ -20629,39 +21288,39 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
   while (1) {
     __pyx_t_16 = __Pyx_dict_iter_next(__pyx_t_11, __pyx_t_15, &__pyx_t_5, &__pyx_t_6, NULL, NULL, __pyx_t_8);
     if (unlikely(__pyx_t_16 == 0)) break;
-    if (unlikely(__pyx_t_16 == -1)) __PYX_ERR(0, 227, __pyx_L1_error)
+    if (unlikely(__pyx_t_16 == -1)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_XDECREF_SET(__pyx_v_sig, __pyx_t_6);
     __pyx_t_6 = 0;
     __pyx_v_match_found = 0;
-    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_sig, __pyx_n_s_strip); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_sig, __pyx_n_s_strip); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_tuple__16, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_tuple__16, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_split); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_split); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_tuple__17, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_tuple__17, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_XDECREF_SET(__pyx_v_src_sig, __pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_17 = PyList_GET_SIZE(__pyx_v_dest_sig); if (unlikely(__pyx_t_17 == -1)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_17 = PyList_GET_SIZE(__pyx_v_dest_sig); if (unlikely(__pyx_t_17 == -1)) __PYX_ERR(0, 241, __pyx_L1_error)
     for (__pyx_t_18 = 0; __pyx_t_18 < __pyx_t_17; __pyx_t_18+=1) {
       __pyx_v_i = __pyx_t_18;
-      __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_dest_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 1, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_dest_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 1, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_XDECREF_SET(__pyx_v_dst_type, __pyx_t_1);
       __pyx_t_1 = 0;
       __pyx_t_2 = (__pyx_v_dst_type != Py_None);
       __pyx_t_3 = (__pyx_t_2 != 0);
       if (__pyx_t_3) {
-        __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_src_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_src_sig, __pyx_v_i, Py_ssize_t, 1, PyInt_FromSsize_t, 0, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_6 = PyObject_RichCompare(__pyx_t_1, __pyx_v_dst_type, Py_EQ); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_6 = PyObject_RichCompare(__pyx_t_1, __pyx_v_dst_type, Py_EQ); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
         if (__pyx_t_3) {
           __pyx_v_match_found = 1;
@@ -20677,35 +21336,35 @@ static PyObject *__pyx_pf_8implicit_4_als_10_calculate_loss(CYTHON_UNUSED PyObje
     __pyx_L95_break:;
     __pyx_t_3 = (__pyx_v_match_found != 0);
     if (__pyx_t_3) {
-      __pyx_t_19 = __Pyx_PyList_Append(__pyx_v_candidates, __pyx_v_sig); if (unlikely(__pyx_t_19 == -1)) __PYX_ERR(0, 227, __pyx_L1_error)
+      __pyx_t_19 = __Pyx_PyList_Append(__pyx_v_candidates, __pyx_v_sig); if (unlikely(__pyx_t_19 == -1)) __PYX_ERR(0, 241, __pyx_L1_error)
     }
   }
   __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
   __pyx_t_3 = (__pyx_v_candidates != Py_None) && (PyList_GET_SIZE(__pyx_v_candidates) != 0);
   __pyx_t_2 = ((!__pyx_t_3) != 0);
   if (__pyx_t_2) {
-    __pyx_t_11 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__18, NULL); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_11 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__18, NULL); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_11);
     __Pyx_Raise(__pyx_t_11, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
-    __PYX_ERR(0, 227, __pyx_L1_error)
+    __PYX_ERR(0, 241, __pyx_L1_error)
   }
-  __pyx_t_15 = PyList_GET_SIZE(__pyx_v_candidates); if (unlikely(__pyx_t_15 == -1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_15 = PyList_GET_SIZE(__pyx_v_candidates); if (unlikely(__pyx_t_15 == -1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __pyx_t_2 = ((__pyx_t_15 > 1) != 0);
   if (__pyx_t_2) {
-    __pyx_t_11 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__19, NULL); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_11 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_tuple__19, NULL); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_11);
     __Pyx_Raise(__pyx_t_11, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
-    __PYX_ERR(0, 227, __pyx_L1_error)
+    __PYX_ERR(0, 241, __pyx_L1_error)
   }
   /*else*/ {
     __Pyx_XDECREF(__pyx_r);
     if (unlikely(__pyx_v_signatures == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 227, __pyx_L1_error)
+      __PYX_ERR(0, 241, __pyx_L1_error)
     }
-    __pyx_t_11 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_signatures), PyList_GET_ITEM(__pyx_v_candidates, 0)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+    __pyx_t_11 = __Pyx_PyDict_GetItem(((PyObject*)__pyx_v_signatures), PyList_GET_ITEM(__pyx_v_candidates, 0)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_11);
     __pyx_r = __pyx_t_11;
     __pyx_t_11 = 0;
@@ -20748,14 +21407,14 @@ static PyObject *__pyx_pf_8implicit_4_als_114__defaults__(CYTHON_UNUSED PyObject
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("__defaults__", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults30, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults30, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_2);
   PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_2);
@@ -20830,37 +21489,37 @@ static PyObject *__pyx_fuse_0_0__pyx_pw_8implicit_4_als_41_calculate_loss(PyObje
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indptr)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 1); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 1); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indices)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 2); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 2); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_data)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 3); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 3); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
         if (likely((values[4] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_X)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 4); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 4); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  5:
         if (likely((values[5] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_Y)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 5); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 5); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  6:
         if (likely((values[6] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_regularization)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 6); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 6); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  7:
@@ -20870,7 +21529,7 @@ static PyObject *__pyx_fuse_0_0__pyx_pw_8implicit_4_als_41_calculate_loss(PyObje
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_calculate_loss") < 0)) __PYX_ERR(0, 227, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_calculate_loss") < 0)) __PYX_ERR(0, 241, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -20888,21 +21547,21 @@ static PyObject *__pyx_fuse_0_0__pyx_pw_8implicit_4_als_41_calculate_loss(PyObje
       }
     }
     __pyx_v_Cui = values[0];
-    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_short(values[1]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_short(values[2]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[3]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[4]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 228, __pyx_L3_error)
-    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[5]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 228, __pyx_L3_error)
-    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[6]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 228, __pyx_L3_error)
+    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_short(values[1]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_short(values[2]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[3]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[4]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 242, __pyx_L3_error)
+    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[5]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 242, __pyx_L3_error)
+    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[6]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 242, __pyx_L3_error)
     if (values[7]) {
-      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 229, __pyx_L3_error)
+      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 243, __pyx_L3_error)
     } else {
       __pyx_v_num_threads = __pyx_dynamic_args->__pyx_arg_num_threads;
     }
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 227, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 241, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("implicit._als._calculate_loss", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -20956,7 +21615,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
   int __pyx_t_19;
   Py_ssize_t __pyx_t_20;
   Py_ssize_t __pyx_t_21;
-  Py_ssize_t __pyx_t_22;
+  int __pyx_t_22;
   Py_ssize_t __pyx_t_23;
   Py_ssize_t __pyx_t_24;
   Py_ssize_t __pyx_t_25;
@@ -20972,9 +21631,10 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
   Py_ssize_t __pyx_t_35;
   Py_ssize_t __pyx_t_36;
   Py_ssize_t __pyx_t_37;
+  Py_ssize_t __pyx_t_38;
   __Pyx_RefNannySetupContext("__pyx_fuse_0_0_calculate_loss", 0);
 
-  /* "implicit/_als.pyx":230
+  /* "implicit/_als.pyx":244
  *                     floating[:, :] X, floating[:, :] Y, float regularization,
  *                     int num_threads=0):
  *     dtype = np.float64 if floating is double else np.float32             # <<<<<<<<<<<<<<
@@ -20982,17 +21642,17 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
  *     cdef floating confidence, temp
  */
   if ((0 != 0)) {
-    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_1 = __pyx_t_3;
     __pyx_t_3 = 0;
   } else {
-    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_t_1 = __pyx_t_2;
@@ -21001,7 +21661,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_dtype = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "implicit/_als.pyx":231
+  /* "implicit/_als.pyx":245
  *                     int num_threads=0):
  *     dtype = np.float64 if floating is double else np.float32
  *     cdef int users = X.shape[0], N = X.shape[1], items = Y.shape[0], u, i, index, one = 1             # <<<<<<<<<<<<<<
@@ -21013,7 +21673,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_items = (__pyx_v_Y.shape[0]);
   __pyx_v_one = 1;
 
-  /* "implicit/_als.pyx":233
+  /* "implicit/_als.pyx":247
  *     cdef int users = X.shape[0], N = X.shape[1], items = Y.shape[0], u, i, index, one = 1
  *     cdef floating confidence, temp
  *     cdef floating zero = 0.             # <<<<<<<<<<<<<<
@@ -21022,24 +21682,24 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
  */
   __pyx_v_zero = 0.;
 
-  /* "implicit/_als.pyx":235
+  /* "implicit/_als.pyx":249
  *     cdef floating zero = 0.
  * 
  *     cdef floating[:, :] YtY = np.dot(np.transpose(Y), Y)             # <<<<<<<<<<<<<<
  * 
  *     cdef floating * r
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_6 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -21052,14 +21712,14 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
     }
   }
   if (!__pyx_t_6) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_GOTREF(__pyx_t_2);
   } else {
     #if CYTHON_FAST_PYCALL
     if (PyFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -21068,26 +21728,26 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
     #if CYTHON_FAST_PYCCALL
     if (__Pyx_PyFastCFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     } else
     #endif
     {
-      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_6); __pyx_t_6 = NULL;
       __Pyx_GIVEREF(__pyx_t_4);
       PyTuple_SET_ITEM(__pyx_t_7, 0+1, __pyx_t_4);
       __pyx_t_4 = 0;
-      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     }
   }
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_7 = NULL;
   __pyx_t_8 = 0;
@@ -21104,7 +21764,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -21114,7 +21774,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -21122,7 +21782,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
   } else
   #endif
   {
-    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     if (__pyx_t_7) {
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -21133,19 +21793,19 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
     PyTuple_SET_ITEM(__pyx_t_4, 1+__pyx_t_8, __pyx_t_5);
     __pyx_t_2 = 0;
     __pyx_t_5 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(__pyx_t_1);
-  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 235, __pyx_L1_error)
+  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v_YtY = __pyx_t_9;
   __pyx_t_9.memview = NULL;
   __pyx_t_9.data = NULL;
 
-  /* "implicit/_als.pyx":239
+  /* "implicit/_als.pyx":253
  *     cdef floating * r
  * 
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0             # <<<<<<<<<<<<<<
@@ -21157,7 +21817,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_item_norm = 0.0;
   __pyx_v_user_norm = 0.0;
 
-  /* "implicit/_als.pyx":241
+  /* "implicit/_als.pyx":255
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -21179,13 +21839,13 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
                 #define unlikely(x) (x)
             #endif
             #ifdef _OPENMP
-            #pragma omp parallel private(__pyx_v_r) reduction(+:__pyx_v_loss) reduction(+:__pyx_v_total_confidence) reduction(+:__pyx_v_user_norm) reduction(+:__pyx_v_item_norm) private(__pyx_t_10, __pyx_t_11, __pyx_t_12, __pyx_t_13, __pyx_t_14, __pyx_t_15, __pyx_t_16, __pyx_t_17, __pyx_t_18, __pyx_t_19, __pyx_t_20, __pyx_t_21, __pyx_t_22, __pyx_t_23, __pyx_t_24, __pyx_t_25, __pyx_t_26, __pyx_t_27, __pyx_t_28, __pyx_t_29, __pyx_t_30, __pyx_t_31, __pyx_t_32, __pyx_t_33, __pyx_t_34, __pyx_t_35, __pyx_t_36, __pyx_t_37, __pyx_t_8) num_threads(__pyx_v_num_threads)
+            #pragma omp parallel private(__pyx_v_r) reduction(+:__pyx_v_loss) reduction(+:__pyx_v_total_confidence) reduction(+:__pyx_v_user_norm) reduction(+:__pyx_v_item_norm) private(__pyx_t_10, __pyx_t_11, __pyx_t_12, __pyx_t_13, __pyx_t_14, __pyx_t_15, __pyx_t_16, __pyx_t_17, __pyx_t_18, __pyx_t_19, __pyx_t_20, __pyx_t_21, __pyx_t_22, __pyx_t_23, __pyx_t_24, __pyx_t_25, __pyx_t_26, __pyx_t_27, __pyx_t_28, __pyx_t_29, __pyx_t_30, __pyx_t_31, __pyx_t_32, __pyx_t_33, __pyx_t_34, __pyx_t_35, __pyx_t_36, __pyx_t_37, __pyx_t_38, __pyx_t_8) num_threads(__pyx_v_num_threads)
             #endif /* _OPENMP */
             {
                 /* Initialize private variables to invalid values */
                 __pyx_v_r = ((float *)1);
 
-                /* "implicit/_als.pyx":242
+                /* "implicit/_als.pyx":256
  * 
  *     with nogil, parallel(num_threads=num_threads):
  *         r = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -21194,7 +21854,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
  */
                 __pyx_v_r = ((float *)malloc(((sizeof(float)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":243
+                /* "implicit/_als.pyx":257
  *     with nogil, parallel(num_threads=num_threads):
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:             # <<<<<<<<<<<<<<
@@ -21203,7 +21863,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
  */
                 /*try:*/ {
 
-                  /* "implicit/_als.pyx":244
+                  /* "implicit/_als.pyx":258
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:
  *             for u in prange(users, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -21228,7 +21888,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
                                   __pyx_v_index = ((int)0xbad0bad0);
                                   __pyx_v_temp = ((float)__PYX_NAN());
 
-                                  /* "implicit/_als.pyx":246
+                                  /* "implicit/_als.pyx":260
  *             for u in prange(users, schedule='guided'):
  *                 # calculates (A.dot(Xu) - 2 * b).dot(Xu), without calculating A
  *                 temp = 1.0             # <<<<<<<<<<<<<<
@@ -21237,7 +21897,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
  */
                                   __pyx_v_temp = 1.0;
 
-                                  /* "implicit/_als.pyx":247
+                                  /* "implicit/_als.pyx":261
  *                 # calculates (A.dot(Xu) - 2 * b).dot(Xu), without calculating A
  *                 temp = 1.0
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, &X[u, 0], &one, &zero, r, &one)             # <<<<<<<<<<<<<<
@@ -21254,7 +21914,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
                                   if (__pyx_t_15 < 0) __pyx_t_15 += __pyx_v_X.shape[1];
                                   __pyx_fuse_0__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_12 * __pyx_v_YtY.strides[0]) ) + __pyx_t_13 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_14 * __pyx_v_X.strides[0]) ) + __pyx_t_15 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":249
+                                  /* "implicit/_als.pyx":263
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, &X[u, 0], &one, &zero, r, &one)
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -21269,7 +21929,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
                                   for (__pyx_t_19 = (*((short *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_18 * __pyx_v_indptr.strides[0]) ))); __pyx_t_19 < __pyx_t_17; __pyx_t_19+=1) {
                                     __pyx_v_index = __pyx_t_19;
 
-                                    /* "implicit/_als.pyx":250
+                                    /* "implicit/_als.pyx":264
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]             # <<<<<<<<<<<<<<
@@ -21280,56 +21940,98 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
                                     if (__pyx_t_20 < 0) __pyx_t_20 += __pyx_v_indices.shape[0];
                                     __pyx_v_i = (*((short *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_20 * __pyx_v_indices.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":251
+                                    /* "implicit/_als.pyx":265
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]
  *                     confidence = data[index]             # <<<<<<<<<<<<<<
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
+ *                     if confidence > 0:
  */
                                     __pyx_t_21 = __pyx_v_index;
                                     if (__pyx_t_21 < 0) __pyx_t_21 += __pyx_v_data.shape[0];
                                     __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_21 * __pyx_v_data.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":253
+                                    /* "implicit/_als.pyx":267
  *                     confidence = data[index]
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],             # <<<<<<<<<<<<<<
- *                                                   &one) - 2 * confidence
- *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = -2 * confidence
+ *                     else:
  */
-                                    __pyx_t_22 = __pyx_v_i;
-                                    __pyx_t_23 = 0;
-                                    if (__pyx_t_22 < 0) __pyx_t_22 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_Y.shape[1];
-                                    __pyx_t_24 = __pyx_v_u;
-                                    __pyx_t_25 = 0;
-                                    if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_X.shape[0];
-                                    if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_X.shape[1];
+                                    __pyx_t_22 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_22) {
 
-                                    /* "implicit/_als.pyx":254
+                                      /* "implicit/_als.pyx":268
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
- *                                                   &one) - 2 * confidence             # <<<<<<<<<<<<<<
+ *                     if confidence > 0:
+ *                         temp = -2 * confidence             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         temp = 0
+ */
+                                      __pyx_v_temp = (-2.0 * __pyx_v_confidence);
+
+                                      /* "implicit/_als.pyx":267
+ *                     confidence = data[index]
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = -2 * confidence
+ *                     else:
+ */
+                                      goto __pyx_L21;
+                                    }
+
+                                    /* "implicit/_als.pyx":270
+ *                         temp = -2 * confidence
+ *                     else:
+ *                         temp = 0             # <<<<<<<<<<<<<<
+ *                         confidence = -1 * confidence
+ * 
+ */
+                                    /*else*/ {
+                                      __pyx_v_temp = 0.0;
+
+                                      /* "implicit/_als.pyx":271
+ *                     else:
+ *                         temp = 0
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)
+ */
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L21:;
+
+                                    /* "implicit/_als.pyx":273
+ *                         confidence = -1 * confidence
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  */
-                                    __pyx_v_temp = (((__pyx_v_confidence - 1.0) * __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_22 * __pyx_v_Y.strides[0]) ) + __pyx_t_23 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_24 * __pyx_v_X.strides[0]) ) + __pyx_t_25 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one))) - (2.0 * __pyx_v_confidence));
+                                    __pyx_t_23 = __pyx_v_i;
+                                    __pyx_t_24 = 0;
+                                    if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_Y.shape[0];
+                                    if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_Y.shape[1];
+                                    __pyx_t_25 = __pyx_v_u;
+                                    __pyx_t_26 = 0;
+                                    if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_X.shape[0];
+                                    if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_X.shape[1];
+                                    __pyx_v_temp = (__pyx_v_temp + ((__pyx_v_confidence - 1.0) * __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_23 * __pyx_v_Y.strides[0]) ) + __pyx_t_24 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_25 * __pyx_v_X.strides[0]) ) + __pyx_t_26 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one))));
 
-                                    /* "implicit/_als.pyx":255
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
- *                                                   &one) - 2 * confidence
+                                    /* "implicit/_als.pyx":274
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)             # <<<<<<<<<<<<<<
  * 
  *                     total_confidence += confidence
  */
-                                    __pyx_t_26 = __pyx_v_i;
-                                    __pyx_t_27 = 0;
-                                    if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[1];
-                                    __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_26 * __pyx_v_Y.strides[0]) ) + __pyx_t_27 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
+                                    __pyx_t_27 = __pyx_v_i;
+                                    __pyx_t_28 = 0;
+                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
+                                    if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
+                                    __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":257
+                                    /* "implicit/_als.pyx":276
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  *                     total_confidence += confidence             # <<<<<<<<<<<<<<
@@ -21338,7 +22040,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
  */
                                     __pyx_v_total_confidence = (__pyx_v_total_confidence + __pyx_v_confidence);
 
-                                    /* "implicit/_als.pyx":258
+                                    /* "implicit/_als.pyx":277
  * 
  *                     total_confidence += confidence
  *                     loss += confidence             # <<<<<<<<<<<<<<
@@ -21348,41 +22050,41 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
                                     __pyx_v_loss = (__pyx_v_loss + __pyx_v_confidence);
                                   }
 
-                                  /* "implicit/_als.pyx":260
+                                  /* "implicit/_als.pyx":279
  *                     loss += confidence
  * 
  *                 loss += dot(&N, r, &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)
  * 
  */
-                                  __pyx_t_28 = __pyx_v_u;
-                                  __pyx_t_29 = 0;
-                                  if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_29 < 0) __pyx_t_29 += __pyx_v_X.shape[1];
-                                  __pyx_v_loss = (__pyx_v_loss + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_28 * __pyx_v_X.strides[0]) ) + __pyx_t_29 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_29 = __pyx_v_u;
+                                  __pyx_t_30 = 0;
+                                  if (__pyx_t_29 < 0) __pyx_t_29 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_30 < 0) __pyx_t_30 += __pyx_v_X.shape[1];
+                                  __pyx_v_loss = (__pyx_v_loss + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_29 * __pyx_v_X.strides[0]) ) + __pyx_t_30 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
 
-                                  /* "implicit/_als.pyx":261
+                                  /* "implicit/_als.pyx":280
  * 
  *                 loss += dot(&N, r, &one, &X[u, 0], &one)
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  * 
  *             for i in prange(items, schedule='guided'):
  */
-                                  __pyx_t_30 = __pyx_v_u;
-                                  __pyx_t_31 = 0;
-                                  if (__pyx_t_30 < 0) __pyx_t_30 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_31 < 0) __pyx_t_31 += __pyx_v_X.shape[1];
-                                  __pyx_t_32 = __pyx_v_u;
-                                  __pyx_t_33 = 0;
-                                  if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_33 < 0) __pyx_t_33 += __pyx_v_X.shape[1];
-                                  __pyx_v_user_norm = (__pyx_v_user_norm + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_30 * __pyx_v_X.strides[0]) ) + __pyx_t_31 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_32 * __pyx_v_X.strides[0]) ) + __pyx_t_33 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_31 = __pyx_v_u;
+                                  __pyx_t_32 = 0;
+                                  if (__pyx_t_31 < 0) __pyx_t_31 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_X.shape[1];
+                                  __pyx_t_33 = __pyx_v_u;
+                                  __pyx_t_34 = 0;
+                                  if (__pyx_t_33 < 0) __pyx_t_33 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_34 < 0) __pyx_t_34 += __pyx_v_X.shape[1];
+                                  __pyx_v_user_norm = (__pyx_v_user_norm + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_31 * __pyx_v_X.strides[0]) ) + __pyx_t_32 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_33 * __pyx_v_X.strides[0]) ) + __pyx_t_34 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
                               }
                           }
                       }
                   }
 
-                  /* "implicit/_als.pyx":263
+                  /* "implicit/_als.pyx":282
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)
  * 
  *             for i in prange(items, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -21402,29 +22104,29 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
                               {
                                   __pyx_v_i = (int)(0 + 1 * __pyx_t_10);
 
-                                  /* "implicit/_als.pyx":264
+                                  /* "implicit/_als.pyx":283
  * 
  *             for i in prange(items, schedule='guided'):
  *                 item_norm += dot(&N, &Y[i, 0], &one, &Y[i, 0], &one)             # <<<<<<<<<<<<<<
  * 
  *         finally:
  */
-                                  __pyx_t_34 = __pyx_v_i;
-                                  __pyx_t_35 = 0;
-                                  if (__pyx_t_34 < 0) __pyx_t_34 += __pyx_v_Y.shape[0];
-                                  if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_Y.shape[1];
-                                  __pyx_t_36 = __pyx_v_i;
-                                  __pyx_t_37 = 0;
-                                  if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_Y.shape[0];
-                                  if (__pyx_t_37 < 0) __pyx_t_37 += __pyx_v_Y.shape[1];
-                                  __pyx_v_item_norm = (__pyx_v_item_norm + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_34 * __pyx_v_Y.strides[0]) ) + __pyx_t_35 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_36 * __pyx_v_Y.strides[0]) ) + __pyx_t_37 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_35 = __pyx_v_i;
+                                  __pyx_t_36 = 0;
+                                  if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_Y.shape[0];
+                                  if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_Y.shape[1];
+                                  __pyx_t_37 = __pyx_v_i;
+                                  __pyx_t_38 = 0;
+                                  if (__pyx_t_37 < 0) __pyx_t_37 += __pyx_v_Y.shape[0];
+                                  if (__pyx_t_38 < 0) __pyx_t_38 += __pyx_v_Y.shape[1];
+                                  __pyx_v_item_norm = (__pyx_v_item_norm + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_35 * __pyx_v_Y.strides[0]) ) + __pyx_t_36 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_37 * __pyx_v_Y.strides[0]) ) + __pyx_t_38 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one)));
                               }
                           }
                       }
                   }
                 }
 
-                /* "implicit/_als.pyx":267
+                /* "implicit/_als.pyx":286
  * 
  *         finally:
  *             free(r)             # <<<<<<<<<<<<<<
@@ -21448,7 +22150,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
         #endif
       }
 
-      /* "implicit/_als.pyx":241
+      /* "implicit/_als.pyx":255
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -21467,7 +22169,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
       }
   }
 
-  /* "implicit/_als.pyx":269
+  /* "implicit/_als.pyx":288
  *             free(r)
  * 
  *     loss += regularization * (item_norm + user_norm)             # <<<<<<<<<<<<<<
@@ -21475,41 +22177,41 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
  */
   __pyx_v_loss = (__pyx_v_loss + (__pyx_v_regularization * (__pyx_v_item_norm + __pyx_v_user_norm)));
 
-  /* "implicit/_als.pyx":270
+  /* "implicit/_als.pyx":289
  * 
  *     loss += regularization * (item_norm + user_norm)
  *     return loss / (total_confidence + Cui.shape[0] * Cui.shape[1] - Cui.nnz)             # <<<<<<<<<<<<<<
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyFloat_FromDouble(__pyx_v_loss); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_1 = PyFloat_FromDouble(__pyx_v_loss); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_total_confidence); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_total_confidence); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_GetItemInt(__pyx_t_4, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_GetItemInt(__pyx_t_4, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_4, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_4, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = PyNumber_Multiply(__pyx_t_5, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = PyNumber_Multiply(__pyx_t_5, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = PyNumber_Add(__pyx_t_3, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_2 = PyNumber_Add(__pyx_t_3, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_nnz); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_nnz); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_3 = PyNumber_Subtract(__pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_3 = PyNumber_Subtract(__pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyNumber_Divide(__pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyNumber_Divide(__pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -21517,7 +22219,7 @@ static PyObject *__pyx_pf_8implicit_4_als_40_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_t_4 = 0;
   goto __pyx_L0;
 
-  /* "implicit/_als.pyx":227
+  /* "implicit/_als.pyx":241
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _calculate_loss(Cui, integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
@@ -21557,14 +22259,14 @@ static PyObject *__pyx_pf_8implicit_4_als_116__defaults__(CYTHON_UNUSED PyObject
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("__defaults__", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults31, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults31, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_2);
   PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_2);
@@ -21639,37 +22341,37 @@ static PyObject *__pyx_fuse_0_1__pyx_pw_8implicit_4_als_43_calculate_loss(PyObje
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indptr)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 1); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 1); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indices)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 2); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 2); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_data)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 3); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 3); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
         if (likely((values[4] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_X)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 4); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 4); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  5:
         if (likely((values[5] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_Y)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 5); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 5); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  6:
         if (likely((values[6] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_regularization)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 6); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 6); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  7:
@@ -21679,7 +22381,7 @@ static PyObject *__pyx_fuse_0_1__pyx_pw_8implicit_4_als_43_calculate_loss(PyObje
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_calculate_loss") < 0)) __PYX_ERR(0, 227, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_calculate_loss") < 0)) __PYX_ERR(0, 241, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -21697,21 +22399,21 @@ static PyObject *__pyx_fuse_0_1__pyx_pw_8implicit_4_als_43_calculate_loss(PyObje
       }
     }
     __pyx_v_Cui = values[0];
-    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_short(values[1]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_short(values[2]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[3]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[4]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 228, __pyx_L3_error)
-    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[5]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 228, __pyx_L3_error)
-    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[6]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 228, __pyx_L3_error)
+    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_short(values[1]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_short(values[2]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[3]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[4]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 242, __pyx_L3_error)
+    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[5]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 242, __pyx_L3_error)
+    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[6]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 242, __pyx_L3_error)
     if (values[7]) {
-      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 229, __pyx_L3_error)
+      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 243, __pyx_L3_error)
     } else {
       __pyx_v_num_threads = __pyx_dynamic_args->__pyx_arg_num_threads;
     }
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 227, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 241, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("implicit._als._calculate_loss", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -21765,7 +22467,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
   int __pyx_t_19;
   Py_ssize_t __pyx_t_20;
   Py_ssize_t __pyx_t_21;
-  Py_ssize_t __pyx_t_22;
+  int __pyx_t_22;
   Py_ssize_t __pyx_t_23;
   Py_ssize_t __pyx_t_24;
   Py_ssize_t __pyx_t_25;
@@ -21781,9 +22483,10 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
   Py_ssize_t __pyx_t_35;
   Py_ssize_t __pyx_t_36;
   Py_ssize_t __pyx_t_37;
+  Py_ssize_t __pyx_t_38;
   __Pyx_RefNannySetupContext("__pyx_fuse_0_1_calculate_loss", 0);
 
-  /* "implicit/_als.pyx":230
+  /* "implicit/_als.pyx":244
  *                     floating[:, :] X, floating[:, :] Y, float regularization,
  *                     int num_threads=0):
  *     dtype = np.float64 if floating is double else np.float32             # <<<<<<<<<<<<<<
@@ -21791,17 +22494,17 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
  *     cdef floating confidence, temp
  */
   if ((1 != 0)) {
-    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_1 = __pyx_t_3;
     __pyx_t_3 = 0;
   } else {
-    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_t_1 = __pyx_t_2;
@@ -21810,7 +22513,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_dtype = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "implicit/_als.pyx":231
+  /* "implicit/_als.pyx":245
  *                     int num_threads=0):
  *     dtype = np.float64 if floating is double else np.float32
  *     cdef int users = X.shape[0], N = X.shape[1], items = Y.shape[0], u, i, index, one = 1             # <<<<<<<<<<<<<<
@@ -21822,7 +22525,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_items = (__pyx_v_Y.shape[0]);
   __pyx_v_one = 1;
 
-  /* "implicit/_als.pyx":233
+  /* "implicit/_als.pyx":247
  *     cdef int users = X.shape[0], N = X.shape[1], items = Y.shape[0], u, i, index, one = 1
  *     cdef floating confidence, temp
  *     cdef floating zero = 0.             # <<<<<<<<<<<<<<
@@ -21831,24 +22534,24 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
  */
   __pyx_v_zero = 0.;
 
-  /* "implicit/_als.pyx":235
+  /* "implicit/_als.pyx":249
  *     cdef floating zero = 0.
  * 
  *     cdef floating[:, :] YtY = np.dot(np.transpose(Y), Y)             # <<<<<<<<<<<<<<
  * 
  *     cdef floating * r
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_6 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -21861,14 +22564,14 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
     }
   }
   if (!__pyx_t_6) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_GOTREF(__pyx_t_2);
   } else {
     #if CYTHON_FAST_PYCALL
     if (PyFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -21877,26 +22580,26 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
     #if CYTHON_FAST_PYCCALL
     if (__Pyx_PyFastCFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     } else
     #endif
     {
-      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_6); __pyx_t_6 = NULL;
       __Pyx_GIVEREF(__pyx_t_4);
       PyTuple_SET_ITEM(__pyx_t_7, 0+1, __pyx_t_4);
       __pyx_t_4 = 0;
-      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     }
   }
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_7 = NULL;
   __pyx_t_8 = 0;
@@ -21913,7 +22616,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -21923,7 +22626,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -21931,7 +22634,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
   } else
   #endif
   {
-    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     if (__pyx_t_7) {
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -21942,19 +22645,19 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
     PyTuple_SET_ITEM(__pyx_t_4, 1+__pyx_t_8, __pyx_t_5);
     __pyx_t_2 = 0;
     __pyx_t_5 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(__pyx_t_1);
-  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 235, __pyx_L1_error)
+  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v_YtY = __pyx_t_9;
   __pyx_t_9.memview = NULL;
   __pyx_t_9.data = NULL;
 
-  /* "implicit/_als.pyx":239
+  /* "implicit/_als.pyx":253
  *     cdef floating * r
  * 
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0             # <<<<<<<<<<<<<<
@@ -21966,7 +22669,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_item_norm = 0.0;
   __pyx_v_user_norm = 0.0;
 
-  /* "implicit/_als.pyx":241
+  /* "implicit/_als.pyx":255
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -21988,13 +22691,13 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
                 #define unlikely(x) (x)
             #endif
             #ifdef _OPENMP
-            #pragma omp parallel private(__pyx_v_r) reduction(+:__pyx_v_loss) reduction(+:__pyx_v_total_confidence) reduction(+:__pyx_v_user_norm) reduction(+:__pyx_v_item_norm) private(__pyx_t_10, __pyx_t_11, __pyx_t_12, __pyx_t_13, __pyx_t_14, __pyx_t_15, __pyx_t_16, __pyx_t_17, __pyx_t_18, __pyx_t_19, __pyx_t_20, __pyx_t_21, __pyx_t_22, __pyx_t_23, __pyx_t_24, __pyx_t_25, __pyx_t_26, __pyx_t_27, __pyx_t_28, __pyx_t_29, __pyx_t_30, __pyx_t_31, __pyx_t_32, __pyx_t_33, __pyx_t_34, __pyx_t_35, __pyx_t_36, __pyx_t_37, __pyx_t_8) num_threads(__pyx_v_num_threads)
+            #pragma omp parallel private(__pyx_v_r) reduction(+:__pyx_v_loss) reduction(+:__pyx_v_total_confidence) reduction(+:__pyx_v_user_norm) reduction(+:__pyx_v_item_norm) private(__pyx_t_10, __pyx_t_11, __pyx_t_12, __pyx_t_13, __pyx_t_14, __pyx_t_15, __pyx_t_16, __pyx_t_17, __pyx_t_18, __pyx_t_19, __pyx_t_20, __pyx_t_21, __pyx_t_22, __pyx_t_23, __pyx_t_24, __pyx_t_25, __pyx_t_26, __pyx_t_27, __pyx_t_28, __pyx_t_29, __pyx_t_30, __pyx_t_31, __pyx_t_32, __pyx_t_33, __pyx_t_34, __pyx_t_35, __pyx_t_36, __pyx_t_37, __pyx_t_38, __pyx_t_8) num_threads(__pyx_v_num_threads)
             #endif /* _OPENMP */
             {
                 /* Initialize private variables to invalid values */
                 __pyx_v_r = ((double *)1);
 
-                /* "implicit/_als.pyx":242
+                /* "implicit/_als.pyx":256
  * 
  *     with nogil, parallel(num_threads=num_threads):
  *         r = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -22003,7 +22706,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
  */
                 __pyx_v_r = ((double *)malloc(((sizeof(double)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":243
+                /* "implicit/_als.pyx":257
  *     with nogil, parallel(num_threads=num_threads):
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:             # <<<<<<<<<<<<<<
@@ -22012,7 +22715,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
  */
                 /*try:*/ {
 
-                  /* "implicit/_als.pyx":244
+                  /* "implicit/_als.pyx":258
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:
  *             for u in prange(users, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -22037,7 +22740,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
                                   __pyx_v_index = ((int)0xbad0bad0);
                                   __pyx_v_temp = ((double)__PYX_NAN());
 
-                                  /* "implicit/_als.pyx":246
+                                  /* "implicit/_als.pyx":260
  *             for u in prange(users, schedule='guided'):
  *                 # calculates (A.dot(Xu) - 2 * b).dot(Xu), without calculating A
  *                 temp = 1.0             # <<<<<<<<<<<<<<
@@ -22046,7 +22749,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
  */
                                   __pyx_v_temp = 1.0;
 
-                                  /* "implicit/_als.pyx":247
+                                  /* "implicit/_als.pyx":261
  *                 # calculates (A.dot(Xu) - 2 * b).dot(Xu), without calculating A
  *                 temp = 1.0
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, &X[u, 0], &one, &zero, r, &one)             # <<<<<<<<<<<<<<
@@ -22063,7 +22766,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
                                   if (__pyx_t_15 < 0) __pyx_t_15 += __pyx_v_X.shape[1];
                                   __pyx_fuse_1__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_12 * __pyx_v_YtY.strides[0]) ) + __pyx_t_13 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_14 * __pyx_v_X.strides[0]) ) + __pyx_t_15 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":249
+                                  /* "implicit/_als.pyx":263
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, &X[u, 0], &one, &zero, r, &one)
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -22078,7 +22781,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
                                   for (__pyx_t_19 = (*((short *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_18 * __pyx_v_indptr.strides[0]) ))); __pyx_t_19 < __pyx_t_17; __pyx_t_19+=1) {
                                     __pyx_v_index = __pyx_t_19;
 
-                                    /* "implicit/_als.pyx":250
+                                    /* "implicit/_als.pyx":264
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]             # <<<<<<<<<<<<<<
@@ -22089,56 +22792,98 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
                                     if (__pyx_t_20 < 0) __pyx_t_20 += __pyx_v_indices.shape[0];
                                     __pyx_v_i = (*((short *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_20 * __pyx_v_indices.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":251
+                                    /* "implicit/_als.pyx":265
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]
  *                     confidence = data[index]             # <<<<<<<<<<<<<<
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
+ *                     if confidence > 0:
  */
                                     __pyx_t_21 = __pyx_v_index;
                                     if (__pyx_t_21 < 0) __pyx_t_21 += __pyx_v_data.shape[0];
                                     __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_21 * __pyx_v_data.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":253
+                                    /* "implicit/_als.pyx":267
  *                     confidence = data[index]
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],             # <<<<<<<<<<<<<<
- *                                                   &one) - 2 * confidence
- *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = -2 * confidence
+ *                     else:
  */
-                                    __pyx_t_22 = __pyx_v_i;
-                                    __pyx_t_23 = 0;
-                                    if (__pyx_t_22 < 0) __pyx_t_22 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_Y.shape[1];
-                                    __pyx_t_24 = __pyx_v_u;
-                                    __pyx_t_25 = 0;
-                                    if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_X.shape[0];
-                                    if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_X.shape[1];
+                                    __pyx_t_22 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_22) {
 
-                                    /* "implicit/_als.pyx":254
+                                      /* "implicit/_als.pyx":268
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
- *                                                   &one) - 2 * confidence             # <<<<<<<<<<<<<<
+ *                     if confidence > 0:
+ *                         temp = -2 * confidence             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         temp = 0
+ */
+                                      __pyx_v_temp = (-2.0 * __pyx_v_confidence);
+
+                                      /* "implicit/_als.pyx":267
+ *                     confidence = data[index]
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = -2 * confidence
+ *                     else:
+ */
+                                      goto __pyx_L21;
+                                    }
+
+                                    /* "implicit/_als.pyx":270
+ *                         temp = -2 * confidence
+ *                     else:
+ *                         temp = 0             # <<<<<<<<<<<<<<
+ *                         confidence = -1 * confidence
+ * 
+ */
+                                    /*else*/ {
+                                      __pyx_v_temp = 0.0;
+
+                                      /* "implicit/_als.pyx":271
+ *                     else:
+ *                         temp = 0
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)
+ */
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L21:;
+
+                                    /* "implicit/_als.pyx":273
+ *                         confidence = -1 * confidence
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  */
-                                    __pyx_v_temp = (((__pyx_v_confidence - 1.0) * __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_22 * __pyx_v_Y.strides[0]) ) + __pyx_t_23 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_24 * __pyx_v_X.strides[0]) ) + __pyx_t_25 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one))) - (2.0 * __pyx_v_confidence));
+                                    __pyx_t_23 = __pyx_v_i;
+                                    __pyx_t_24 = 0;
+                                    if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_Y.shape[0];
+                                    if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_Y.shape[1];
+                                    __pyx_t_25 = __pyx_v_u;
+                                    __pyx_t_26 = 0;
+                                    if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_X.shape[0];
+                                    if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_X.shape[1];
+                                    __pyx_v_temp = (__pyx_v_temp + ((__pyx_v_confidence - 1.0) * __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_23 * __pyx_v_Y.strides[0]) ) + __pyx_t_24 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_25 * __pyx_v_X.strides[0]) ) + __pyx_t_26 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one))));
 
-                                    /* "implicit/_als.pyx":255
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
- *                                                   &one) - 2 * confidence
+                                    /* "implicit/_als.pyx":274
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)             # <<<<<<<<<<<<<<
  * 
  *                     total_confidence += confidence
  */
-                                    __pyx_t_26 = __pyx_v_i;
-                                    __pyx_t_27 = 0;
-                                    if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[1];
-                                    __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_26 * __pyx_v_Y.strides[0]) ) + __pyx_t_27 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
+                                    __pyx_t_27 = __pyx_v_i;
+                                    __pyx_t_28 = 0;
+                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
+                                    if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
+                                    __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":257
+                                    /* "implicit/_als.pyx":276
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  *                     total_confidence += confidence             # <<<<<<<<<<<<<<
@@ -22147,7 +22892,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
  */
                                     __pyx_v_total_confidence = (__pyx_v_total_confidence + __pyx_v_confidence);
 
-                                    /* "implicit/_als.pyx":258
+                                    /* "implicit/_als.pyx":277
  * 
  *                     total_confidence += confidence
  *                     loss += confidence             # <<<<<<<<<<<<<<
@@ -22157,41 +22902,41 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
                                     __pyx_v_loss = (__pyx_v_loss + __pyx_v_confidence);
                                   }
 
-                                  /* "implicit/_als.pyx":260
+                                  /* "implicit/_als.pyx":279
  *                     loss += confidence
  * 
  *                 loss += dot(&N, r, &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)
  * 
  */
-                                  __pyx_t_28 = __pyx_v_u;
-                                  __pyx_t_29 = 0;
-                                  if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_29 < 0) __pyx_t_29 += __pyx_v_X.shape[1];
-                                  __pyx_v_loss = (__pyx_v_loss + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_28 * __pyx_v_X.strides[0]) ) + __pyx_t_29 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_29 = __pyx_v_u;
+                                  __pyx_t_30 = 0;
+                                  if (__pyx_t_29 < 0) __pyx_t_29 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_30 < 0) __pyx_t_30 += __pyx_v_X.shape[1];
+                                  __pyx_v_loss = (__pyx_v_loss + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_29 * __pyx_v_X.strides[0]) ) + __pyx_t_30 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
 
-                                  /* "implicit/_als.pyx":261
+                                  /* "implicit/_als.pyx":280
  * 
  *                 loss += dot(&N, r, &one, &X[u, 0], &one)
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  * 
  *             for i in prange(items, schedule='guided'):
  */
-                                  __pyx_t_30 = __pyx_v_u;
-                                  __pyx_t_31 = 0;
-                                  if (__pyx_t_30 < 0) __pyx_t_30 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_31 < 0) __pyx_t_31 += __pyx_v_X.shape[1];
-                                  __pyx_t_32 = __pyx_v_u;
-                                  __pyx_t_33 = 0;
-                                  if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_33 < 0) __pyx_t_33 += __pyx_v_X.shape[1];
-                                  __pyx_v_user_norm = (__pyx_v_user_norm + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_30 * __pyx_v_X.strides[0]) ) + __pyx_t_31 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_32 * __pyx_v_X.strides[0]) ) + __pyx_t_33 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_31 = __pyx_v_u;
+                                  __pyx_t_32 = 0;
+                                  if (__pyx_t_31 < 0) __pyx_t_31 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_X.shape[1];
+                                  __pyx_t_33 = __pyx_v_u;
+                                  __pyx_t_34 = 0;
+                                  if (__pyx_t_33 < 0) __pyx_t_33 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_34 < 0) __pyx_t_34 += __pyx_v_X.shape[1];
+                                  __pyx_v_user_norm = (__pyx_v_user_norm + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_31 * __pyx_v_X.strides[0]) ) + __pyx_t_32 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_33 * __pyx_v_X.strides[0]) ) + __pyx_t_34 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
                               }
                           }
                       }
                   }
 
-                  /* "implicit/_als.pyx":263
+                  /* "implicit/_als.pyx":282
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)
  * 
  *             for i in prange(items, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -22211,29 +22956,29 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
                               {
                                   __pyx_v_i = (int)(0 + 1 * __pyx_t_10);
 
-                                  /* "implicit/_als.pyx":264
+                                  /* "implicit/_als.pyx":283
  * 
  *             for i in prange(items, schedule='guided'):
  *                 item_norm += dot(&N, &Y[i, 0], &one, &Y[i, 0], &one)             # <<<<<<<<<<<<<<
  * 
  *         finally:
  */
-                                  __pyx_t_34 = __pyx_v_i;
-                                  __pyx_t_35 = 0;
-                                  if (__pyx_t_34 < 0) __pyx_t_34 += __pyx_v_Y.shape[0];
-                                  if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_Y.shape[1];
-                                  __pyx_t_36 = __pyx_v_i;
-                                  __pyx_t_37 = 0;
-                                  if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_Y.shape[0];
-                                  if (__pyx_t_37 < 0) __pyx_t_37 += __pyx_v_Y.shape[1];
-                                  __pyx_v_item_norm = (__pyx_v_item_norm + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_34 * __pyx_v_Y.strides[0]) ) + __pyx_t_35 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_36 * __pyx_v_Y.strides[0]) ) + __pyx_t_37 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_35 = __pyx_v_i;
+                                  __pyx_t_36 = 0;
+                                  if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_Y.shape[0];
+                                  if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_Y.shape[1];
+                                  __pyx_t_37 = __pyx_v_i;
+                                  __pyx_t_38 = 0;
+                                  if (__pyx_t_37 < 0) __pyx_t_37 += __pyx_v_Y.shape[0];
+                                  if (__pyx_t_38 < 0) __pyx_t_38 += __pyx_v_Y.shape[1];
+                                  __pyx_v_item_norm = (__pyx_v_item_norm + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_35 * __pyx_v_Y.strides[0]) ) + __pyx_t_36 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_37 * __pyx_v_Y.strides[0]) ) + __pyx_t_38 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one)));
                               }
                           }
                       }
                   }
                 }
 
-                /* "implicit/_als.pyx":267
+                /* "implicit/_als.pyx":286
  * 
  *         finally:
  *             free(r)             # <<<<<<<<<<<<<<
@@ -22257,7 +23002,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
         #endif
       }
 
-      /* "implicit/_als.pyx":241
+      /* "implicit/_als.pyx":255
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -22276,7 +23021,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
       }
   }
 
-  /* "implicit/_als.pyx":269
+  /* "implicit/_als.pyx":288
  *             free(r)
  * 
  *     loss += regularization * (item_norm + user_norm)             # <<<<<<<<<<<<<<
@@ -22284,41 +23029,41 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
  */
   __pyx_v_loss = (__pyx_v_loss + (__pyx_v_regularization * (__pyx_v_item_norm + __pyx_v_user_norm)));
 
-  /* "implicit/_als.pyx":270
+  /* "implicit/_als.pyx":289
  * 
  *     loss += regularization * (item_norm + user_norm)
  *     return loss / (total_confidence + Cui.shape[0] * Cui.shape[1] - Cui.nnz)             # <<<<<<<<<<<<<<
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyFloat_FromDouble(__pyx_v_loss); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_1 = PyFloat_FromDouble(__pyx_v_loss); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_total_confidence); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_total_confidence); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_GetItemInt(__pyx_t_4, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_GetItemInt(__pyx_t_4, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_4, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_4, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = PyNumber_Multiply(__pyx_t_5, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = PyNumber_Multiply(__pyx_t_5, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = PyNumber_Add(__pyx_t_3, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_2 = PyNumber_Add(__pyx_t_3, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_nnz); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_nnz); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_3 = PyNumber_Subtract(__pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_3 = PyNumber_Subtract(__pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyNumber_Divide(__pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyNumber_Divide(__pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -22326,7 +23071,7 @@ static PyObject *__pyx_pf_8implicit_4_als_42_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_t_4 = 0;
   goto __pyx_L0;
 
-  /* "implicit/_als.pyx":227
+  /* "implicit/_als.pyx":241
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _calculate_loss(Cui, integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
@@ -22366,14 +23111,14 @@ static PyObject *__pyx_pf_8implicit_4_als_118__defaults__(CYTHON_UNUSED PyObject
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("__defaults__", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults32, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults32, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_2);
   PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_2);
@@ -22448,37 +23193,37 @@ static PyObject *__pyx_fuse_1_0__pyx_pw_8implicit_4_als_45_calculate_loss(PyObje
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indptr)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 1); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 1); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indices)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 2); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 2); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_data)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 3); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 3); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
         if (likely((values[4] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_X)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 4); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 4); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  5:
         if (likely((values[5] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_Y)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 5); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 5); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  6:
         if (likely((values[6] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_regularization)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 6); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 6); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  7:
@@ -22488,7 +23233,7 @@ static PyObject *__pyx_fuse_1_0__pyx_pw_8implicit_4_als_45_calculate_loss(PyObje
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_calculate_loss") < 0)) __PYX_ERR(0, 227, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_calculate_loss") < 0)) __PYX_ERR(0, 241, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -22506,21 +23251,21 @@ static PyObject *__pyx_fuse_1_0__pyx_pw_8implicit_4_als_45_calculate_loss(PyObje
       }
     }
     __pyx_v_Cui = values[0];
-    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_int(values[1]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_int(values[2]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[3]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[4]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 228, __pyx_L3_error)
-    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[5]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 228, __pyx_L3_error)
-    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[6]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 228, __pyx_L3_error)
+    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_int(values[1]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_int(values[2]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[3]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[4]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 242, __pyx_L3_error)
+    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[5]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 242, __pyx_L3_error)
+    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[6]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 242, __pyx_L3_error)
     if (values[7]) {
-      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 229, __pyx_L3_error)
+      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 243, __pyx_L3_error)
     } else {
       __pyx_v_num_threads = __pyx_dynamic_args->__pyx_arg_num_threads;
     }
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 227, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 241, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("implicit._als._calculate_loss", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -22574,7 +23319,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
   int __pyx_t_19;
   Py_ssize_t __pyx_t_20;
   Py_ssize_t __pyx_t_21;
-  Py_ssize_t __pyx_t_22;
+  int __pyx_t_22;
   Py_ssize_t __pyx_t_23;
   Py_ssize_t __pyx_t_24;
   Py_ssize_t __pyx_t_25;
@@ -22590,9 +23335,10 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
   Py_ssize_t __pyx_t_35;
   Py_ssize_t __pyx_t_36;
   Py_ssize_t __pyx_t_37;
+  Py_ssize_t __pyx_t_38;
   __Pyx_RefNannySetupContext("__pyx_fuse_1_0_calculate_loss", 0);
 
-  /* "implicit/_als.pyx":230
+  /* "implicit/_als.pyx":244
  *                     floating[:, :] X, floating[:, :] Y, float regularization,
  *                     int num_threads=0):
  *     dtype = np.float64 if floating is double else np.float32             # <<<<<<<<<<<<<<
@@ -22600,17 +23346,17 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
  *     cdef floating confidence, temp
  */
   if ((0 != 0)) {
-    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_1 = __pyx_t_3;
     __pyx_t_3 = 0;
   } else {
-    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_t_1 = __pyx_t_2;
@@ -22619,7 +23365,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_dtype = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "implicit/_als.pyx":231
+  /* "implicit/_als.pyx":245
  *                     int num_threads=0):
  *     dtype = np.float64 if floating is double else np.float32
  *     cdef int users = X.shape[0], N = X.shape[1], items = Y.shape[0], u, i, index, one = 1             # <<<<<<<<<<<<<<
@@ -22631,7 +23377,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_items = (__pyx_v_Y.shape[0]);
   __pyx_v_one = 1;
 
-  /* "implicit/_als.pyx":233
+  /* "implicit/_als.pyx":247
  *     cdef int users = X.shape[0], N = X.shape[1], items = Y.shape[0], u, i, index, one = 1
  *     cdef floating confidence, temp
  *     cdef floating zero = 0.             # <<<<<<<<<<<<<<
@@ -22640,24 +23386,24 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
  */
   __pyx_v_zero = 0.;
 
-  /* "implicit/_als.pyx":235
+  /* "implicit/_als.pyx":249
  *     cdef floating zero = 0.
  * 
  *     cdef floating[:, :] YtY = np.dot(np.transpose(Y), Y)             # <<<<<<<<<<<<<<
  * 
  *     cdef floating * r
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_6 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -22670,14 +23416,14 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
     }
   }
   if (!__pyx_t_6) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_GOTREF(__pyx_t_2);
   } else {
     #if CYTHON_FAST_PYCALL
     if (PyFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -22686,26 +23432,26 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
     #if CYTHON_FAST_PYCCALL
     if (__Pyx_PyFastCFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     } else
     #endif
     {
-      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_6); __pyx_t_6 = NULL;
       __Pyx_GIVEREF(__pyx_t_4);
       PyTuple_SET_ITEM(__pyx_t_7, 0+1, __pyx_t_4);
       __pyx_t_4 = 0;
-      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     }
   }
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_7 = NULL;
   __pyx_t_8 = 0;
@@ -22722,7 +23468,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -22732,7 +23478,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -22740,7 +23486,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
   } else
   #endif
   {
-    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     if (__pyx_t_7) {
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -22751,19 +23497,19 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
     PyTuple_SET_ITEM(__pyx_t_4, 1+__pyx_t_8, __pyx_t_5);
     __pyx_t_2 = 0;
     __pyx_t_5 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(__pyx_t_1);
-  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 235, __pyx_L1_error)
+  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v_YtY = __pyx_t_9;
   __pyx_t_9.memview = NULL;
   __pyx_t_9.data = NULL;
 
-  /* "implicit/_als.pyx":239
+  /* "implicit/_als.pyx":253
  *     cdef floating * r
  * 
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0             # <<<<<<<<<<<<<<
@@ -22775,7 +23521,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_item_norm = 0.0;
   __pyx_v_user_norm = 0.0;
 
-  /* "implicit/_als.pyx":241
+  /* "implicit/_als.pyx":255
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -22797,13 +23543,13 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
                 #define unlikely(x) (x)
             #endif
             #ifdef _OPENMP
-            #pragma omp parallel private(__pyx_v_r) reduction(+:__pyx_v_loss) reduction(+:__pyx_v_total_confidence) reduction(+:__pyx_v_user_norm) reduction(+:__pyx_v_item_norm) private(__pyx_t_10, __pyx_t_11, __pyx_t_12, __pyx_t_13, __pyx_t_14, __pyx_t_15, __pyx_t_16, __pyx_t_17, __pyx_t_18, __pyx_t_19, __pyx_t_20, __pyx_t_21, __pyx_t_22, __pyx_t_23, __pyx_t_24, __pyx_t_25, __pyx_t_26, __pyx_t_27, __pyx_t_28, __pyx_t_29, __pyx_t_30, __pyx_t_31, __pyx_t_32, __pyx_t_33, __pyx_t_34, __pyx_t_35, __pyx_t_36, __pyx_t_37, __pyx_t_8) num_threads(__pyx_v_num_threads)
+            #pragma omp parallel private(__pyx_v_r) reduction(+:__pyx_v_loss) reduction(+:__pyx_v_total_confidence) reduction(+:__pyx_v_user_norm) reduction(+:__pyx_v_item_norm) private(__pyx_t_10, __pyx_t_11, __pyx_t_12, __pyx_t_13, __pyx_t_14, __pyx_t_15, __pyx_t_16, __pyx_t_17, __pyx_t_18, __pyx_t_19, __pyx_t_20, __pyx_t_21, __pyx_t_22, __pyx_t_23, __pyx_t_24, __pyx_t_25, __pyx_t_26, __pyx_t_27, __pyx_t_28, __pyx_t_29, __pyx_t_30, __pyx_t_31, __pyx_t_32, __pyx_t_33, __pyx_t_34, __pyx_t_35, __pyx_t_36, __pyx_t_37, __pyx_t_38, __pyx_t_8) num_threads(__pyx_v_num_threads)
             #endif /* _OPENMP */
             {
                 /* Initialize private variables to invalid values */
                 __pyx_v_r = ((float *)1);
 
-                /* "implicit/_als.pyx":242
+                /* "implicit/_als.pyx":256
  * 
  *     with nogil, parallel(num_threads=num_threads):
  *         r = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -22812,7 +23558,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
  */
                 __pyx_v_r = ((float *)malloc(((sizeof(float)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":243
+                /* "implicit/_als.pyx":257
  *     with nogil, parallel(num_threads=num_threads):
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:             # <<<<<<<<<<<<<<
@@ -22821,7 +23567,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
  */
                 /*try:*/ {
 
-                  /* "implicit/_als.pyx":244
+                  /* "implicit/_als.pyx":258
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:
  *             for u in prange(users, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -22846,7 +23592,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
                                   __pyx_v_index = ((int)0xbad0bad0);
                                   __pyx_v_temp = ((float)__PYX_NAN());
 
-                                  /* "implicit/_als.pyx":246
+                                  /* "implicit/_als.pyx":260
  *             for u in prange(users, schedule='guided'):
  *                 # calculates (A.dot(Xu) - 2 * b).dot(Xu), without calculating A
  *                 temp = 1.0             # <<<<<<<<<<<<<<
@@ -22855,7 +23601,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
  */
                                   __pyx_v_temp = 1.0;
 
-                                  /* "implicit/_als.pyx":247
+                                  /* "implicit/_als.pyx":261
  *                 # calculates (A.dot(Xu) - 2 * b).dot(Xu), without calculating A
  *                 temp = 1.0
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, &X[u, 0], &one, &zero, r, &one)             # <<<<<<<<<<<<<<
@@ -22872,7 +23618,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
                                   if (__pyx_t_15 < 0) __pyx_t_15 += __pyx_v_X.shape[1];
                                   __pyx_fuse_0__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_12 * __pyx_v_YtY.strides[0]) ) + __pyx_t_13 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_14 * __pyx_v_X.strides[0]) ) + __pyx_t_15 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":249
+                                  /* "implicit/_als.pyx":263
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, &X[u, 0], &one, &zero, r, &one)
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -22887,7 +23633,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
                                   for (__pyx_t_19 = (*((int *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_18 * __pyx_v_indptr.strides[0]) ))); __pyx_t_19 < __pyx_t_17; __pyx_t_19+=1) {
                                     __pyx_v_index = __pyx_t_19;
 
-                                    /* "implicit/_als.pyx":250
+                                    /* "implicit/_als.pyx":264
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]             # <<<<<<<<<<<<<<
@@ -22898,56 +23644,98 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
                                     if (__pyx_t_20 < 0) __pyx_t_20 += __pyx_v_indices.shape[0];
                                     __pyx_v_i = (*((int *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_20 * __pyx_v_indices.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":251
+                                    /* "implicit/_als.pyx":265
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]
  *                     confidence = data[index]             # <<<<<<<<<<<<<<
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
+ *                     if confidence > 0:
  */
                                     __pyx_t_21 = __pyx_v_index;
                                     if (__pyx_t_21 < 0) __pyx_t_21 += __pyx_v_data.shape[0];
                                     __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_21 * __pyx_v_data.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":253
+                                    /* "implicit/_als.pyx":267
  *                     confidence = data[index]
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],             # <<<<<<<<<<<<<<
- *                                                   &one) - 2 * confidence
- *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = -2 * confidence
+ *                     else:
  */
-                                    __pyx_t_22 = __pyx_v_i;
-                                    __pyx_t_23 = 0;
-                                    if (__pyx_t_22 < 0) __pyx_t_22 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_Y.shape[1];
-                                    __pyx_t_24 = __pyx_v_u;
-                                    __pyx_t_25 = 0;
-                                    if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_X.shape[0];
-                                    if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_X.shape[1];
+                                    __pyx_t_22 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_22) {
 
-                                    /* "implicit/_als.pyx":254
+                                      /* "implicit/_als.pyx":268
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
- *                                                   &one) - 2 * confidence             # <<<<<<<<<<<<<<
+ *                     if confidence > 0:
+ *                         temp = -2 * confidence             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         temp = 0
+ */
+                                      __pyx_v_temp = (-2.0 * __pyx_v_confidence);
+
+                                      /* "implicit/_als.pyx":267
+ *                     confidence = data[index]
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = -2 * confidence
+ *                     else:
+ */
+                                      goto __pyx_L21;
+                                    }
+
+                                    /* "implicit/_als.pyx":270
+ *                         temp = -2 * confidence
+ *                     else:
+ *                         temp = 0             # <<<<<<<<<<<<<<
+ *                         confidence = -1 * confidence
+ * 
+ */
+                                    /*else*/ {
+                                      __pyx_v_temp = 0.0;
+
+                                      /* "implicit/_als.pyx":271
+ *                     else:
+ *                         temp = 0
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)
+ */
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L21:;
+
+                                    /* "implicit/_als.pyx":273
+ *                         confidence = -1 * confidence
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  */
-                                    __pyx_v_temp = (((__pyx_v_confidence - 1.0) * __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_22 * __pyx_v_Y.strides[0]) ) + __pyx_t_23 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_24 * __pyx_v_X.strides[0]) ) + __pyx_t_25 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one))) - (2.0 * __pyx_v_confidence));
+                                    __pyx_t_23 = __pyx_v_i;
+                                    __pyx_t_24 = 0;
+                                    if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_Y.shape[0];
+                                    if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_Y.shape[1];
+                                    __pyx_t_25 = __pyx_v_u;
+                                    __pyx_t_26 = 0;
+                                    if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_X.shape[0];
+                                    if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_X.shape[1];
+                                    __pyx_v_temp = (__pyx_v_temp + ((__pyx_v_confidence - 1.0) * __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_23 * __pyx_v_Y.strides[0]) ) + __pyx_t_24 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_25 * __pyx_v_X.strides[0]) ) + __pyx_t_26 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one))));
 
-                                    /* "implicit/_als.pyx":255
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
- *                                                   &one) - 2 * confidence
+                                    /* "implicit/_als.pyx":274
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)             # <<<<<<<<<<<<<<
  * 
  *                     total_confidence += confidence
  */
-                                    __pyx_t_26 = __pyx_v_i;
-                                    __pyx_t_27 = 0;
-                                    if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[1];
-                                    __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_26 * __pyx_v_Y.strides[0]) ) + __pyx_t_27 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
+                                    __pyx_t_27 = __pyx_v_i;
+                                    __pyx_t_28 = 0;
+                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
+                                    if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
+                                    __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":257
+                                    /* "implicit/_als.pyx":276
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  *                     total_confidence += confidence             # <<<<<<<<<<<<<<
@@ -22956,7 +23744,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
  */
                                     __pyx_v_total_confidence = (__pyx_v_total_confidence + __pyx_v_confidence);
 
-                                    /* "implicit/_als.pyx":258
+                                    /* "implicit/_als.pyx":277
  * 
  *                     total_confidence += confidence
  *                     loss += confidence             # <<<<<<<<<<<<<<
@@ -22966,41 +23754,41 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
                                     __pyx_v_loss = (__pyx_v_loss + __pyx_v_confidence);
                                   }
 
-                                  /* "implicit/_als.pyx":260
+                                  /* "implicit/_als.pyx":279
  *                     loss += confidence
  * 
  *                 loss += dot(&N, r, &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)
  * 
  */
-                                  __pyx_t_28 = __pyx_v_u;
-                                  __pyx_t_29 = 0;
-                                  if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_29 < 0) __pyx_t_29 += __pyx_v_X.shape[1];
-                                  __pyx_v_loss = (__pyx_v_loss + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_28 * __pyx_v_X.strides[0]) ) + __pyx_t_29 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_29 = __pyx_v_u;
+                                  __pyx_t_30 = 0;
+                                  if (__pyx_t_29 < 0) __pyx_t_29 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_30 < 0) __pyx_t_30 += __pyx_v_X.shape[1];
+                                  __pyx_v_loss = (__pyx_v_loss + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_29 * __pyx_v_X.strides[0]) ) + __pyx_t_30 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
 
-                                  /* "implicit/_als.pyx":261
+                                  /* "implicit/_als.pyx":280
  * 
  *                 loss += dot(&N, r, &one, &X[u, 0], &one)
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  * 
  *             for i in prange(items, schedule='guided'):
  */
-                                  __pyx_t_30 = __pyx_v_u;
-                                  __pyx_t_31 = 0;
-                                  if (__pyx_t_30 < 0) __pyx_t_30 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_31 < 0) __pyx_t_31 += __pyx_v_X.shape[1];
-                                  __pyx_t_32 = __pyx_v_u;
-                                  __pyx_t_33 = 0;
-                                  if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_33 < 0) __pyx_t_33 += __pyx_v_X.shape[1];
-                                  __pyx_v_user_norm = (__pyx_v_user_norm + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_30 * __pyx_v_X.strides[0]) ) + __pyx_t_31 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_32 * __pyx_v_X.strides[0]) ) + __pyx_t_33 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_31 = __pyx_v_u;
+                                  __pyx_t_32 = 0;
+                                  if (__pyx_t_31 < 0) __pyx_t_31 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_X.shape[1];
+                                  __pyx_t_33 = __pyx_v_u;
+                                  __pyx_t_34 = 0;
+                                  if (__pyx_t_33 < 0) __pyx_t_33 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_34 < 0) __pyx_t_34 += __pyx_v_X.shape[1];
+                                  __pyx_v_user_norm = (__pyx_v_user_norm + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_31 * __pyx_v_X.strides[0]) ) + __pyx_t_32 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_33 * __pyx_v_X.strides[0]) ) + __pyx_t_34 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
                               }
                           }
                       }
                   }
 
-                  /* "implicit/_als.pyx":263
+                  /* "implicit/_als.pyx":282
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)
  * 
  *             for i in prange(items, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -23020,29 +23808,29 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
                               {
                                   __pyx_v_i = (int)(0 + 1 * __pyx_t_10);
 
-                                  /* "implicit/_als.pyx":264
+                                  /* "implicit/_als.pyx":283
  * 
  *             for i in prange(items, schedule='guided'):
  *                 item_norm += dot(&N, &Y[i, 0], &one, &Y[i, 0], &one)             # <<<<<<<<<<<<<<
  * 
  *         finally:
  */
-                                  __pyx_t_34 = __pyx_v_i;
-                                  __pyx_t_35 = 0;
-                                  if (__pyx_t_34 < 0) __pyx_t_34 += __pyx_v_Y.shape[0];
-                                  if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_Y.shape[1];
-                                  __pyx_t_36 = __pyx_v_i;
-                                  __pyx_t_37 = 0;
-                                  if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_Y.shape[0];
-                                  if (__pyx_t_37 < 0) __pyx_t_37 += __pyx_v_Y.shape[1];
-                                  __pyx_v_item_norm = (__pyx_v_item_norm + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_34 * __pyx_v_Y.strides[0]) ) + __pyx_t_35 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_36 * __pyx_v_Y.strides[0]) ) + __pyx_t_37 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_35 = __pyx_v_i;
+                                  __pyx_t_36 = 0;
+                                  if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_Y.shape[0];
+                                  if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_Y.shape[1];
+                                  __pyx_t_37 = __pyx_v_i;
+                                  __pyx_t_38 = 0;
+                                  if (__pyx_t_37 < 0) __pyx_t_37 += __pyx_v_Y.shape[0];
+                                  if (__pyx_t_38 < 0) __pyx_t_38 += __pyx_v_Y.shape[1];
+                                  __pyx_v_item_norm = (__pyx_v_item_norm + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_35 * __pyx_v_Y.strides[0]) ) + __pyx_t_36 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_37 * __pyx_v_Y.strides[0]) ) + __pyx_t_38 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one)));
                               }
                           }
                       }
                   }
                 }
 
-                /* "implicit/_als.pyx":267
+                /* "implicit/_als.pyx":286
  * 
  *         finally:
  *             free(r)             # <<<<<<<<<<<<<<
@@ -23066,7 +23854,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
         #endif
       }
 
-      /* "implicit/_als.pyx":241
+      /* "implicit/_als.pyx":255
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -23085,7 +23873,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
       }
   }
 
-  /* "implicit/_als.pyx":269
+  /* "implicit/_als.pyx":288
  *             free(r)
  * 
  *     loss += regularization * (item_norm + user_norm)             # <<<<<<<<<<<<<<
@@ -23093,41 +23881,41 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
  */
   __pyx_v_loss = (__pyx_v_loss + (__pyx_v_regularization * (__pyx_v_item_norm + __pyx_v_user_norm)));
 
-  /* "implicit/_als.pyx":270
+  /* "implicit/_als.pyx":289
  * 
  *     loss += regularization * (item_norm + user_norm)
  *     return loss / (total_confidence + Cui.shape[0] * Cui.shape[1] - Cui.nnz)             # <<<<<<<<<<<<<<
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyFloat_FromDouble(__pyx_v_loss); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_1 = PyFloat_FromDouble(__pyx_v_loss); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_total_confidence); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_total_confidence); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_GetItemInt(__pyx_t_4, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_GetItemInt(__pyx_t_4, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_4, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_4, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = PyNumber_Multiply(__pyx_t_5, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = PyNumber_Multiply(__pyx_t_5, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = PyNumber_Add(__pyx_t_3, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_2 = PyNumber_Add(__pyx_t_3, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_nnz); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_nnz); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_3 = PyNumber_Subtract(__pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_3 = PyNumber_Subtract(__pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyNumber_Divide(__pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyNumber_Divide(__pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -23135,7 +23923,7 @@ static PyObject *__pyx_pf_8implicit_4_als_44_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_t_4 = 0;
   goto __pyx_L0;
 
-  /* "implicit/_als.pyx":227
+  /* "implicit/_als.pyx":241
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _calculate_loss(Cui, integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
@@ -23175,14 +23963,14 @@ static PyObject *__pyx_pf_8implicit_4_als_120__defaults__(CYTHON_UNUSED PyObject
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("__defaults__", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults33, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults33, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_2);
   PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_2);
@@ -23257,37 +24045,37 @@ static PyObject *__pyx_fuse_1_1__pyx_pw_8implicit_4_als_47_calculate_loss(PyObje
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indptr)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 1); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 1); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indices)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 2); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 2); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_data)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 3); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 3); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
         if (likely((values[4] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_X)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 4); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 4); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  5:
         if (likely((values[5] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_Y)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 5); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 5); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  6:
         if (likely((values[6] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_regularization)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 6); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 6); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  7:
@@ -23297,7 +24085,7 @@ static PyObject *__pyx_fuse_1_1__pyx_pw_8implicit_4_als_47_calculate_loss(PyObje
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_calculate_loss") < 0)) __PYX_ERR(0, 227, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_calculate_loss") < 0)) __PYX_ERR(0, 241, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -23315,21 +24103,21 @@ static PyObject *__pyx_fuse_1_1__pyx_pw_8implicit_4_als_47_calculate_loss(PyObje
       }
     }
     __pyx_v_Cui = values[0];
-    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_int(values[1]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_int(values[2]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[3]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[4]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 228, __pyx_L3_error)
-    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[5]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 228, __pyx_L3_error)
-    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[6]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 228, __pyx_L3_error)
+    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_int(values[1]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_int(values[2]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[3]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[4]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 242, __pyx_L3_error)
+    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[5]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 242, __pyx_L3_error)
+    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[6]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 242, __pyx_L3_error)
     if (values[7]) {
-      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 229, __pyx_L3_error)
+      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 243, __pyx_L3_error)
     } else {
       __pyx_v_num_threads = __pyx_dynamic_args->__pyx_arg_num_threads;
     }
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 227, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 241, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("implicit._als._calculate_loss", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -23383,7 +24171,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
   int __pyx_t_19;
   Py_ssize_t __pyx_t_20;
   Py_ssize_t __pyx_t_21;
-  Py_ssize_t __pyx_t_22;
+  int __pyx_t_22;
   Py_ssize_t __pyx_t_23;
   Py_ssize_t __pyx_t_24;
   Py_ssize_t __pyx_t_25;
@@ -23399,9 +24187,10 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
   Py_ssize_t __pyx_t_35;
   Py_ssize_t __pyx_t_36;
   Py_ssize_t __pyx_t_37;
+  Py_ssize_t __pyx_t_38;
   __Pyx_RefNannySetupContext("__pyx_fuse_1_1_calculate_loss", 0);
 
-  /* "implicit/_als.pyx":230
+  /* "implicit/_als.pyx":244
  *                     floating[:, :] X, floating[:, :] Y, float regularization,
  *                     int num_threads=0):
  *     dtype = np.float64 if floating is double else np.float32             # <<<<<<<<<<<<<<
@@ -23409,17 +24198,17 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
  *     cdef floating confidence, temp
  */
   if ((1 != 0)) {
-    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_1 = __pyx_t_3;
     __pyx_t_3 = 0;
   } else {
-    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_t_1 = __pyx_t_2;
@@ -23428,7 +24217,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_dtype = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "implicit/_als.pyx":231
+  /* "implicit/_als.pyx":245
  *                     int num_threads=0):
  *     dtype = np.float64 if floating is double else np.float32
  *     cdef int users = X.shape[0], N = X.shape[1], items = Y.shape[0], u, i, index, one = 1             # <<<<<<<<<<<<<<
@@ -23440,7 +24229,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_items = (__pyx_v_Y.shape[0]);
   __pyx_v_one = 1;
 
-  /* "implicit/_als.pyx":233
+  /* "implicit/_als.pyx":247
  *     cdef int users = X.shape[0], N = X.shape[1], items = Y.shape[0], u, i, index, one = 1
  *     cdef floating confidence, temp
  *     cdef floating zero = 0.             # <<<<<<<<<<<<<<
@@ -23449,24 +24238,24 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
  */
   __pyx_v_zero = 0.;
 
-  /* "implicit/_als.pyx":235
+  /* "implicit/_als.pyx":249
  *     cdef floating zero = 0.
  * 
  *     cdef floating[:, :] YtY = np.dot(np.transpose(Y), Y)             # <<<<<<<<<<<<<<
  * 
  *     cdef floating * r
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_6 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -23479,14 +24268,14 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
     }
   }
   if (!__pyx_t_6) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_GOTREF(__pyx_t_2);
   } else {
     #if CYTHON_FAST_PYCALL
     if (PyFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -23495,26 +24284,26 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
     #if CYTHON_FAST_PYCCALL
     if (__Pyx_PyFastCFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     } else
     #endif
     {
-      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_6); __pyx_t_6 = NULL;
       __Pyx_GIVEREF(__pyx_t_4);
       PyTuple_SET_ITEM(__pyx_t_7, 0+1, __pyx_t_4);
       __pyx_t_4 = 0;
-      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     }
   }
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_7 = NULL;
   __pyx_t_8 = 0;
@@ -23531,7 +24320,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -23541,7 +24330,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -23549,7 +24338,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
   } else
   #endif
   {
-    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     if (__pyx_t_7) {
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -23560,19 +24349,19 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
     PyTuple_SET_ITEM(__pyx_t_4, 1+__pyx_t_8, __pyx_t_5);
     __pyx_t_2 = 0;
     __pyx_t_5 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(__pyx_t_1);
-  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 235, __pyx_L1_error)
+  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v_YtY = __pyx_t_9;
   __pyx_t_9.memview = NULL;
   __pyx_t_9.data = NULL;
 
-  /* "implicit/_als.pyx":239
+  /* "implicit/_als.pyx":253
  *     cdef floating * r
  * 
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0             # <<<<<<<<<<<<<<
@@ -23584,7 +24373,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_item_norm = 0.0;
   __pyx_v_user_norm = 0.0;
 
-  /* "implicit/_als.pyx":241
+  /* "implicit/_als.pyx":255
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -23606,13 +24395,13 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
                 #define unlikely(x) (x)
             #endif
             #ifdef _OPENMP
-            #pragma omp parallel private(__pyx_v_r) reduction(+:__pyx_v_loss) reduction(+:__pyx_v_total_confidence) reduction(+:__pyx_v_user_norm) reduction(+:__pyx_v_item_norm) private(__pyx_t_10, __pyx_t_11, __pyx_t_12, __pyx_t_13, __pyx_t_14, __pyx_t_15, __pyx_t_16, __pyx_t_17, __pyx_t_18, __pyx_t_19, __pyx_t_20, __pyx_t_21, __pyx_t_22, __pyx_t_23, __pyx_t_24, __pyx_t_25, __pyx_t_26, __pyx_t_27, __pyx_t_28, __pyx_t_29, __pyx_t_30, __pyx_t_31, __pyx_t_32, __pyx_t_33, __pyx_t_34, __pyx_t_35, __pyx_t_36, __pyx_t_37, __pyx_t_8) num_threads(__pyx_v_num_threads)
+            #pragma omp parallel private(__pyx_v_r) reduction(+:__pyx_v_loss) reduction(+:__pyx_v_total_confidence) reduction(+:__pyx_v_user_norm) reduction(+:__pyx_v_item_norm) private(__pyx_t_10, __pyx_t_11, __pyx_t_12, __pyx_t_13, __pyx_t_14, __pyx_t_15, __pyx_t_16, __pyx_t_17, __pyx_t_18, __pyx_t_19, __pyx_t_20, __pyx_t_21, __pyx_t_22, __pyx_t_23, __pyx_t_24, __pyx_t_25, __pyx_t_26, __pyx_t_27, __pyx_t_28, __pyx_t_29, __pyx_t_30, __pyx_t_31, __pyx_t_32, __pyx_t_33, __pyx_t_34, __pyx_t_35, __pyx_t_36, __pyx_t_37, __pyx_t_38, __pyx_t_8) num_threads(__pyx_v_num_threads)
             #endif /* _OPENMP */
             {
                 /* Initialize private variables to invalid values */
                 __pyx_v_r = ((double *)1);
 
-                /* "implicit/_als.pyx":242
+                /* "implicit/_als.pyx":256
  * 
  *     with nogil, parallel(num_threads=num_threads):
  *         r = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -23621,7 +24410,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
  */
                 __pyx_v_r = ((double *)malloc(((sizeof(double)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":243
+                /* "implicit/_als.pyx":257
  *     with nogil, parallel(num_threads=num_threads):
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:             # <<<<<<<<<<<<<<
@@ -23630,7 +24419,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
  */
                 /*try:*/ {
 
-                  /* "implicit/_als.pyx":244
+                  /* "implicit/_als.pyx":258
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:
  *             for u in prange(users, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -23655,7 +24444,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
                                   __pyx_v_index = ((int)0xbad0bad0);
                                   __pyx_v_temp = ((double)__PYX_NAN());
 
-                                  /* "implicit/_als.pyx":246
+                                  /* "implicit/_als.pyx":260
  *             for u in prange(users, schedule='guided'):
  *                 # calculates (A.dot(Xu) - 2 * b).dot(Xu), without calculating A
  *                 temp = 1.0             # <<<<<<<<<<<<<<
@@ -23664,7 +24453,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
  */
                                   __pyx_v_temp = 1.0;
 
-                                  /* "implicit/_als.pyx":247
+                                  /* "implicit/_als.pyx":261
  *                 # calculates (A.dot(Xu) - 2 * b).dot(Xu), without calculating A
  *                 temp = 1.0
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, &X[u, 0], &one, &zero, r, &one)             # <<<<<<<<<<<<<<
@@ -23681,7 +24470,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
                                   if (__pyx_t_15 < 0) __pyx_t_15 += __pyx_v_X.shape[1];
                                   __pyx_fuse_1__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_12 * __pyx_v_YtY.strides[0]) ) + __pyx_t_13 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_14 * __pyx_v_X.strides[0]) ) + __pyx_t_15 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":249
+                                  /* "implicit/_als.pyx":263
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, &X[u, 0], &one, &zero, r, &one)
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -23696,7 +24485,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
                                   for (__pyx_t_19 = (*((int *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_18 * __pyx_v_indptr.strides[0]) ))); __pyx_t_19 < __pyx_t_17; __pyx_t_19+=1) {
                                     __pyx_v_index = __pyx_t_19;
 
-                                    /* "implicit/_als.pyx":250
+                                    /* "implicit/_als.pyx":264
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]             # <<<<<<<<<<<<<<
@@ -23707,56 +24496,98 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
                                     if (__pyx_t_20 < 0) __pyx_t_20 += __pyx_v_indices.shape[0];
                                     __pyx_v_i = (*((int *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_20 * __pyx_v_indices.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":251
+                                    /* "implicit/_als.pyx":265
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]
  *                     confidence = data[index]             # <<<<<<<<<<<<<<
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
+ *                     if confidence > 0:
  */
                                     __pyx_t_21 = __pyx_v_index;
                                     if (__pyx_t_21 < 0) __pyx_t_21 += __pyx_v_data.shape[0];
                                     __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_21 * __pyx_v_data.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":253
+                                    /* "implicit/_als.pyx":267
  *                     confidence = data[index]
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],             # <<<<<<<<<<<<<<
- *                                                   &one) - 2 * confidence
- *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = -2 * confidence
+ *                     else:
  */
-                                    __pyx_t_22 = __pyx_v_i;
-                                    __pyx_t_23 = 0;
-                                    if (__pyx_t_22 < 0) __pyx_t_22 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_Y.shape[1];
-                                    __pyx_t_24 = __pyx_v_u;
-                                    __pyx_t_25 = 0;
-                                    if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_X.shape[0];
-                                    if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_X.shape[1];
+                                    __pyx_t_22 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_22) {
 
-                                    /* "implicit/_als.pyx":254
+                                      /* "implicit/_als.pyx":268
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
- *                                                   &one) - 2 * confidence             # <<<<<<<<<<<<<<
+ *                     if confidence > 0:
+ *                         temp = -2 * confidence             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         temp = 0
+ */
+                                      __pyx_v_temp = (-2.0 * __pyx_v_confidence);
+
+                                      /* "implicit/_als.pyx":267
+ *                     confidence = data[index]
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = -2 * confidence
+ *                     else:
+ */
+                                      goto __pyx_L21;
+                                    }
+
+                                    /* "implicit/_als.pyx":270
+ *                         temp = -2 * confidence
+ *                     else:
+ *                         temp = 0             # <<<<<<<<<<<<<<
+ *                         confidence = -1 * confidence
+ * 
+ */
+                                    /*else*/ {
+                                      __pyx_v_temp = 0.0;
+
+                                      /* "implicit/_als.pyx":271
+ *                     else:
+ *                         temp = 0
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)
+ */
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L21:;
+
+                                    /* "implicit/_als.pyx":273
+ *                         confidence = -1 * confidence
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  */
-                                    __pyx_v_temp = (((__pyx_v_confidence - 1.0) * __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_22 * __pyx_v_Y.strides[0]) ) + __pyx_t_23 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_24 * __pyx_v_X.strides[0]) ) + __pyx_t_25 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one))) - (2.0 * __pyx_v_confidence));
+                                    __pyx_t_23 = __pyx_v_i;
+                                    __pyx_t_24 = 0;
+                                    if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_Y.shape[0];
+                                    if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_Y.shape[1];
+                                    __pyx_t_25 = __pyx_v_u;
+                                    __pyx_t_26 = 0;
+                                    if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_X.shape[0];
+                                    if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_X.shape[1];
+                                    __pyx_v_temp = (__pyx_v_temp + ((__pyx_v_confidence - 1.0) * __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_23 * __pyx_v_Y.strides[0]) ) + __pyx_t_24 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_25 * __pyx_v_X.strides[0]) ) + __pyx_t_26 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one))));
 
-                                    /* "implicit/_als.pyx":255
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
- *                                                   &one) - 2 * confidence
+                                    /* "implicit/_als.pyx":274
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)             # <<<<<<<<<<<<<<
  * 
  *                     total_confidence += confidence
  */
-                                    __pyx_t_26 = __pyx_v_i;
-                                    __pyx_t_27 = 0;
-                                    if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[1];
-                                    __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_26 * __pyx_v_Y.strides[0]) ) + __pyx_t_27 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
+                                    __pyx_t_27 = __pyx_v_i;
+                                    __pyx_t_28 = 0;
+                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
+                                    if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
+                                    __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":257
+                                    /* "implicit/_als.pyx":276
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  *                     total_confidence += confidence             # <<<<<<<<<<<<<<
@@ -23765,7 +24596,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
  */
                                     __pyx_v_total_confidence = (__pyx_v_total_confidence + __pyx_v_confidence);
 
-                                    /* "implicit/_als.pyx":258
+                                    /* "implicit/_als.pyx":277
  * 
  *                     total_confidence += confidence
  *                     loss += confidence             # <<<<<<<<<<<<<<
@@ -23775,41 +24606,41 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
                                     __pyx_v_loss = (__pyx_v_loss + __pyx_v_confidence);
                                   }
 
-                                  /* "implicit/_als.pyx":260
+                                  /* "implicit/_als.pyx":279
  *                     loss += confidence
  * 
  *                 loss += dot(&N, r, &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)
  * 
  */
-                                  __pyx_t_28 = __pyx_v_u;
-                                  __pyx_t_29 = 0;
-                                  if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_29 < 0) __pyx_t_29 += __pyx_v_X.shape[1];
-                                  __pyx_v_loss = (__pyx_v_loss + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_28 * __pyx_v_X.strides[0]) ) + __pyx_t_29 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_29 = __pyx_v_u;
+                                  __pyx_t_30 = 0;
+                                  if (__pyx_t_29 < 0) __pyx_t_29 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_30 < 0) __pyx_t_30 += __pyx_v_X.shape[1];
+                                  __pyx_v_loss = (__pyx_v_loss + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_29 * __pyx_v_X.strides[0]) ) + __pyx_t_30 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
 
-                                  /* "implicit/_als.pyx":261
+                                  /* "implicit/_als.pyx":280
  * 
  *                 loss += dot(&N, r, &one, &X[u, 0], &one)
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  * 
  *             for i in prange(items, schedule='guided'):
  */
-                                  __pyx_t_30 = __pyx_v_u;
-                                  __pyx_t_31 = 0;
-                                  if (__pyx_t_30 < 0) __pyx_t_30 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_31 < 0) __pyx_t_31 += __pyx_v_X.shape[1];
-                                  __pyx_t_32 = __pyx_v_u;
-                                  __pyx_t_33 = 0;
-                                  if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_33 < 0) __pyx_t_33 += __pyx_v_X.shape[1];
-                                  __pyx_v_user_norm = (__pyx_v_user_norm + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_30 * __pyx_v_X.strides[0]) ) + __pyx_t_31 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_32 * __pyx_v_X.strides[0]) ) + __pyx_t_33 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_31 = __pyx_v_u;
+                                  __pyx_t_32 = 0;
+                                  if (__pyx_t_31 < 0) __pyx_t_31 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_X.shape[1];
+                                  __pyx_t_33 = __pyx_v_u;
+                                  __pyx_t_34 = 0;
+                                  if (__pyx_t_33 < 0) __pyx_t_33 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_34 < 0) __pyx_t_34 += __pyx_v_X.shape[1];
+                                  __pyx_v_user_norm = (__pyx_v_user_norm + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_31 * __pyx_v_X.strides[0]) ) + __pyx_t_32 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_33 * __pyx_v_X.strides[0]) ) + __pyx_t_34 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
                               }
                           }
                       }
                   }
 
-                  /* "implicit/_als.pyx":263
+                  /* "implicit/_als.pyx":282
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)
  * 
  *             for i in prange(items, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -23829,29 +24660,29 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
                               {
                                   __pyx_v_i = (int)(0 + 1 * __pyx_t_10);
 
-                                  /* "implicit/_als.pyx":264
+                                  /* "implicit/_als.pyx":283
  * 
  *             for i in prange(items, schedule='guided'):
  *                 item_norm += dot(&N, &Y[i, 0], &one, &Y[i, 0], &one)             # <<<<<<<<<<<<<<
  * 
  *         finally:
  */
-                                  __pyx_t_34 = __pyx_v_i;
-                                  __pyx_t_35 = 0;
-                                  if (__pyx_t_34 < 0) __pyx_t_34 += __pyx_v_Y.shape[0];
-                                  if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_Y.shape[1];
-                                  __pyx_t_36 = __pyx_v_i;
-                                  __pyx_t_37 = 0;
-                                  if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_Y.shape[0];
-                                  if (__pyx_t_37 < 0) __pyx_t_37 += __pyx_v_Y.shape[1];
-                                  __pyx_v_item_norm = (__pyx_v_item_norm + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_34 * __pyx_v_Y.strides[0]) ) + __pyx_t_35 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_36 * __pyx_v_Y.strides[0]) ) + __pyx_t_37 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_35 = __pyx_v_i;
+                                  __pyx_t_36 = 0;
+                                  if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_Y.shape[0];
+                                  if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_Y.shape[1];
+                                  __pyx_t_37 = __pyx_v_i;
+                                  __pyx_t_38 = 0;
+                                  if (__pyx_t_37 < 0) __pyx_t_37 += __pyx_v_Y.shape[0];
+                                  if (__pyx_t_38 < 0) __pyx_t_38 += __pyx_v_Y.shape[1];
+                                  __pyx_v_item_norm = (__pyx_v_item_norm + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_35 * __pyx_v_Y.strides[0]) ) + __pyx_t_36 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_37 * __pyx_v_Y.strides[0]) ) + __pyx_t_38 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one)));
                               }
                           }
                       }
                   }
                 }
 
-                /* "implicit/_als.pyx":267
+                /* "implicit/_als.pyx":286
  * 
  *         finally:
  *             free(r)             # <<<<<<<<<<<<<<
@@ -23875,7 +24706,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
         #endif
       }
 
-      /* "implicit/_als.pyx":241
+      /* "implicit/_als.pyx":255
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -23894,7 +24725,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
       }
   }
 
-  /* "implicit/_als.pyx":269
+  /* "implicit/_als.pyx":288
  *             free(r)
  * 
  *     loss += regularization * (item_norm + user_norm)             # <<<<<<<<<<<<<<
@@ -23902,41 +24733,41 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
  */
   __pyx_v_loss = (__pyx_v_loss + (__pyx_v_regularization * (__pyx_v_item_norm + __pyx_v_user_norm)));
 
-  /* "implicit/_als.pyx":270
+  /* "implicit/_als.pyx":289
  * 
  *     loss += regularization * (item_norm + user_norm)
  *     return loss / (total_confidence + Cui.shape[0] * Cui.shape[1] - Cui.nnz)             # <<<<<<<<<<<<<<
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyFloat_FromDouble(__pyx_v_loss); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_1 = PyFloat_FromDouble(__pyx_v_loss); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_total_confidence); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_total_confidence); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_GetItemInt(__pyx_t_4, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_GetItemInt(__pyx_t_4, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_4, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_4, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = PyNumber_Multiply(__pyx_t_5, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = PyNumber_Multiply(__pyx_t_5, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = PyNumber_Add(__pyx_t_3, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_2 = PyNumber_Add(__pyx_t_3, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_nnz); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_nnz); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_3 = PyNumber_Subtract(__pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_3 = PyNumber_Subtract(__pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyNumber_Divide(__pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyNumber_Divide(__pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -23944,7 +24775,7 @@ static PyObject *__pyx_pf_8implicit_4_als_46_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_t_4 = 0;
   goto __pyx_L0;
 
-  /* "implicit/_als.pyx":227
+  /* "implicit/_als.pyx":241
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _calculate_loss(Cui, integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
@@ -23984,14 +24815,14 @@ static PyObject *__pyx_pf_8implicit_4_als_122__defaults__(CYTHON_UNUSED PyObject
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("__defaults__", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults34, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults34, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_2);
   PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_2);
@@ -24066,37 +24897,37 @@ static PyObject *__pyx_fuse_2_0__pyx_pw_8implicit_4_als_49_calculate_loss(PyObje
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indptr)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 1); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 1); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indices)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 2); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 2); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_data)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 3); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 3); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
         if (likely((values[4] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_X)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 4); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 4); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  5:
         if (likely((values[5] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_Y)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 5); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 5); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  6:
         if (likely((values[6] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_regularization)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 6); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 6); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  7:
@@ -24106,7 +24937,7 @@ static PyObject *__pyx_fuse_2_0__pyx_pw_8implicit_4_als_49_calculate_loss(PyObje
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_calculate_loss") < 0)) __PYX_ERR(0, 227, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_calculate_loss") < 0)) __PYX_ERR(0, 241, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -24124,21 +24955,21 @@ static PyObject *__pyx_fuse_2_0__pyx_pw_8implicit_4_als_49_calculate_loss(PyObje
       }
     }
     __pyx_v_Cui = values[0];
-    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_long(values[1]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_long(values[2]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[3]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[4]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 228, __pyx_L3_error)
-    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[5]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 228, __pyx_L3_error)
-    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[6]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 228, __pyx_L3_error)
+    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_long(values[1]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_long(values[2]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[3]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[4]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 242, __pyx_L3_error)
+    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(values[5]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 242, __pyx_L3_error)
+    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[6]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 242, __pyx_L3_error)
     if (values[7]) {
-      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 229, __pyx_L3_error)
+      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 243, __pyx_L3_error)
     } else {
       __pyx_v_num_threads = __pyx_dynamic_args->__pyx_arg_num_threads;
     }
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 227, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 241, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("implicit._als._calculate_loss", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -24192,7 +25023,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
   int __pyx_t_19;
   Py_ssize_t __pyx_t_20;
   Py_ssize_t __pyx_t_21;
-  Py_ssize_t __pyx_t_22;
+  int __pyx_t_22;
   Py_ssize_t __pyx_t_23;
   Py_ssize_t __pyx_t_24;
   Py_ssize_t __pyx_t_25;
@@ -24208,9 +25039,10 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
   Py_ssize_t __pyx_t_35;
   Py_ssize_t __pyx_t_36;
   Py_ssize_t __pyx_t_37;
+  Py_ssize_t __pyx_t_38;
   __Pyx_RefNannySetupContext("__pyx_fuse_2_0_calculate_loss", 0);
 
-  /* "implicit/_als.pyx":230
+  /* "implicit/_als.pyx":244
  *                     floating[:, :] X, floating[:, :] Y, float regularization,
  *                     int num_threads=0):
  *     dtype = np.float64 if floating is double else np.float32             # <<<<<<<<<<<<<<
@@ -24218,17 +25050,17 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
  *     cdef floating confidence, temp
  */
   if ((0 != 0)) {
-    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_1 = __pyx_t_3;
     __pyx_t_3 = 0;
   } else {
-    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_t_1 = __pyx_t_2;
@@ -24237,7 +25069,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_dtype = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "implicit/_als.pyx":231
+  /* "implicit/_als.pyx":245
  *                     int num_threads=0):
  *     dtype = np.float64 if floating is double else np.float32
  *     cdef int users = X.shape[0], N = X.shape[1], items = Y.shape[0], u, i, index, one = 1             # <<<<<<<<<<<<<<
@@ -24249,7 +25081,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_items = (__pyx_v_Y.shape[0]);
   __pyx_v_one = 1;
 
-  /* "implicit/_als.pyx":233
+  /* "implicit/_als.pyx":247
  *     cdef int users = X.shape[0], N = X.shape[1], items = Y.shape[0], u, i, index, one = 1
  *     cdef floating confidence, temp
  *     cdef floating zero = 0.             # <<<<<<<<<<<<<<
@@ -24258,24 +25090,24 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
  */
   __pyx_v_zero = 0.;
 
-  /* "implicit/_als.pyx":235
+  /* "implicit/_als.pyx":249
  *     cdef floating zero = 0.
  * 
  *     cdef floating[:, :] YtY = np.dot(np.transpose(Y), Y)             # <<<<<<<<<<<<<<
  * 
  *     cdef floating * r
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_6 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -24288,14 +25120,14 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
     }
   }
   if (!__pyx_t_6) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_GOTREF(__pyx_t_2);
   } else {
     #if CYTHON_FAST_PYCALL
     if (PyFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -24304,26 +25136,26 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
     #if CYTHON_FAST_PYCCALL
     if (__Pyx_PyFastCFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     } else
     #endif
     {
-      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_6); __pyx_t_6 = NULL;
       __Pyx_GIVEREF(__pyx_t_4);
       PyTuple_SET_ITEM(__pyx_t_7, 0+1, __pyx_t_4);
       __pyx_t_4 = 0;
-      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     }
   }
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_float, (int (*)(char *, PyObject *)) __pyx_memview_set_float, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_7 = NULL;
   __pyx_t_8 = 0;
@@ -24340,7 +25172,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -24350,7 +25182,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -24358,7 +25190,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
   } else
   #endif
   {
-    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     if (__pyx_t_7) {
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -24369,19 +25201,19 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
     PyTuple_SET_ITEM(__pyx_t_4, 1+__pyx_t_8, __pyx_t_5);
     __pyx_t_2 = 0;
     __pyx_t_5 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_float(__pyx_t_1);
-  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 235, __pyx_L1_error)
+  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v_YtY = __pyx_t_9;
   __pyx_t_9.memview = NULL;
   __pyx_t_9.data = NULL;
 
-  /* "implicit/_als.pyx":239
+  /* "implicit/_als.pyx":253
  *     cdef floating * r
  * 
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0             # <<<<<<<<<<<<<<
@@ -24393,7 +25225,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_item_norm = 0.0;
   __pyx_v_user_norm = 0.0;
 
-  /* "implicit/_als.pyx":241
+  /* "implicit/_als.pyx":255
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -24415,13 +25247,13 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
                 #define unlikely(x) (x)
             #endif
             #ifdef _OPENMP
-            #pragma omp parallel private(__pyx_v_r) reduction(+:__pyx_v_loss) reduction(+:__pyx_v_total_confidence) reduction(+:__pyx_v_user_norm) reduction(+:__pyx_v_item_norm) private(__pyx_t_10, __pyx_t_11, __pyx_t_12, __pyx_t_13, __pyx_t_14, __pyx_t_15, __pyx_t_16, __pyx_t_17, __pyx_t_18, __pyx_t_19, __pyx_t_20, __pyx_t_21, __pyx_t_22, __pyx_t_23, __pyx_t_24, __pyx_t_25, __pyx_t_26, __pyx_t_27, __pyx_t_28, __pyx_t_29, __pyx_t_30, __pyx_t_31, __pyx_t_32, __pyx_t_33, __pyx_t_34, __pyx_t_35, __pyx_t_36, __pyx_t_37, __pyx_t_8) num_threads(__pyx_v_num_threads)
+            #pragma omp parallel private(__pyx_v_r) reduction(+:__pyx_v_loss) reduction(+:__pyx_v_total_confidence) reduction(+:__pyx_v_user_norm) reduction(+:__pyx_v_item_norm) private(__pyx_t_10, __pyx_t_11, __pyx_t_12, __pyx_t_13, __pyx_t_14, __pyx_t_15, __pyx_t_16, __pyx_t_17, __pyx_t_18, __pyx_t_19, __pyx_t_20, __pyx_t_21, __pyx_t_22, __pyx_t_23, __pyx_t_24, __pyx_t_25, __pyx_t_26, __pyx_t_27, __pyx_t_28, __pyx_t_29, __pyx_t_30, __pyx_t_31, __pyx_t_32, __pyx_t_33, __pyx_t_34, __pyx_t_35, __pyx_t_36, __pyx_t_37, __pyx_t_38, __pyx_t_8) num_threads(__pyx_v_num_threads)
             #endif /* _OPENMP */
             {
                 /* Initialize private variables to invalid values */
                 __pyx_v_r = ((float *)1);
 
-                /* "implicit/_als.pyx":242
+                /* "implicit/_als.pyx":256
  * 
  *     with nogil, parallel(num_threads=num_threads):
  *         r = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -24430,7 +25262,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
  */
                 __pyx_v_r = ((float *)malloc(((sizeof(float)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":243
+                /* "implicit/_als.pyx":257
  *     with nogil, parallel(num_threads=num_threads):
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:             # <<<<<<<<<<<<<<
@@ -24439,7 +25271,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
  */
                 /*try:*/ {
 
-                  /* "implicit/_als.pyx":244
+                  /* "implicit/_als.pyx":258
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:
  *             for u in prange(users, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -24464,7 +25296,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
                                   __pyx_v_index = ((int)0xbad0bad0);
                                   __pyx_v_temp = ((float)__PYX_NAN());
 
-                                  /* "implicit/_als.pyx":246
+                                  /* "implicit/_als.pyx":260
  *             for u in prange(users, schedule='guided'):
  *                 # calculates (A.dot(Xu) - 2 * b).dot(Xu), without calculating A
  *                 temp = 1.0             # <<<<<<<<<<<<<<
@@ -24473,7 +25305,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
  */
                                   __pyx_v_temp = 1.0;
 
-                                  /* "implicit/_als.pyx":247
+                                  /* "implicit/_als.pyx":261
  *                 # calculates (A.dot(Xu) - 2 * b).dot(Xu), without calculating A
  *                 temp = 1.0
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, &X[u, 0], &one, &zero, r, &one)             # <<<<<<<<<<<<<<
@@ -24490,7 +25322,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
                                   if (__pyx_t_15 < 0) __pyx_t_15 += __pyx_v_X.shape[1];
                                   __pyx_fuse_0__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_12 * __pyx_v_YtY.strides[0]) ) + __pyx_t_13 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_14 * __pyx_v_X.strides[0]) ) + __pyx_t_15 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":249
+                                  /* "implicit/_als.pyx":263
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, &X[u, 0], &one, &zero, r, &one)
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -24505,7 +25337,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
                                   for (__pyx_t_19 = (*((long *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_18 * __pyx_v_indptr.strides[0]) ))); __pyx_t_19 < __pyx_t_17; __pyx_t_19+=1) {
                                     __pyx_v_index = __pyx_t_19;
 
-                                    /* "implicit/_als.pyx":250
+                                    /* "implicit/_als.pyx":264
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]             # <<<<<<<<<<<<<<
@@ -24516,56 +25348,98 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
                                     if (__pyx_t_20 < 0) __pyx_t_20 += __pyx_v_indices.shape[0];
                                     __pyx_v_i = (*((long *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_20 * __pyx_v_indices.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":251
+                                    /* "implicit/_als.pyx":265
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]
  *                     confidence = data[index]             # <<<<<<<<<<<<<<
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
+ *                     if confidence > 0:
  */
                                     __pyx_t_21 = __pyx_v_index;
                                     if (__pyx_t_21 < 0) __pyx_t_21 += __pyx_v_data.shape[0];
                                     __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_21 * __pyx_v_data.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":253
+                                    /* "implicit/_als.pyx":267
  *                     confidence = data[index]
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],             # <<<<<<<<<<<<<<
- *                                                   &one) - 2 * confidence
- *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = -2 * confidence
+ *                     else:
  */
-                                    __pyx_t_22 = __pyx_v_i;
-                                    __pyx_t_23 = 0;
-                                    if (__pyx_t_22 < 0) __pyx_t_22 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_Y.shape[1];
-                                    __pyx_t_24 = __pyx_v_u;
-                                    __pyx_t_25 = 0;
-                                    if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_X.shape[0];
-                                    if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_X.shape[1];
+                                    __pyx_t_22 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_22) {
 
-                                    /* "implicit/_als.pyx":254
+                                      /* "implicit/_als.pyx":268
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
- *                                                   &one) - 2 * confidence             # <<<<<<<<<<<<<<
+ *                     if confidence > 0:
+ *                         temp = -2 * confidence             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         temp = 0
+ */
+                                      __pyx_v_temp = (-2.0 * __pyx_v_confidence);
+
+                                      /* "implicit/_als.pyx":267
+ *                     confidence = data[index]
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = -2 * confidence
+ *                     else:
+ */
+                                      goto __pyx_L21;
+                                    }
+
+                                    /* "implicit/_als.pyx":270
+ *                         temp = -2 * confidence
+ *                     else:
+ *                         temp = 0             # <<<<<<<<<<<<<<
+ *                         confidence = -1 * confidence
+ * 
+ */
+                                    /*else*/ {
+                                      __pyx_v_temp = 0.0;
+
+                                      /* "implicit/_als.pyx":271
+ *                     else:
+ *                         temp = 0
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)
+ */
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L21:;
+
+                                    /* "implicit/_als.pyx":273
+ *                         confidence = -1 * confidence
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  */
-                                    __pyx_v_temp = (((__pyx_v_confidence - 1.0) * __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_22 * __pyx_v_Y.strides[0]) ) + __pyx_t_23 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_24 * __pyx_v_X.strides[0]) ) + __pyx_t_25 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one))) - (2.0 * __pyx_v_confidence));
+                                    __pyx_t_23 = __pyx_v_i;
+                                    __pyx_t_24 = 0;
+                                    if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_Y.shape[0];
+                                    if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_Y.shape[1];
+                                    __pyx_t_25 = __pyx_v_u;
+                                    __pyx_t_26 = 0;
+                                    if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_X.shape[0];
+                                    if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_X.shape[1];
+                                    __pyx_v_temp = (__pyx_v_temp + ((__pyx_v_confidence - 1.0) * __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_23 * __pyx_v_Y.strides[0]) ) + __pyx_t_24 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_25 * __pyx_v_X.strides[0]) ) + __pyx_t_26 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one))));
 
-                                    /* "implicit/_als.pyx":255
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
- *                                                   &one) - 2 * confidence
+                                    /* "implicit/_als.pyx":274
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)             # <<<<<<<<<<<<<<
  * 
  *                     total_confidence += confidence
  */
-                                    __pyx_t_26 = __pyx_v_i;
-                                    __pyx_t_27 = 0;
-                                    if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[1];
-                                    __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_26 * __pyx_v_Y.strides[0]) ) + __pyx_t_27 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
+                                    __pyx_t_27 = __pyx_v_i;
+                                    __pyx_t_28 = 0;
+                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
+                                    if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
+                                    __pyx_fuse_0__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":257
+                                    /* "implicit/_als.pyx":276
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  *                     total_confidence += confidence             # <<<<<<<<<<<<<<
@@ -24574,7 +25448,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
  */
                                     __pyx_v_total_confidence = (__pyx_v_total_confidence + __pyx_v_confidence);
 
-                                    /* "implicit/_als.pyx":258
+                                    /* "implicit/_als.pyx":277
  * 
  *                     total_confidence += confidence
  *                     loss += confidence             # <<<<<<<<<<<<<<
@@ -24584,41 +25458,41 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
                                     __pyx_v_loss = (__pyx_v_loss + __pyx_v_confidence);
                                   }
 
-                                  /* "implicit/_als.pyx":260
+                                  /* "implicit/_als.pyx":279
  *                     loss += confidence
  * 
  *                 loss += dot(&N, r, &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)
  * 
  */
-                                  __pyx_t_28 = __pyx_v_u;
-                                  __pyx_t_29 = 0;
-                                  if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_29 < 0) __pyx_t_29 += __pyx_v_X.shape[1];
-                                  __pyx_v_loss = (__pyx_v_loss + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_28 * __pyx_v_X.strides[0]) ) + __pyx_t_29 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_29 = __pyx_v_u;
+                                  __pyx_t_30 = 0;
+                                  if (__pyx_t_29 < 0) __pyx_t_29 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_30 < 0) __pyx_t_30 += __pyx_v_X.shape[1];
+                                  __pyx_v_loss = (__pyx_v_loss + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_29 * __pyx_v_X.strides[0]) ) + __pyx_t_30 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
 
-                                  /* "implicit/_als.pyx":261
+                                  /* "implicit/_als.pyx":280
  * 
  *                 loss += dot(&N, r, &one, &X[u, 0], &one)
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  * 
  *             for i in prange(items, schedule='guided'):
  */
-                                  __pyx_t_30 = __pyx_v_u;
-                                  __pyx_t_31 = 0;
-                                  if (__pyx_t_30 < 0) __pyx_t_30 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_31 < 0) __pyx_t_31 += __pyx_v_X.shape[1];
-                                  __pyx_t_32 = __pyx_v_u;
-                                  __pyx_t_33 = 0;
-                                  if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_33 < 0) __pyx_t_33 += __pyx_v_X.shape[1];
-                                  __pyx_v_user_norm = (__pyx_v_user_norm + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_30 * __pyx_v_X.strides[0]) ) + __pyx_t_31 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_32 * __pyx_v_X.strides[0]) ) + __pyx_t_33 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_31 = __pyx_v_u;
+                                  __pyx_t_32 = 0;
+                                  if (__pyx_t_31 < 0) __pyx_t_31 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_X.shape[1];
+                                  __pyx_t_33 = __pyx_v_u;
+                                  __pyx_t_34 = 0;
+                                  if (__pyx_t_33 < 0) __pyx_t_33 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_34 < 0) __pyx_t_34 += __pyx_v_X.shape[1];
+                                  __pyx_v_user_norm = (__pyx_v_user_norm + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_31 * __pyx_v_X.strides[0]) ) + __pyx_t_32 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_33 * __pyx_v_X.strides[0]) ) + __pyx_t_34 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
                               }
                           }
                       }
                   }
 
-                  /* "implicit/_als.pyx":263
+                  /* "implicit/_als.pyx":282
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)
  * 
  *             for i in prange(items, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -24638,29 +25512,29 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
                               {
                                   __pyx_v_i = (int)(0 + 1 * __pyx_t_10);
 
-                                  /* "implicit/_als.pyx":264
+                                  /* "implicit/_als.pyx":283
  * 
  *             for i in prange(items, schedule='guided'):
  *                 item_norm += dot(&N, &Y[i, 0], &one, &Y[i, 0], &one)             # <<<<<<<<<<<<<<
  * 
  *         finally:
  */
-                                  __pyx_t_34 = __pyx_v_i;
-                                  __pyx_t_35 = 0;
-                                  if (__pyx_t_34 < 0) __pyx_t_34 += __pyx_v_Y.shape[0];
-                                  if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_Y.shape[1];
-                                  __pyx_t_36 = __pyx_v_i;
-                                  __pyx_t_37 = 0;
-                                  if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_Y.shape[0];
-                                  if (__pyx_t_37 < 0) __pyx_t_37 += __pyx_v_Y.shape[1];
-                                  __pyx_v_item_norm = (__pyx_v_item_norm + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_34 * __pyx_v_Y.strides[0]) ) + __pyx_t_35 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_36 * __pyx_v_Y.strides[0]) ) + __pyx_t_37 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_35 = __pyx_v_i;
+                                  __pyx_t_36 = 0;
+                                  if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_Y.shape[0];
+                                  if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_Y.shape[1];
+                                  __pyx_t_37 = __pyx_v_i;
+                                  __pyx_t_38 = 0;
+                                  if (__pyx_t_37 < 0) __pyx_t_37 += __pyx_v_Y.shape[0];
+                                  if (__pyx_t_38 < 0) __pyx_t_38 += __pyx_v_Y.shape[1];
+                                  __pyx_v_item_norm = (__pyx_v_item_norm + __pyx_fuse_0__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_35 * __pyx_v_Y.strides[0]) ) + __pyx_t_36 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((float *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_37 * __pyx_v_Y.strides[0]) ) + __pyx_t_38 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one)));
                               }
                           }
                       }
                   }
                 }
 
-                /* "implicit/_als.pyx":267
+                /* "implicit/_als.pyx":286
  * 
  *         finally:
  *             free(r)             # <<<<<<<<<<<<<<
@@ -24684,7 +25558,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
         #endif
       }
 
-      /* "implicit/_als.pyx":241
+      /* "implicit/_als.pyx":255
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -24703,7 +25577,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
       }
   }
 
-  /* "implicit/_als.pyx":269
+  /* "implicit/_als.pyx":288
  *             free(r)
  * 
  *     loss += regularization * (item_norm + user_norm)             # <<<<<<<<<<<<<<
@@ -24711,41 +25585,41 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
  */
   __pyx_v_loss = (__pyx_v_loss + (__pyx_v_regularization * (__pyx_v_item_norm + __pyx_v_user_norm)));
 
-  /* "implicit/_als.pyx":270
+  /* "implicit/_als.pyx":289
  * 
  *     loss += regularization * (item_norm + user_norm)
  *     return loss / (total_confidence + Cui.shape[0] * Cui.shape[1] - Cui.nnz)             # <<<<<<<<<<<<<<
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyFloat_FromDouble(__pyx_v_loss); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_1 = PyFloat_FromDouble(__pyx_v_loss); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_total_confidence); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_total_confidence); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_GetItemInt(__pyx_t_4, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_GetItemInt(__pyx_t_4, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_4, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_4, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = PyNumber_Multiply(__pyx_t_5, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = PyNumber_Multiply(__pyx_t_5, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = PyNumber_Add(__pyx_t_3, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_2 = PyNumber_Add(__pyx_t_3, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_nnz); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_nnz); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_3 = PyNumber_Subtract(__pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_3 = PyNumber_Subtract(__pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyNumber_Divide(__pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyNumber_Divide(__pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -24753,7 +25627,7 @@ static PyObject *__pyx_pf_8implicit_4_als_48_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_t_4 = 0;
   goto __pyx_L0;
 
-  /* "implicit/_als.pyx":227
+  /* "implicit/_als.pyx":241
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _calculate_loss(Cui, integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
@@ -24793,14 +25667,14 @@ static PyObject *__pyx_pf_8implicit_4_als_124__defaults__(CYTHON_UNUSED PyObject
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("__defaults__", 0);
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults35, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__Pyx_CyFunction_Defaults(__pyx_defaults35, __pyx_self)->__pyx_arg_num_threads); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_2);
   PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_2);
@@ -24875,37 +25749,37 @@ static PyObject *__pyx_fuse_2_1__pyx_pw_8implicit_4_als_51_calculate_loss(PyObje
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indptr)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 1); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 1); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_indices)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 2); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 2); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_data)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 3); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 3); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
         if (likely((values[4] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_X)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 4); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 4); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  5:
         if (likely((values[5] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_Y)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 5); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 5); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  6:
         if (likely((values[6] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_regularization)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 6); __PYX_ERR(0, 227, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, 6); __PYX_ERR(0, 241, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  7:
@@ -24915,7 +25789,7 @@ static PyObject *__pyx_fuse_2_1__pyx_pw_8implicit_4_als_51_calculate_loss(PyObje
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_calculate_loss") < 0)) __PYX_ERR(0, 227, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "_calculate_loss") < 0)) __PYX_ERR(0, 241, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -24933,21 +25807,21 @@ static PyObject *__pyx_fuse_2_1__pyx_pw_8implicit_4_als_51_calculate_loss(PyObje
       }
     }
     __pyx_v_Cui = values[0];
-    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_long(values[1]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_long(values[2]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[3]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 227, __pyx_L3_error)
-    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[4]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 228, __pyx_L3_error)
-    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[5]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 228, __pyx_L3_error)
-    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[6]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 228, __pyx_L3_error)
+    __pyx_v_indptr = __Pyx_PyObject_to_MemoryviewSlice_ds_long(values[1]); if (unlikely(!__pyx_v_indptr.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_indices = __Pyx_PyObject_to_MemoryviewSlice_ds_long(values[2]); if (unlikely(!__pyx_v_indices.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_data = __Pyx_PyObject_to_MemoryviewSlice_ds_float(values[3]); if (unlikely(!__pyx_v_data.memview)) __PYX_ERR(0, 241, __pyx_L3_error)
+    __pyx_v_X = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[4]); if (unlikely(!__pyx_v_X.memview)) __PYX_ERR(0, 242, __pyx_L3_error)
+    __pyx_v_Y = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(values[5]); if (unlikely(!__pyx_v_Y.memview)) __PYX_ERR(0, 242, __pyx_L3_error)
+    __pyx_v_regularization = __pyx_PyFloat_AsFloat(values[6]); if (unlikely((__pyx_v_regularization == (float)-1) && PyErr_Occurred())) __PYX_ERR(0, 242, __pyx_L3_error)
     if (values[7]) {
-      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 229, __pyx_L3_error)
+      __pyx_v_num_threads = __Pyx_PyInt_As_int(values[7]); if (unlikely((__pyx_v_num_threads == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 243, __pyx_L3_error)
     } else {
       __pyx_v_num_threads = __pyx_dynamic_args->__pyx_arg_num_threads;
     }
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 227, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("_calculate_loss", 0, 7, 8, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 241, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("implicit._als._calculate_loss", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -25001,7 +25875,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
   int __pyx_t_19;
   Py_ssize_t __pyx_t_20;
   Py_ssize_t __pyx_t_21;
-  Py_ssize_t __pyx_t_22;
+  int __pyx_t_22;
   Py_ssize_t __pyx_t_23;
   Py_ssize_t __pyx_t_24;
   Py_ssize_t __pyx_t_25;
@@ -25017,9 +25891,10 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
   Py_ssize_t __pyx_t_35;
   Py_ssize_t __pyx_t_36;
   Py_ssize_t __pyx_t_37;
+  Py_ssize_t __pyx_t_38;
   __Pyx_RefNannySetupContext("__pyx_fuse_2_1_calculate_loss", 0);
 
-  /* "implicit/_als.pyx":230
+  /* "implicit/_als.pyx":244
  *                     floating[:, :] X, floating[:, :] Y, float regularization,
  *                     int num_threads=0):
  *     dtype = np.float64 if floating is double else np.float32             # <<<<<<<<<<<<<<
@@ -25027,17 +25902,17 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
  *     cdef floating confidence, temp
  */
   if ((1 != 0)) {
-    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_float64); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_1 = __pyx_t_3;
     __pyx_t_3 = 0;
   } else {
-    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 230, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_float32); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_t_1 = __pyx_t_2;
@@ -25046,7 +25921,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_dtype = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "implicit/_als.pyx":231
+  /* "implicit/_als.pyx":245
  *                     int num_threads=0):
  *     dtype = np.float64 if floating is double else np.float32
  *     cdef int users = X.shape[0], N = X.shape[1], items = Y.shape[0], u, i, index, one = 1             # <<<<<<<<<<<<<<
@@ -25058,7 +25933,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_items = (__pyx_v_Y.shape[0]);
   __pyx_v_one = 1;
 
-  /* "implicit/_als.pyx":233
+  /* "implicit/_als.pyx":247
  *     cdef int users = X.shape[0], N = X.shape[1], items = Y.shape[0], u, i, index, one = 1
  *     cdef floating confidence, temp
  *     cdef floating zero = 0.             # <<<<<<<<<<<<<<
@@ -25067,24 +25942,24 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
  */
   __pyx_v_zero = 0.;
 
-  /* "implicit/_als.pyx":235
+  /* "implicit/_als.pyx":249
  *     cdef floating zero = 0.
  * 
  *     cdef floating[:, :] YtY = np.dot(np.transpose(Y), Y)             # <<<<<<<<<<<<<<
  * 
  *     cdef floating * r
  */
-  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dot); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetModuleGlobalName(__pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_transpose); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_4 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_t_6 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -25097,14 +25972,14 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
     }
   }
   if (!__pyx_t_6) {
-    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __Pyx_GOTREF(__pyx_t_2);
   } else {
     #if CYTHON_FAST_PYCALL
     if (PyFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -25113,26 +25988,26 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
     #if CYTHON_FAST_PYCCALL
     if (__Pyx_PyFastCFunction_Check(__pyx_t_5)) {
       PyObject *__pyx_temp[2] = {__pyx_t_6, __pyx_t_4};
-      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-1, 1+1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     } else
     #endif
     {
-      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_6); __pyx_t_6 = NULL;
       __Pyx_GIVEREF(__pyx_t_4);
       PyTuple_SET_ITEM(__pyx_t_7, 0+1, __pyx_t_4);
       __pyx_t_4 = 0;
-      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     }
   }
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 235, __pyx_L1_error)
+  __pyx_t_5 = __pyx_memoryview_fromslice(__pyx_v_Y, 2, (PyObject *(*)(char *)) __pyx_memview_get_double, (int (*)(char *, PyObject *)) __pyx_memview_set_double, 0);; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_7 = NULL;
   __pyx_t_8 = 0;
@@ -25149,7 +26024,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -25159,7 +26034,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
     PyObject *__pyx_temp[3] = {__pyx_t_7, __pyx_t_2, __pyx_t_5};
-    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -25167,7 +26042,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
   } else
   #endif
   {
-    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_4 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     if (__pyx_t_7) {
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -25178,19 +26053,19 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
     PyTuple_SET_ITEM(__pyx_t_4, 1+__pyx_t_8, __pyx_t_5);
     __pyx_t_2 = 0;
     __pyx_t_5 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_4, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_t_9 = __Pyx_PyObject_to_MemoryviewSlice_dsds_double(__pyx_t_1);
-  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 235, __pyx_L1_error)
+  if (unlikely(!__pyx_t_9.memview)) __PYX_ERR(0, 249, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v_YtY = __pyx_t_9;
   __pyx_t_9.memview = NULL;
   __pyx_t_9.data = NULL;
 
-  /* "implicit/_als.pyx":239
+  /* "implicit/_als.pyx":253
  *     cdef floating * r
  * 
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0             # <<<<<<<<<<<<<<
@@ -25202,7 +26077,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_v_item_norm = 0.0;
   __pyx_v_user_norm = 0.0;
 
-  /* "implicit/_als.pyx":241
+  /* "implicit/_als.pyx":255
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -25224,13 +26099,13 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
                 #define unlikely(x) (x)
             #endif
             #ifdef _OPENMP
-            #pragma omp parallel private(__pyx_v_r) reduction(+:__pyx_v_loss) reduction(+:__pyx_v_total_confidence) reduction(+:__pyx_v_user_norm) reduction(+:__pyx_v_item_norm) private(__pyx_t_10, __pyx_t_11, __pyx_t_12, __pyx_t_13, __pyx_t_14, __pyx_t_15, __pyx_t_16, __pyx_t_17, __pyx_t_18, __pyx_t_19, __pyx_t_20, __pyx_t_21, __pyx_t_22, __pyx_t_23, __pyx_t_24, __pyx_t_25, __pyx_t_26, __pyx_t_27, __pyx_t_28, __pyx_t_29, __pyx_t_30, __pyx_t_31, __pyx_t_32, __pyx_t_33, __pyx_t_34, __pyx_t_35, __pyx_t_36, __pyx_t_37, __pyx_t_8) num_threads(__pyx_v_num_threads)
+            #pragma omp parallel private(__pyx_v_r) reduction(+:__pyx_v_loss) reduction(+:__pyx_v_total_confidence) reduction(+:__pyx_v_user_norm) reduction(+:__pyx_v_item_norm) private(__pyx_t_10, __pyx_t_11, __pyx_t_12, __pyx_t_13, __pyx_t_14, __pyx_t_15, __pyx_t_16, __pyx_t_17, __pyx_t_18, __pyx_t_19, __pyx_t_20, __pyx_t_21, __pyx_t_22, __pyx_t_23, __pyx_t_24, __pyx_t_25, __pyx_t_26, __pyx_t_27, __pyx_t_28, __pyx_t_29, __pyx_t_30, __pyx_t_31, __pyx_t_32, __pyx_t_33, __pyx_t_34, __pyx_t_35, __pyx_t_36, __pyx_t_37, __pyx_t_38, __pyx_t_8) num_threads(__pyx_v_num_threads)
             #endif /* _OPENMP */
             {
                 /* Initialize private variables to invalid values */
                 __pyx_v_r = ((double *)1);
 
-                /* "implicit/_als.pyx":242
+                /* "implicit/_als.pyx":256
  * 
  *     with nogil, parallel(num_threads=num_threads):
  *         r = <floating *> malloc(sizeof(floating) * N)             # <<<<<<<<<<<<<<
@@ -25239,7 +26114,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
  */
                 __pyx_v_r = ((double *)malloc(((sizeof(double)) * __pyx_v_N)));
 
-                /* "implicit/_als.pyx":243
+                /* "implicit/_als.pyx":257
  *     with nogil, parallel(num_threads=num_threads):
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:             # <<<<<<<<<<<<<<
@@ -25248,7 +26123,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
  */
                 /*try:*/ {
 
-                  /* "implicit/_als.pyx":244
+                  /* "implicit/_als.pyx":258
  *         r = <floating *> malloc(sizeof(floating) * N)
  *         try:
  *             for u in prange(users, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -25273,7 +26148,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
                                   __pyx_v_index = ((int)0xbad0bad0);
                                   __pyx_v_temp = ((double)__PYX_NAN());
 
-                                  /* "implicit/_als.pyx":246
+                                  /* "implicit/_als.pyx":260
  *             for u in prange(users, schedule='guided'):
  *                 # calculates (A.dot(Xu) - 2 * b).dot(Xu), without calculating A
  *                 temp = 1.0             # <<<<<<<<<<<<<<
@@ -25282,7 +26157,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
  */
                                   __pyx_v_temp = 1.0;
 
-                                  /* "implicit/_als.pyx":247
+                                  /* "implicit/_als.pyx":261
  *                 # calculates (A.dot(Xu) - 2 * b).dot(Xu), without calculating A
  *                 temp = 1.0
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, &X[u, 0], &one, &zero, r, &one)             # <<<<<<<<<<<<<<
@@ -25299,7 +26174,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
                                   if (__pyx_t_15 < 0) __pyx_t_15 += __pyx_v_X.shape[1];
                                   __pyx_fuse_1__pyx_f_8implicit_4_als_symv(((char *)"U"), (&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_YtY.data + __pyx_t_12 * __pyx_v_YtY.strides[0]) ) + __pyx_t_13 * __pyx_v_YtY.strides[1]) )))), (&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_14 * __pyx_v_X.strides[0]) ) + __pyx_t_15 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&__pyx_v_zero), __pyx_v_r, (&__pyx_v_one));
 
-                                  /* "implicit/_als.pyx":249
+                                  /* "implicit/_als.pyx":263
  *                 symv("U", &N, &temp, &YtY[0, 0], &N, &X[u, 0], &one, &zero, r, &one)
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):             # <<<<<<<<<<<<<<
@@ -25314,7 +26189,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
                                   for (__pyx_t_19 = (*((long *) ( /* dim=0 */ (__pyx_v_indptr.data + __pyx_t_18 * __pyx_v_indptr.strides[0]) ))); __pyx_t_19 < __pyx_t_17; __pyx_t_19+=1) {
                                     __pyx_v_index = __pyx_t_19;
 
-                                    /* "implicit/_als.pyx":250
+                                    /* "implicit/_als.pyx":264
  * 
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]             # <<<<<<<<<<<<<<
@@ -25325,56 +26200,98 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
                                     if (__pyx_t_20 < 0) __pyx_t_20 += __pyx_v_indices.shape[0];
                                     __pyx_v_i = (*((long *) ( /* dim=0 */ (__pyx_v_indices.data + __pyx_t_20 * __pyx_v_indices.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":251
+                                    /* "implicit/_als.pyx":265
  *                 for index in range(indptr[u], indptr[u + 1]):
  *                     i = indices[index]
  *                     confidence = data[index]             # <<<<<<<<<<<<<<
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
+ *                     if confidence > 0:
  */
                                     __pyx_t_21 = __pyx_v_index;
                                     if (__pyx_t_21 < 0) __pyx_t_21 += __pyx_v_data.shape[0];
                                     __pyx_v_confidence = (*((float *) ( /* dim=0 */ (__pyx_v_data.data + __pyx_t_21 * __pyx_v_data.strides[0]) )));
 
-                                    /* "implicit/_als.pyx":253
+                                    /* "implicit/_als.pyx":267
  *                     confidence = data[index]
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],             # <<<<<<<<<<<<<<
- *                                                   &one) - 2 * confidence
- *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = -2 * confidence
+ *                     else:
  */
-                                    __pyx_t_22 = __pyx_v_i;
-                                    __pyx_t_23 = 0;
-                                    if (__pyx_t_22 < 0) __pyx_t_22 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_Y.shape[1];
-                                    __pyx_t_24 = __pyx_v_u;
-                                    __pyx_t_25 = 0;
-                                    if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_X.shape[0];
-                                    if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_X.shape[1];
+                                    __pyx_t_22 = ((__pyx_v_confidence > 0.0) != 0);
+                                    if (__pyx_t_22) {
 
-                                    /* "implicit/_als.pyx":254
+                                      /* "implicit/_als.pyx":268
  * 
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
- *                                                   &one) - 2 * confidence             # <<<<<<<<<<<<<<
+ *                     if confidence > 0:
+ *                         temp = -2 * confidence             # <<<<<<<<<<<<<<
+ *                     else:
+ *                         temp = 0
+ */
+                                      __pyx_v_temp = (-2.0 * __pyx_v_confidence);
+
+                                      /* "implicit/_als.pyx":267
+ *                     confidence = data[index]
+ * 
+ *                     if confidence > 0:             # <<<<<<<<<<<<<<
+ *                         temp = -2 * confidence
+ *                     else:
+ */
+                                      goto __pyx_L21;
+                                    }
+
+                                    /* "implicit/_als.pyx":270
+ *                         temp = -2 * confidence
+ *                     else:
+ *                         temp = 0             # <<<<<<<<<<<<<<
+ *                         confidence = -1 * confidence
+ * 
+ */
+                                    /*else*/ {
+                                      __pyx_v_temp = 0.0;
+
+                                      /* "implicit/_als.pyx":271
+ *                     else:
+ *                         temp = 0
+ *                         confidence = -1 * confidence             # <<<<<<<<<<<<<<
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)
+ */
+                                      __pyx_v_confidence = (-1.0 * __pyx_v_confidence);
+                                    }
+                                    __pyx_L21:;
+
+                                    /* "implicit/_als.pyx":273
+ *                         confidence = -1 * confidence
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  */
-                                    __pyx_v_temp = (((__pyx_v_confidence - 1.0) * __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_22 * __pyx_v_Y.strides[0]) ) + __pyx_t_23 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_24 * __pyx_v_X.strides[0]) ) + __pyx_t_25 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one))) - (2.0 * __pyx_v_confidence));
+                                    __pyx_t_23 = __pyx_v_i;
+                                    __pyx_t_24 = 0;
+                                    if (__pyx_t_23 < 0) __pyx_t_23 += __pyx_v_Y.shape[0];
+                                    if (__pyx_t_24 < 0) __pyx_t_24 += __pyx_v_Y.shape[1];
+                                    __pyx_t_25 = __pyx_v_u;
+                                    __pyx_t_26 = 0;
+                                    if (__pyx_t_25 < 0) __pyx_t_25 += __pyx_v_X.shape[0];
+                                    if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_X.shape[1];
+                                    __pyx_v_temp = (__pyx_v_temp + ((__pyx_v_confidence - 1.0) * __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_23 * __pyx_v_Y.strides[0]) ) + __pyx_t_24 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_25 * __pyx_v_X.strides[0]) ) + __pyx_t_26 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one))));
 
-                                    /* "implicit/_als.pyx":255
- *                     temp = (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0],
- *                                                   &one) - 2 * confidence
+                                    /* "implicit/_als.pyx":274
+ * 
+ *                     temp = temp + (confidence - 1) * dot(&N, &Y[i, 0], &one, &X[u, 0], &one)
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)             # <<<<<<<<<<<<<<
  * 
  *                     total_confidence += confidence
  */
-                                    __pyx_t_26 = __pyx_v_i;
-                                    __pyx_t_27 = 0;
-                                    if (__pyx_t_26 < 0) __pyx_t_26 += __pyx_v_Y.shape[0];
-                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[1];
-                                    __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_26 * __pyx_v_Y.strides[0]) ) + __pyx_t_27 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
+                                    __pyx_t_27 = __pyx_v_i;
+                                    __pyx_t_28 = 0;
+                                    if (__pyx_t_27 < 0) __pyx_t_27 += __pyx_v_Y.shape[0];
+                                    if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_Y.shape[1];
+                                    __pyx_fuse_1__pyx_f_8implicit_4_als_axpy((&__pyx_v_N), (&__pyx_v_temp), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_27 * __pyx_v_Y.strides[0]) ) + __pyx_t_28 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), __pyx_v_r, (&__pyx_v_one));
 
-                                    /* "implicit/_als.pyx":257
+                                    /* "implicit/_als.pyx":276
  *                     axpy(&N, &temp, &Y[i, 0], &one, r, &one)
  * 
  *                     total_confidence += confidence             # <<<<<<<<<<<<<<
@@ -25383,7 +26300,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
  */
                                     __pyx_v_total_confidence = (__pyx_v_total_confidence + __pyx_v_confidence);
 
-                                    /* "implicit/_als.pyx":258
+                                    /* "implicit/_als.pyx":277
  * 
  *                     total_confidence += confidence
  *                     loss += confidence             # <<<<<<<<<<<<<<
@@ -25393,41 +26310,41 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
                                     __pyx_v_loss = (__pyx_v_loss + __pyx_v_confidence);
                                   }
 
-                                  /* "implicit/_als.pyx":260
+                                  /* "implicit/_als.pyx":279
  *                     loss += confidence
  * 
  *                 loss += dot(&N, r, &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)
  * 
  */
-                                  __pyx_t_28 = __pyx_v_u;
-                                  __pyx_t_29 = 0;
-                                  if (__pyx_t_28 < 0) __pyx_t_28 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_29 < 0) __pyx_t_29 += __pyx_v_X.shape[1];
-                                  __pyx_v_loss = (__pyx_v_loss + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_28 * __pyx_v_X.strides[0]) ) + __pyx_t_29 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_29 = __pyx_v_u;
+                                  __pyx_t_30 = 0;
+                                  if (__pyx_t_29 < 0) __pyx_t_29 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_30 < 0) __pyx_t_30 += __pyx_v_X.shape[1];
+                                  __pyx_v_loss = (__pyx_v_loss + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), __pyx_v_r, (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_29 * __pyx_v_X.strides[0]) ) + __pyx_t_30 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
 
-                                  /* "implicit/_als.pyx":261
+                                  /* "implicit/_als.pyx":280
  * 
  *                 loss += dot(&N, r, &one, &X[u, 0], &one)
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)             # <<<<<<<<<<<<<<
  * 
  *             for i in prange(items, schedule='guided'):
  */
-                                  __pyx_t_30 = __pyx_v_u;
-                                  __pyx_t_31 = 0;
-                                  if (__pyx_t_30 < 0) __pyx_t_30 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_31 < 0) __pyx_t_31 += __pyx_v_X.shape[1];
-                                  __pyx_t_32 = __pyx_v_u;
-                                  __pyx_t_33 = 0;
-                                  if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_X.shape[0];
-                                  if (__pyx_t_33 < 0) __pyx_t_33 += __pyx_v_X.shape[1];
-                                  __pyx_v_user_norm = (__pyx_v_user_norm + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_30 * __pyx_v_X.strides[0]) ) + __pyx_t_31 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_32 * __pyx_v_X.strides[0]) ) + __pyx_t_33 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_31 = __pyx_v_u;
+                                  __pyx_t_32 = 0;
+                                  if (__pyx_t_31 < 0) __pyx_t_31 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_32 < 0) __pyx_t_32 += __pyx_v_X.shape[1];
+                                  __pyx_t_33 = __pyx_v_u;
+                                  __pyx_t_34 = 0;
+                                  if (__pyx_t_33 < 0) __pyx_t_33 += __pyx_v_X.shape[0];
+                                  if (__pyx_t_34 < 0) __pyx_t_34 += __pyx_v_X.shape[1];
+                                  __pyx_v_user_norm = (__pyx_v_user_norm + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_31 * __pyx_v_X.strides[0]) ) + __pyx_t_32 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_X.data + __pyx_t_33 * __pyx_v_X.strides[0]) ) + __pyx_t_34 * __pyx_v_X.strides[1]) )))), (&__pyx_v_one)));
                               }
                           }
                       }
                   }
 
-                  /* "implicit/_als.pyx":263
+                  /* "implicit/_als.pyx":282
  *                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)
  * 
  *             for i in prange(items, schedule='guided'):             # <<<<<<<<<<<<<<
@@ -25447,29 +26364,29 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
                               {
                                   __pyx_v_i = (int)(0 + 1 * __pyx_t_10);
 
-                                  /* "implicit/_als.pyx":264
+                                  /* "implicit/_als.pyx":283
  * 
  *             for i in prange(items, schedule='guided'):
  *                 item_norm += dot(&N, &Y[i, 0], &one, &Y[i, 0], &one)             # <<<<<<<<<<<<<<
  * 
  *         finally:
  */
-                                  __pyx_t_34 = __pyx_v_i;
-                                  __pyx_t_35 = 0;
-                                  if (__pyx_t_34 < 0) __pyx_t_34 += __pyx_v_Y.shape[0];
-                                  if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_Y.shape[1];
-                                  __pyx_t_36 = __pyx_v_i;
-                                  __pyx_t_37 = 0;
-                                  if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_Y.shape[0];
-                                  if (__pyx_t_37 < 0) __pyx_t_37 += __pyx_v_Y.shape[1];
-                                  __pyx_v_item_norm = (__pyx_v_item_norm + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_34 * __pyx_v_Y.strides[0]) ) + __pyx_t_35 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_36 * __pyx_v_Y.strides[0]) ) + __pyx_t_37 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one)));
+                                  __pyx_t_35 = __pyx_v_i;
+                                  __pyx_t_36 = 0;
+                                  if (__pyx_t_35 < 0) __pyx_t_35 += __pyx_v_Y.shape[0];
+                                  if (__pyx_t_36 < 0) __pyx_t_36 += __pyx_v_Y.shape[1];
+                                  __pyx_t_37 = __pyx_v_i;
+                                  __pyx_t_38 = 0;
+                                  if (__pyx_t_37 < 0) __pyx_t_37 += __pyx_v_Y.shape[0];
+                                  if (__pyx_t_38 < 0) __pyx_t_38 += __pyx_v_Y.shape[1];
+                                  __pyx_v_item_norm = (__pyx_v_item_norm + __pyx_fuse_1__pyx_f_8implicit_4_als_dot((&__pyx_v_N), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_35 * __pyx_v_Y.strides[0]) ) + __pyx_t_36 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one), (&(*((double *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_Y.data + __pyx_t_37 * __pyx_v_Y.strides[0]) ) + __pyx_t_38 * __pyx_v_Y.strides[1]) )))), (&__pyx_v_one)));
                               }
                           }
                       }
                   }
                 }
 
-                /* "implicit/_als.pyx":267
+                /* "implicit/_als.pyx":286
  * 
  *         finally:
  *             free(r)             # <<<<<<<<<<<<<<
@@ -25493,7 +26410,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
         #endif
       }
 
-      /* "implicit/_als.pyx":241
+      /* "implicit/_als.pyx":255
  *     cdef double loss = 0, total_confidence = 0, item_norm = 0, user_norm = 0
  * 
  *     with nogil, parallel(num_threads=num_threads):             # <<<<<<<<<<<<<<
@@ -25512,7 +26429,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
       }
   }
 
-  /* "implicit/_als.pyx":269
+  /* "implicit/_als.pyx":288
  *             free(r)
  * 
  *     loss += regularization * (item_norm + user_norm)             # <<<<<<<<<<<<<<
@@ -25520,41 +26437,41 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
  */
   __pyx_v_loss = (__pyx_v_loss + (__pyx_v_regularization * (__pyx_v_item_norm + __pyx_v_user_norm)));
 
-  /* "implicit/_als.pyx":270
+  /* "implicit/_als.pyx":289
  * 
  *     loss += regularization * (item_norm + user_norm)
  *     return loss / (total_confidence + Cui.shape[0] * Cui.shape[1] - Cui.nnz)             # <<<<<<<<<<<<<<
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = PyFloat_FromDouble(__pyx_v_loss); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_1 = PyFloat_FromDouble(__pyx_v_loss); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_total_confidence); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_total_confidence); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_GetItemInt(__pyx_t_4, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_GetItemInt(__pyx_t_4, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_shape); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_4, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_4, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = PyNumber_Multiply(__pyx_t_5, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = PyNumber_Multiply(__pyx_t_5, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = PyNumber_Add(__pyx_t_3, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_2 = PyNumber_Add(__pyx_t_3, __pyx_t_4); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_nnz); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_Cui, __pyx_n_s_nnz); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_3 = PyNumber_Subtract(__pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_3 = PyNumber_Subtract(__pyx_t_2, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyNumber_Divide(__pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 270, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyNumber_Divide(__pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 289, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -25562,7 +26479,7 @@ static PyObject *__pyx_pf_8implicit_4_als_50_calculate_loss(CYTHON_UNUSED PyObje
   __pyx_t_4 = 0;
   goto __pyx_L0;
 
-  /* "implicit/_als.pyx":227
+  /* "implicit/_als.pyx":241
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _calculate_loss(Cui, integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
@@ -39280,7 +40197,7 @@ static int __Pyx_InitCachedBuiltins(void) {
   __pyx_builtin_zip = __Pyx_GetBuiltinName(__pyx_n_s_zip); if (!__pyx_builtin_zip) __PYX_ERR(0, 60, __pyx_L1_error)
   __pyx_builtin_reversed = __Pyx_GetBuiltinName(__pyx_n_s_reversed); if (!__pyx_builtin_reversed) __PYX_ERR(0, 60, __pyx_L1_error)
   __pyx_builtin_range = __Pyx_GetBuiltinName(__pyx_n_s_range); if (!__pyx_builtin_range) __PYX_ERR(0, 60, __pyx_L1_error)
-  __pyx_builtin_ValueError = __Pyx_GetBuiltinName(__pyx_n_s_ValueError); if (!__pyx_builtin_ValueError) __PYX_ERR(0, 119, __pyx_L1_error)
+  __pyx_builtin_ValueError = __Pyx_GetBuiltinName(__pyx_n_s_ValueError); if (!__pyx_builtin_ValueError) __PYX_ERR(0, 122, __pyx_L1_error)
   __pyx_builtin_MemoryError = __Pyx_GetBuiltinName(__pyx_n_s_MemoryError); if (!__pyx_builtin_MemoryError) __PYX_ERR(1, 146, __pyx_L1_error)
   __pyx_builtin_enumerate = __Pyx_GetBuiltinName(__pyx_n_s_enumerate); if (!__pyx_builtin_enumerate) __PYX_ERR(1, 149, __pyx_L1_error)
   __pyx_builtin_Ellipsis = __Pyx_GetBuiltinName(__pyx_n_s_Ellipsis); if (!__pyx_builtin_Ellipsis) __PYX_ERR(1, 398, __pyx_L1_error)
@@ -39326,65 +40243,65 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GOTREF(__pyx_tuple__9);
   __Pyx_GIVEREF(__pyx_tuple__9);
 
-  /* "implicit/_als.pyx":128
+  /* "implicit/_als.pyx":131
  * 
  * def least_squares_cg(Cui, X, Y, regularization, num_threads=0, cg_steps=3):
  *     return _least_squares_cg(Cui.indptr, Cui.indices, Cui.data.astype('float32'),             # <<<<<<<<<<<<<<
  *                              X, Y, regularization, num_threads, cg_steps)
  * 
  */
-  __pyx_tuple__10 = PyTuple_Pack(1, __pyx_n_s_float32); if (unlikely(!__pyx_tuple__10)) __PYX_ERR(0, 128, __pyx_L1_error)
+  __pyx_tuple__10 = PyTuple_Pack(1, __pyx_n_s_float32); if (unlikely(!__pyx_tuple__10)) __PYX_ERR(0, 131, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__10);
   __Pyx_GIVEREF(__pyx_tuple__10);
 
-  /* "implicit/_als.pyx":134
+  /* "implicit/_als.pyx":137
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _least_squares_cg(integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
  *                       floating[:, :] X, floating[:, :] Y, float regularization,
  *                       int num_threads=0, int cg_steps=3):
  */
-  __pyx_tuple__11 = PyTuple_Pack(1, __pyx_kp_s__4); if (unlikely(!__pyx_tuple__11)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_tuple__11 = PyTuple_Pack(1, __pyx_kp_s__4); if (unlikely(!__pyx_tuple__11)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__11);
   __Pyx_GIVEREF(__pyx_tuple__11);
-  __pyx_tuple__12 = PyTuple_Pack(1, __pyx_kp_s__6); if (unlikely(!__pyx_tuple__12)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_tuple__12 = PyTuple_Pack(1, __pyx_kp_s__6); if (unlikely(!__pyx_tuple__12)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__12);
   __Pyx_GIVEREF(__pyx_tuple__12);
-  __pyx_tuple__13 = PyTuple_Pack(1, __pyx_kp_s_No_matching_signature_found); if (unlikely(!__pyx_tuple__13)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_tuple__13 = PyTuple_Pack(1, __pyx_kp_s_No_matching_signature_found); if (unlikely(!__pyx_tuple__13)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__13);
   __Pyx_GIVEREF(__pyx_tuple__13);
-  __pyx_tuple__14 = PyTuple_Pack(1, __pyx_kp_s_Function_call_with_ambiguous_arg); if (unlikely(!__pyx_tuple__14)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_tuple__14 = PyTuple_Pack(1, __pyx_kp_s_Function_call_with_ambiguous_arg); if (unlikely(!__pyx_tuple__14)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__14);
   __Pyx_GIVEREF(__pyx_tuple__14);
 
-  /* "implicit/_als.pyx":221
+  /* "implicit/_als.pyx":235
  * 
  * def calculate_loss(Cui, X, Y, regularization, num_threads=0):
  *     return _calculate_loss(Cui, Cui.indptr, Cui.indices, Cui.data.astype('float32'),             # <<<<<<<<<<<<<<
  *                            X, Y, regularization, num_threads)
  * 
  */
-  __pyx_tuple__15 = PyTuple_Pack(1, __pyx_n_s_float32); if (unlikely(!__pyx_tuple__15)) __PYX_ERR(0, 221, __pyx_L1_error)
+  __pyx_tuple__15 = PyTuple_Pack(1, __pyx_n_s_float32); if (unlikely(!__pyx_tuple__15)) __PYX_ERR(0, 235, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__15);
   __Pyx_GIVEREF(__pyx_tuple__15);
 
-  /* "implicit/_als.pyx":227
+  /* "implicit/_als.pyx":241
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _calculate_loss(Cui, integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
  *                     floating[:, :] X, floating[:, :] Y, float regularization,
  *                     int num_threads=0):
  */
-  __pyx_tuple__16 = PyTuple_Pack(1, __pyx_kp_s__4); if (unlikely(!__pyx_tuple__16)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_tuple__16 = PyTuple_Pack(1, __pyx_kp_s__4); if (unlikely(!__pyx_tuple__16)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__16);
   __Pyx_GIVEREF(__pyx_tuple__16);
-  __pyx_tuple__17 = PyTuple_Pack(1, __pyx_kp_s__6); if (unlikely(!__pyx_tuple__17)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_tuple__17 = PyTuple_Pack(1, __pyx_kp_s__6); if (unlikely(!__pyx_tuple__17)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__17);
   __Pyx_GIVEREF(__pyx_tuple__17);
-  __pyx_tuple__18 = PyTuple_Pack(1, __pyx_kp_s_No_matching_signature_found); if (unlikely(!__pyx_tuple__18)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_tuple__18 = PyTuple_Pack(1, __pyx_kp_s_No_matching_signature_found); if (unlikely(!__pyx_tuple__18)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__18);
   __Pyx_GIVEREF(__pyx_tuple__18);
-  __pyx_tuple__19 = PyTuple_Pack(1, __pyx_kp_s_Function_call_with_ambiguous_arg); if (unlikely(!__pyx_tuple__19)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_tuple__19 = PyTuple_Pack(1, __pyx_kp_s_Function_call_with_ambiguous_arg); if (unlikely(!__pyx_tuple__19)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__19);
   __Pyx_GIVEREF(__pyx_tuple__19);
 
@@ -39615,53 +40532,53 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_GIVEREF(__pyx_tuple__41);
   __pyx_codeobj__42 = (PyObject*)__Pyx_PyCode_New(7, 0, 23, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__41, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_implicit__als_pyx, __pyx_n_s_least_squares, 60, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__42)) __PYX_ERR(0, 60, __pyx_L1_error)
 
-  /* "implicit/_als.pyx":127
+  /* "implicit/_als.pyx":130
  * 
  * 
  * def least_squares_cg(Cui, X, Y, regularization, num_threads=0, cg_steps=3):             # <<<<<<<<<<<<<<
  *     return _least_squares_cg(Cui.indptr, Cui.indices, Cui.data.astype('float32'),
  *                              X, Y, regularization, num_threads, cg_steps)
  */
-  __pyx_tuple__43 = PyTuple_Pack(6, __pyx_n_s_Cui, __pyx_n_s_X, __pyx_n_s_Y, __pyx_n_s_regularization, __pyx_n_s_num_threads, __pyx_n_s_cg_steps); if (unlikely(!__pyx_tuple__43)) __PYX_ERR(0, 127, __pyx_L1_error)
+  __pyx_tuple__43 = PyTuple_Pack(6, __pyx_n_s_Cui, __pyx_n_s_X, __pyx_n_s_Y, __pyx_n_s_regularization, __pyx_n_s_num_threads, __pyx_n_s_cg_steps); if (unlikely(!__pyx_tuple__43)) __PYX_ERR(0, 130, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__43);
   __Pyx_GIVEREF(__pyx_tuple__43);
-  __pyx_codeobj__44 = (PyObject*)__Pyx_PyCode_New(6, 0, 6, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__43, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_implicit__als_pyx, __pyx_n_s_least_squares_cg_2, 127, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__44)) __PYX_ERR(0, 127, __pyx_L1_error)
+  __pyx_codeobj__44 = (PyObject*)__Pyx_PyCode_New(6, 0, 6, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__43, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_implicit__als_pyx, __pyx_n_s_least_squares_cg_2, 130, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__44)) __PYX_ERR(0, 130, __pyx_L1_error)
 
-  /* "implicit/_als.pyx":134
+  /* "implicit/_als.pyx":137
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _least_squares_cg(integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
  *                       floating[:, :] X, floating[:, :] Y, float regularization,
  *                       int num_threads=0, int cg_steps=3):
  */
-  __pyx_tuple__45 = PyTuple_Pack(27, __pyx_n_s_indptr, __pyx_n_s_indices, __pyx_n_s_data, __pyx_n_s_X, __pyx_n_s_Y, __pyx_n_s_regularization, __pyx_n_s_num_threads, __pyx_n_s_cg_steps, __pyx_n_s_dtype, __pyx_n_s_users, __pyx_n_s_N, __pyx_n_s_u, __pyx_n_s_i, __pyx_n_s_index, __pyx_n_s_one, __pyx_n_s_it, __pyx_n_s_confidence, __pyx_n_s_temp, __pyx_n_s_alpha, __pyx_n_s_rsnew, __pyx_n_s_rsold, __pyx_n_s_zero, __pyx_n_s_YtY, __pyx_n_s_x, __pyx_n_s_p, __pyx_n_s_r, __pyx_n_s_Ap); if (unlikely(!__pyx_tuple__45)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_tuple__45 = PyTuple_Pack(27, __pyx_n_s_indptr, __pyx_n_s_indices, __pyx_n_s_data, __pyx_n_s_X, __pyx_n_s_Y, __pyx_n_s_regularization, __pyx_n_s_num_threads, __pyx_n_s_cg_steps, __pyx_n_s_dtype, __pyx_n_s_users, __pyx_n_s_N, __pyx_n_s_u, __pyx_n_s_i, __pyx_n_s_index, __pyx_n_s_one, __pyx_n_s_it, __pyx_n_s_confidence, __pyx_n_s_temp, __pyx_n_s_alpha, __pyx_n_s_rsnew, __pyx_n_s_rsold, __pyx_n_s_zero, __pyx_n_s_YtY, __pyx_n_s_x, __pyx_n_s_p, __pyx_n_s_r, __pyx_n_s_Ap); if (unlikely(!__pyx_tuple__45)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__45);
   __Pyx_GIVEREF(__pyx_tuple__45);
-  __pyx_codeobj__46 = (PyObject*)__Pyx_PyCode_New(8, 0, 27, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__45, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_implicit__als_pyx, __pyx_n_s_least_squares_cg, 134, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__46)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_codeobj__46 = (PyObject*)__Pyx_PyCode_New(8, 0, 27, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__45, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_implicit__als_pyx, __pyx_n_s_least_squares_cg, 137, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__46)) __PYX_ERR(0, 137, __pyx_L1_error)
 
-  /* "implicit/_als.pyx":220
+  /* "implicit/_als.pyx":234
  * 
  * 
  * def calculate_loss(Cui, X, Y, regularization, num_threads=0):             # <<<<<<<<<<<<<<
  *     return _calculate_loss(Cui, Cui.indptr, Cui.indices, Cui.data.astype('float32'),
  *                            X, Y, regularization, num_threads)
  */
-  __pyx_tuple__47 = PyTuple_Pack(5, __pyx_n_s_Cui, __pyx_n_s_X, __pyx_n_s_Y, __pyx_n_s_regularization, __pyx_n_s_num_threads); if (unlikely(!__pyx_tuple__47)) __PYX_ERR(0, 220, __pyx_L1_error)
+  __pyx_tuple__47 = PyTuple_Pack(5, __pyx_n_s_Cui, __pyx_n_s_X, __pyx_n_s_Y, __pyx_n_s_regularization, __pyx_n_s_num_threads); if (unlikely(!__pyx_tuple__47)) __PYX_ERR(0, 234, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__47);
   __Pyx_GIVEREF(__pyx_tuple__47);
-  __pyx_codeobj__48 = (PyObject*)__Pyx_PyCode_New(5, 0, 5, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__47, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_implicit__als_pyx, __pyx_n_s_calculate_loss_2, 220, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__48)) __PYX_ERR(0, 220, __pyx_L1_error)
+  __pyx_codeobj__48 = (PyObject*)__Pyx_PyCode_New(5, 0, 5, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__47, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_implicit__als_pyx, __pyx_n_s_calculate_loss_2, 234, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__48)) __PYX_ERR(0, 234, __pyx_L1_error)
 
-  /* "implicit/_als.pyx":227
+  /* "implicit/_als.pyx":241
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _calculate_loss(Cui, integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
  *                     floating[:, :] X, floating[:, :] Y, float regularization,
  *                     int num_threads=0):
  */
-  __pyx_tuple__49 = PyTuple_Pack(25, __pyx_n_s_Cui, __pyx_n_s_indptr, __pyx_n_s_indices, __pyx_n_s_data, __pyx_n_s_X, __pyx_n_s_Y, __pyx_n_s_regularization, __pyx_n_s_num_threads, __pyx_n_s_dtype, __pyx_n_s_users, __pyx_n_s_N, __pyx_n_s_items, __pyx_n_s_u, __pyx_n_s_i, __pyx_n_s_index, __pyx_n_s_one, __pyx_n_s_confidence, __pyx_n_s_temp, __pyx_n_s_zero, __pyx_n_s_YtY, __pyx_n_s_r, __pyx_n_s_loss, __pyx_n_s_total_confidence, __pyx_n_s_item_norm, __pyx_n_s_user_norm); if (unlikely(!__pyx_tuple__49)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_tuple__49 = PyTuple_Pack(25, __pyx_n_s_Cui, __pyx_n_s_indptr, __pyx_n_s_indices, __pyx_n_s_data, __pyx_n_s_X, __pyx_n_s_Y, __pyx_n_s_regularization, __pyx_n_s_num_threads, __pyx_n_s_dtype, __pyx_n_s_users, __pyx_n_s_N, __pyx_n_s_items, __pyx_n_s_u, __pyx_n_s_i, __pyx_n_s_index, __pyx_n_s_one, __pyx_n_s_confidence, __pyx_n_s_temp, __pyx_n_s_zero, __pyx_n_s_YtY, __pyx_n_s_r, __pyx_n_s_loss, __pyx_n_s_total_confidence, __pyx_n_s_item_norm, __pyx_n_s_user_norm); if (unlikely(!__pyx_tuple__49)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__49);
   __Pyx_GIVEREF(__pyx_tuple__49);
-  __pyx_codeobj__50 = (PyObject*)__Pyx_PyCode_New(8, 0, 25, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__49, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_implicit__als_pyx, __pyx_n_s_calculate_loss, 227, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__50)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_codeobj__50 = (PyObject*)__Pyx_PyCode_New(8, 0, 25, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__49, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_implicit__als_pyx, __pyx_n_s_calculate_loss, 241, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__50)) __PYX_ERR(0, 241, __pyx_L1_error)
 
   /* "View.MemoryView":284
  *         return self.name
@@ -40019,38 +40936,38 @@ PyMODINIT_FUNC PyInit__als(void)
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-  /* "implicit/_als.pyx":127
+  /* "implicit/_als.pyx":130
  * 
  * 
  * def least_squares_cg(Cui, X, Y, regularization, num_threads=0, cg_steps=3):             # <<<<<<<<<<<<<<
  *     return _least_squares_cg(Cui.indptr, Cui.indices, Cui.data.astype('float32'),
  *                              X, Y, regularization, num_threads, cg_steps)
  */
-  __pyx_t_6 = PyCFunction_NewEx(&__pyx_mdef_8implicit_4_als_5least_squares_cg, NULL, __pyx_n_s_implicit__als); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 127, __pyx_L1_error)
+  __pyx_t_6 = PyCFunction_NewEx(&__pyx_mdef_8implicit_4_als_5least_squares_cg, NULL, __pyx_n_s_implicit__als); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 130, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_least_squares_cg_2, __pyx_t_6) < 0) __PYX_ERR(0, 127, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_least_squares_cg_2, __pyx_t_6) < 0) __PYX_ERR(0, 130, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
 
-  /* "implicit/_als.pyx":136
+  /* "implicit/_als.pyx":139
  * def _least_squares_cg(integral[:] indptr, integral[:] indices, float[:] data,
  *                       floating[:, :] X, floating[:, :] Y, float regularization,
  *                       int num_threads=0, int cg_steps=3):             # <<<<<<<<<<<<<<
  *     dtype = np.float64 if floating is double else np.float32
  * 
  */
-  __pyx_t_6 = __Pyx_PyInt_From_long(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 136, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyInt_From_long(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 139, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_7 = __Pyx_PyInt_From_long(3); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 136, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyInt_From_long(3); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 139, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
 
-  /* "implicit/_als.pyx":134
+  /* "implicit/_als.pyx":137
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _least_squares_cg(integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
  *                       floating[:, :] X, floating[:, :] Y, float regularization,
  *                       int num_threads=0, int cg_steps=3):
  */
-  __pyx_t_8 = PyTuple_New(2); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_8 = PyTuple_New(2); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_8);
   __Pyx_GIVEREF(__pyx_t_6);
   PyTuple_SET_ITEM(__pyx_t_8, 0, __pyx_t_6);
@@ -40058,163 +40975,163 @@ PyMODINIT_FUNC PyInit__als(void)
   PyTuple_SET_ITEM(__pyx_t_8, 1, __pyx_t_7);
   __pyx_t_6 = 0;
   __pyx_t_7 = 0;
-  __pyx_t_7 = PyDict_New(); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_7 = PyDict_New(); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
-  __pyx_t_6 = __pyx_FusedFunction_NewEx(&__pyx_fuse_0_0__pyx_mdef_8implicit_4_als_27_least_squares_cg, 0, __pyx_n_s_least_squares_cg, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__46)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_6 = __pyx_FusedFunction_NewEx(&__pyx_fuse_0_0__pyx_mdef_8implicit_4_als_27_least_squares_cg, 0, __pyx_n_s_least_squares_cg, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__46)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_6, sizeof(__pyx_defaults18), 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_6, sizeof(__pyx_defaults18), 0)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_CyFunction_Defaults(__pyx_defaults18, __pyx_t_6)->__pyx_arg_num_threads = 0;
   __Pyx_CyFunction_Defaults(__pyx_defaults18, __pyx_t_6)->__pyx_arg_cg_steps = 3;
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_6, __pyx_t_8);
   __Pyx_CyFunction_SetDefaultsGetter(__pyx_t_6, __pyx_pf_8implicit_4_als_90__defaults__);
-  if (PyDict_SetItem(__pyx_t_7, __pyx_kp_s_short_float, __pyx_t_6) < 0) __PYX_ERR(0, 134, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_7, __pyx_kp_s_short_float, __pyx_t_6) < 0) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_6 = __pyx_FusedFunction_NewEx(&__pyx_fuse_0_1__pyx_mdef_8implicit_4_als_29_least_squares_cg, 0, __pyx_n_s_least_squares_cg, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__46)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_6 = __pyx_FusedFunction_NewEx(&__pyx_fuse_0_1__pyx_mdef_8implicit_4_als_29_least_squares_cg, 0, __pyx_n_s_least_squares_cg, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__46)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_6, sizeof(__pyx_defaults19), 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_6, sizeof(__pyx_defaults19), 0)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_CyFunction_Defaults(__pyx_defaults19, __pyx_t_6)->__pyx_arg_num_threads = 0;
   __Pyx_CyFunction_Defaults(__pyx_defaults19, __pyx_t_6)->__pyx_arg_cg_steps = 3;
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_6, __pyx_t_8);
   __Pyx_CyFunction_SetDefaultsGetter(__pyx_t_6, __pyx_pf_8implicit_4_als_92__defaults__);
-  if (PyDict_SetItem(__pyx_t_7, __pyx_kp_s_short_double, __pyx_t_6) < 0) __PYX_ERR(0, 134, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_7, __pyx_kp_s_short_double, __pyx_t_6) < 0) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_6 = __pyx_FusedFunction_NewEx(&__pyx_fuse_1_0__pyx_mdef_8implicit_4_als_31_least_squares_cg, 0, __pyx_n_s_least_squares_cg, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__46)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_6 = __pyx_FusedFunction_NewEx(&__pyx_fuse_1_0__pyx_mdef_8implicit_4_als_31_least_squares_cg, 0, __pyx_n_s_least_squares_cg, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__46)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_6, sizeof(__pyx_defaults20), 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_6, sizeof(__pyx_defaults20), 0)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_CyFunction_Defaults(__pyx_defaults20, __pyx_t_6)->__pyx_arg_num_threads = 0;
   __Pyx_CyFunction_Defaults(__pyx_defaults20, __pyx_t_6)->__pyx_arg_cg_steps = 3;
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_6, __pyx_t_8);
   __Pyx_CyFunction_SetDefaultsGetter(__pyx_t_6, __pyx_pf_8implicit_4_als_94__defaults__);
-  if (PyDict_SetItem(__pyx_t_7, __pyx_kp_s_int_float, __pyx_t_6) < 0) __PYX_ERR(0, 134, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_7, __pyx_kp_s_int_float, __pyx_t_6) < 0) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_6 = __pyx_FusedFunction_NewEx(&__pyx_fuse_1_1__pyx_mdef_8implicit_4_als_33_least_squares_cg, 0, __pyx_n_s_least_squares_cg, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__46)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_6 = __pyx_FusedFunction_NewEx(&__pyx_fuse_1_1__pyx_mdef_8implicit_4_als_33_least_squares_cg, 0, __pyx_n_s_least_squares_cg, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__46)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_6, sizeof(__pyx_defaults21), 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_6, sizeof(__pyx_defaults21), 0)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_CyFunction_Defaults(__pyx_defaults21, __pyx_t_6)->__pyx_arg_num_threads = 0;
   __Pyx_CyFunction_Defaults(__pyx_defaults21, __pyx_t_6)->__pyx_arg_cg_steps = 3;
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_6, __pyx_t_8);
   __Pyx_CyFunction_SetDefaultsGetter(__pyx_t_6, __pyx_pf_8implicit_4_als_96__defaults__);
-  if (PyDict_SetItem(__pyx_t_7, __pyx_kp_s_int_double, __pyx_t_6) < 0) __PYX_ERR(0, 134, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_7, __pyx_kp_s_int_double, __pyx_t_6) < 0) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_6 = __pyx_FusedFunction_NewEx(&__pyx_fuse_2_0__pyx_mdef_8implicit_4_als_35_least_squares_cg, 0, __pyx_n_s_least_squares_cg, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__46)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_6 = __pyx_FusedFunction_NewEx(&__pyx_fuse_2_0__pyx_mdef_8implicit_4_als_35_least_squares_cg, 0, __pyx_n_s_least_squares_cg, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__46)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_6, sizeof(__pyx_defaults22), 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_6, sizeof(__pyx_defaults22), 0)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_CyFunction_Defaults(__pyx_defaults22, __pyx_t_6)->__pyx_arg_num_threads = 0;
   __Pyx_CyFunction_Defaults(__pyx_defaults22, __pyx_t_6)->__pyx_arg_cg_steps = 3;
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_6, __pyx_t_8);
   __Pyx_CyFunction_SetDefaultsGetter(__pyx_t_6, __pyx_pf_8implicit_4_als_98__defaults__);
-  if (PyDict_SetItem(__pyx_t_7, __pyx_kp_s_long_float, __pyx_t_6) < 0) __PYX_ERR(0, 134, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_7, __pyx_kp_s_long_float, __pyx_t_6) < 0) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_6 = __pyx_FusedFunction_NewEx(&__pyx_fuse_2_1__pyx_mdef_8implicit_4_als_37_least_squares_cg, 0, __pyx_n_s_least_squares_cg, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__46)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_6 = __pyx_FusedFunction_NewEx(&__pyx_fuse_2_1__pyx_mdef_8implicit_4_als_37_least_squares_cg, 0, __pyx_n_s_least_squares_cg, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__46)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_6, sizeof(__pyx_defaults23), 0)) __PYX_ERR(0, 134, __pyx_L1_error)
+  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_6, sizeof(__pyx_defaults23), 0)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_CyFunction_Defaults(__pyx_defaults23, __pyx_t_6)->__pyx_arg_num_threads = 0;
   __Pyx_CyFunction_Defaults(__pyx_defaults23, __pyx_t_6)->__pyx_arg_cg_steps = 3;
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_6, __pyx_t_8);
   __Pyx_CyFunction_SetDefaultsGetter(__pyx_t_6, __pyx_pf_8implicit_4_als_100__defaults__);
-  if (PyDict_SetItem(__pyx_t_7, __pyx_kp_s_long_double, __pyx_t_6) < 0) __PYX_ERR(0, 134, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_7, __pyx_kp_s_long_double, __pyx_t_6) < 0) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_6 = __pyx_FusedFunction_NewEx(&__pyx_mdef_8implicit_4_als_7_least_squares_cg, 0, __pyx_n_s_least_squares_cg, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__46)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 134, __pyx_L1_error)
+  __pyx_t_6 = __pyx_FusedFunction_NewEx(&__pyx_mdef_8implicit_4_als_7_least_squares_cg, 0, __pyx_n_s_least_squares_cg, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__46)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_6, __pyx_t_8);
   __Pyx_CyFunction_SetDefaultsGetter(__pyx_t_6, __pyx_pf_8implicit_4_als_90__defaults__);
   ((__pyx_FusedFunctionObject *) __pyx_t_6)->__signatures__ = __pyx_t_7;
   __Pyx_GIVEREF(__pyx_t_7);
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_least_squares_cg, __pyx_t_6) < 0) __PYX_ERR(0, 134, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_least_squares_cg, __pyx_t_6) < 0) __PYX_ERR(0, 137, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-  /* "implicit/_als.pyx":220
+  /* "implicit/_als.pyx":234
  * 
  * 
  * def calculate_loss(Cui, X, Y, regularization, num_threads=0):             # <<<<<<<<<<<<<<
  *     return _calculate_loss(Cui, Cui.indptr, Cui.indices, Cui.data.astype('float32'),
  *                            X, Y, regularization, num_threads)
  */
-  __pyx_t_9 = PyCFunction_NewEx(&__pyx_mdef_8implicit_4_als_9calculate_loss, NULL, __pyx_n_s_implicit__als); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 220, __pyx_L1_error)
+  __pyx_t_9 = PyCFunction_NewEx(&__pyx_mdef_8implicit_4_als_9calculate_loss, NULL, __pyx_n_s_implicit__als); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 234, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_9);
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_calculate_loss_2, __pyx_t_9) < 0) __PYX_ERR(0, 220, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_calculate_loss_2, __pyx_t_9) < 0) __PYX_ERR(0, 234, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
 
-  /* "implicit/_als.pyx":229
+  /* "implicit/_als.pyx":243
  * def _calculate_loss(Cui, integral[:] indptr, integral[:] indices, float[:] data,
  *                     floating[:, :] X, floating[:, :] Y, float regularization,
  *                     int num_threads=0):             # <<<<<<<<<<<<<<
  *     dtype = np.float64 if floating is double else np.float32
  *     cdef int users = X.shape[0], N = X.shape[1], items = Y.shape[0], u, i, index, one = 1
  */
-  __pyx_t_9 = __Pyx_PyInt_From_long(0); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 229, __pyx_L1_error)
+  __pyx_t_9 = __Pyx_PyInt_From_long(0); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 243, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_9);
 
-  /* "implicit/_als.pyx":227
+  /* "implicit/_als.pyx":241
  * @cython.cdivision(True)
  * @cython.boundscheck(False)
  * def _calculate_loss(Cui, integral[:] indptr, integral[:] indices, float[:] data,             # <<<<<<<<<<<<<<
  *                     floating[:, :] X, floating[:, :] Y, float regularization,
  *                     int num_threads=0):
  */
-  __pyx_t_10 = PyTuple_New(1); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_10 = PyTuple_New(1); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_10);
   __Pyx_GIVEREF(__pyx_t_9);
   PyTuple_SET_ITEM(__pyx_t_10, 0, __pyx_t_9);
   __pyx_t_9 = 0;
-  __pyx_t_9 = PyDict_New(); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_9 = PyDict_New(); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_9);
-  __pyx_t_11 = __pyx_FusedFunction_NewEx(&__pyx_fuse_0_0__pyx_mdef_8implicit_4_als_41_calculate_loss, 0, __pyx_n_s_calculate_loss, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__50)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_11 = __pyx_FusedFunction_NewEx(&__pyx_fuse_0_0__pyx_mdef_8implicit_4_als_41_calculate_loss, 0, __pyx_n_s_calculate_loss, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__50)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_11);
-  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_11, sizeof(__pyx_defaults30), 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_11, sizeof(__pyx_defaults30), 0)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_CyFunction_Defaults(__pyx_defaults30, __pyx_t_11)->__pyx_arg_num_threads = 0;
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_11, __pyx_t_10);
   __Pyx_CyFunction_SetDefaultsGetter(__pyx_t_11, __pyx_pf_8implicit_4_als_114__defaults__);
-  if (PyDict_SetItem(__pyx_t_9, __pyx_kp_s_short_float, __pyx_t_11) < 0) __PYX_ERR(0, 227, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_9, __pyx_kp_s_short_float, __pyx_t_11) < 0) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
-  __pyx_t_11 = __pyx_FusedFunction_NewEx(&__pyx_fuse_0_1__pyx_mdef_8implicit_4_als_43_calculate_loss, 0, __pyx_n_s_calculate_loss, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__50)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_11 = __pyx_FusedFunction_NewEx(&__pyx_fuse_0_1__pyx_mdef_8implicit_4_als_43_calculate_loss, 0, __pyx_n_s_calculate_loss, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__50)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_11);
-  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_11, sizeof(__pyx_defaults31), 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_11, sizeof(__pyx_defaults31), 0)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_CyFunction_Defaults(__pyx_defaults31, __pyx_t_11)->__pyx_arg_num_threads = 0;
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_11, __pyx_t_10);
   __Pyx_CyFunction_SetDefaultsGetter(__pyx_t_11, __pyx_pf_8implicit_4_als_116__defaults__);
-  if (PyDict_SetItem(__pyx_t_9, __pyx_kp_s_short_double, __pyx_t_11) < 0) __PYX_ERR(0, 227, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_9, __pyx_kp_s_short_double, __pyx_t_11) < 0) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
-  __pyx_t_11 = __pyx_FusedFunction_NewEx(&__pyx_fuse_1_0__pyx_mdef_8implicit_4_als_45_calculate_loss, 0, __pyx_n_s_calculate_loss, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__50)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_11 = __pyx_FusedFunction_NewEx(&__pyx_fuse_1_0__pyx_mdef_8implicit_4_als_45_calculate_loss, 0, __pyx_n_s_calculate_loss, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__50)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_11);
-  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_11, sizeof(__pyx_defaults32), 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_11, sizeof(__pyx_defaults32), 0)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_CyFunction_Defaults(__pyx_defaults32, __pyx_t_11)->__pyx_arg_num_threads = 0;
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_11, __pyx_t_10);
   __Pyx_CyFunction_SetDefaultsGetter(__pyx_t_11, __pyx_pf_8implicit_4_als_118__defaults__);
-  if (PyDict_SetItem(__pyx_t_9, __pyx_kp_s_int_float, __pyx_t_11) < 0) __PYX_ERR(0, 227, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_9, __pyx_kp_s_int_float, __pyx_t_11) < 0) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
-  __pyx_t_11 = __pyx_FusedFunction_NewEx(&__pyx_fuse_1_1__pyx_mdef_8implicit_4_als_47_calculate_loss, 0, __pyx_n_s_calculate_loss, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__50)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_11 = __pyx_FusedFunction_NewEx(&__pyx_fuse_1_1__pyx_mdef_8implicit_4_als_47_calculate_loss, 0, __pyx_n_s_calculate_loss, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__50)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_11);
-  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_11, sizeof(__pyx_defaults33), 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_11, sizeof(__pyx_defaults33), 0)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_CyFunction_Defaults(__pyx_defaults33, __pyx_t_11)->__pyx_arg_num_threads = 0;
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_11, __pyx_t_10);
   __Pyx_CyFunction_SetDefaultsGetter(__pyx_t_11, __pyx_pf_8implicit_4_als_120__defaults__);
-  if (PyDict_SetItem(__pyx_t_9, __pyx_kp_s_int_double, __pyx_t_11) < 0) __PYX_ERR(0, 227, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_9, __pyx_kp_s_int_double, __pyx_t_11) < 0) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
-  __pyx_t_11 = __pyx_FusedFunction_NewEx(&__pyx_fuse_2_0__pyx_mdef_8implicit_4_als_49_calculate_loss, 0, __pyx_n_s_calculate_loss, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__50)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_11 = __pyx_FusedFunction_NewEx(&__pyx_fuse_2_0__pyx_mdef_8implicit_4_als_49_calculate_loss, 0, __pyx_n_s_calculate_loss, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__50)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_11);
-  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_11, sizeof(__pyx_defaults34), 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_11, sizeof(__pyx_defaults34), 0)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_CyFunction_Defaults(__pyx_defaults34, __pyx_t_11)->__pyx_arg_num_threads = 0;
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_11, __pyx_t_10);
   __Pyx_CyFunction_SetDefaultsGetter(__pyx_t_11, __pyx_pf_8implicit_4_als_122__defaults__);
-  if (PyDict_SetItem(__pyx_t_9, __pyx_kp_s_long_float, __pyx_t_11) < 0) __PYX_ERR(0, 227, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_9, __pyx_kp_s_long_float, __pyx_t_11) < 0) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
-  __pyx_t_11 = __pyx_FusedFunction_NewEx(&__pyx_fuse_2_1__pyx_mdef_8implicit_4_als_51_calculate_loss, 0, __pyx_n_s_calculate_loss, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__50)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_11 = __pyx_FusedFunction_NewEx(&__pyx_fuse_2_1__pyx_mdef_8implicit_4_als_51_calculate_loss, 0, __pyx_n_s_calculate_loss, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__50)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_11);
-  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_11, sizeof(__pyx_defaults35), 0)) __PYX_ERR(0, 227, __pyx_L1_error)
+  if (!__Pyx_CyFunction_InitDefaults(__pyx_t_11, sizeof(__pyx_defaults35), 0)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_CyFunction_Defaults(__pyx_defaults35, __pyx_t_11)->__pyx_arg_num_threads = 0;
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_11, __pyx_t_10);
   __Pyx_CyFunction_SetDefaultsGetter(__pyx_t_11, __pyx_pf_8implicit_4_als_124__defaults__);
-  if (PyDict_SetItem(__pyx_t_9, __pyx_kp_s_long_double, __pyx_t_11) < 0) __PYX_ERR(0, 227, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_9, __pyx_kp_s_long_double, __pyx_t_11) < 0) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
-  __pyx_t_11 = __pyx_FusedFunction_NewEx(&__pyx_mdef_8implicit_4_als_11_calculate_loss, 0, __pyx_n_s_calculate_loss, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__50)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 227, __pyx_L1_error)
+  __pyx_t_11 = __pyx_FusedFunction_NewEx(&__pyx_mdef_8implicit_4_als_11_calculate_loss, 0, __pyx_n_s_calculate_loss, NULL, __pyx_n_s_implicit__als, __pyx_d, ((PyObject *)__pyx_codeobj__50)); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_11);
   __Pyx_CyFunction_SetDefaultsTuple(__pyx_t_11, __pyx_t_10);
   __Pyx_CyFunction_SetDefaultsGetter(__pyx_t_11, __pyx_pf_8implicit_4_als_114__defaults__);
   ((__pyx_FusedFunctionObject *) __pyx_t_11)->__signatures__ = __pyx_t_9;
   __Pyx_GIVEREF(__pyx_t_9);
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_calculate_loss, __pyx_t_11) < 0) __PYX_ERR(0, 227, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_calculate_loss, __pyx_t_11) < 0) __PYX_ERR(0, 241, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
   __Pyx_DECREF(__pyx_t_10); __pyx_t_10 = 0;
 


### PR DESCRIPTION
Allow negative confidence values to be passed in, signifying that the user disliked the item. This lets us set higher confidence values for the known negatives.

Experiments here indicate setting known negatives to a higher confidence level slightly reduces p@10, but signifincantly reduces the likelihood of withheld negative items to be recommended: https://github.com/benfred/implicit/issues/114