### PR TITLE
initialize scorer in ItemItemRecommender load function

### DIFF
--- a/implicit/nearest_neighbours.py
+++ b/implicit/nearest_neighbours.py
@@ -83,6 +83,7 @@ class ItemItemRecommender(RecommenderBase):
 
         ret = cls()
         ret.similarity = similarity
+        ret.scorer = NearestNeighboursScorer(similarity)
         ret.K = m['K']
         return ret
 


### PR DESCRIPTION
_scorer_ is not initialized in the **ItemItemRecommender** _load_ function, so when calling _recommend_ after _load_  it throws AttributeError: 'NoneType' object has no attribute 'recommend'.
