### PR TITLE
Fix parameter of bpr._fit_gpu()

### DIFF
--- a/implicit/als.py
+++ b/implicit/als.py
@@ -133,8 +133,6 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
             Matrix of confidences for the liked items. This matrix should be a csr_matrix where
             the rows of the matrix are the item, the columns are the users that liked that item,
             and the value is the confidence that the user liked the item.
-        vali_item_users: csr_matrix
-            Same format with item_users. It is used to validate the model.
         show_progress : bool, optional
             Whether to show a progress bar during fitting
         """

--- a/implicit/bpr.pyx
+++ b/implicit/bpr.pyx
@@ -150,8 +150,6 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
             the rows of the matrix are the item, and the columns are the users that liked that item.
             BPR ignores the weight value of the matrix right now - it treats non zero entries
             as a binary signal that the user liked the item.
-        vali_item_users: csr_matrix
-            Same format with item_users. It is used to validate the model.
         show_progress : bool, optional
             Whether to show a progress bar
         """
@@ -202,7 +200,7 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
             self.user_factors[:, self.factors] = 1.0
 
         if self.use_gpu:
-            return self._fit_gpu(user_items, userids, vali_item_users, show_progress)
+            return self._fit_gpu(user_items, userids, vali_user_items, show_progress)
 
         # we accept num_threads = 0 as indicating to create as many threads as we have cores,
         # but in that case we need the number of cores, since we need to initialize RNG state per


### PR DESCRIPTION
As the solution for the issue #290,

bpr._fit_gpu() takes vali_user_items as parameters.
But in fit(), line 205, it passes vali_item_users.
And when I run the code, it says variable "vali_item_users" is referenced before assignment.

I referred to als.py and changed vali_item_users to vali_user_items.
And removed "vali_item_users" from function comments of "als.py", "bpr.pyx".