### PR TITLE
Feature/add_bias_terms_to_als

### DIFF
--- a/implicit/als.py
+++ b/implicit/als.py
@@ -162,6 +162,8 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
                     self.user_factors[:, -2] = 1.0
                 solver(Ciu, self.item_factors, self.user_factors, self.regularization,
                        num_threads=self.num_threads)
+                if self.use_bias:
+                    self.item_factors[:, -1] = 1.0
                 progress.update(1)
 
                 if self.calculate_training_loss:

--- a/implicit/als.py
+++ b/implicit/als.py
@@ -150,6 +150,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
             if self.use_bias:
                 log.warning("GPU training with bias factors not implemented,",
                             "setting self.use_bias to False.")
+                self.use_bias = False
             return self._fit_gpu(Ciu, Cui, show_progress)
 
         solver = self.solver

--- a/implicit/als.py
+++ b/implicit/als.py
@@ -148,8 +148,8 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
 
         if self.use_gpu:
             if self.use_bias:
-                log.warning("GPU training with bias factors not implemented,",
-                            "setting self.use_bias to False.")
+                log.warning("GPU training with bias factors not implemented.",
+                            "Setting self.use_bias to False.")
                 self.use_bias = False
             return self._fit_gpu(Ciu, Cui, show_progress)
 

--- a/implicit/als.py
+++ b/implicit/als.py
@@ -158,6 +158,8 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
                 s = time.time()
                 solver(Cui, self.user_factors, self.item_factors, self.regularization,
                        num_threads=self.num_threads)
+                if self.use_bias:
+                    self.user_factors[:, -2] = 1.0
                 solver(Ciu, self.item_factors, self.user_factors, self.regularization,
                        num_threads=self.num_threads)
                 progress.update(1)

--- a/implicit/als.py
+++ b/implicit/als.py
@@ -147,6 +147,9 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         self._YtY = None
 
         if self.use_gpu:
+            if self.use_bias:
+                log.warning("GPU training with bias factors not implemented,",
+                            "setting self.use_bias to False.")
             return self._fit_gpu(Ciu, Cui, show_progress)
 
         solver = self.solver

--- a/implicit/als.py
+++ b/implicit/als.py
@@ -152,6 +152,10 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         solver = self.solver
 
         log.debug("Running %i ALS iterations", self.iterations)
+        if self.use_bias:
+            log.info("Training model with bias factors.")
+            log.debug("Last element of self.user_factors is user bias.",
+                      "Second-to-last element of self.item_factors is item bias.")
         with tqdm(total=self.iterations, disable=not show_progress) as progress:
             # alternate between learning the user_factors from the item_factors and vice-versa
             for iteration in range(self.iterations):

--- a/implicit/als.py
+++ b/implicit/als.py
@@ -60,7 +60,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
 
     def __init__(self, factors=100, regularization=0.01, dtype=np.float32,
                  use_native=True, use_cg=True, use_gpu=implicit.cuda.HAS_CUDA,
-                 iterations=15, calculate_training_loss=False, num_threads=0):
+                 iterations=15, calculate_training_loss=False, num_threads=0, use_bias=False):
         super(AlternatingLeastSquares, self).__init__()
 
         # currently there are some issues when training on the GPU when some of the warps
@@ -87,6 +87,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         self.num_threads = num_threads
         self.fit_callback = None
         self.cg_steps = 3
+        self.use_bias = use_bias
 
         # cache for item factors squared
         self._YtY = None

--- a/implicit/als.py
+++ b/implicit/als.py
@@ -137,8 +137,12 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         # Initialize the variables randomly if they haven't already been set
         if self.user_factors is None:
             self.user_factors = np.random.rand(users, self.factors).astype(self.dtype) * 0.01
+            if self.use_bias:
+                self.user_factors[:, -2] = 1.0
         if self.item_factors is None:
             self.item_factors = np.random.rand(items, self.factors).astype(self.dtype) * 0.01
+            if self.use_bias:
+                self.item_factors[:, -1] = 1.0
 
         log.debug("Initialized factors in %s", time.time() - s)
 


### PR DESCRIPTION
Added optional user and item bias terms to `als.py` as suggested by ita9naiwa in issue #176 and already implemented in [LMF](https://github.com/benfred/implicit/blob/fbed6211547e676ba414fdf734432aa3252ac90b/implicit/lmf.pyx#L169-L181). Set `use_bias=True` to train with bias terms (not implemented for GPU yet).