### PR TITLE
Attemp to fix travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ before_install:
       PIP=pip3
       PY=python3
     fi
-    brew reinstall gcc
   fi
 install:
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: python
 sudo: require
 python:
   - "2.7"
-  - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 matrix:
   # xcode11 has a known bug: https://github.com/Homebrew/homebrew-core/issues/44579
@@ -15,7 +16,6 @@ matrix:
       osx_image: xcode11.3
     - language: generic
       os: osx
-      python: 3.6.5
       env: PYTHON=3
       osx_image: xcode11.3
 
@@ -25,9 +25,6 @@ addons:
     - libblas-dev
     - liblapack-dev
     - gfortran
-  homebrew:
-    packages:
-    - python3
 
 before_install:
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - language: generic
       os: osx
       env: PYTHON=3
-      osx_image: xcode11.3
+      osx_image: xcode12
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ before_install:
 install:
 - |
   travis_wait travis_retry $PIP uninstall numpy -y
-  travis_wait travis_retry $PIP install -r requirements.txt --ignore-installed flake8 isort cpplint faiss annoy
+  travis_wait travis_retry $PIP install -r requirements.txt --ignore-installed flake8 isort cpplint annoy
   if  [ "${PYTHON:0:1}" = "3" ]; then
-     travis_wait travis_retry $PIP install nmslib
+     travis_wait travis_retry $PIP install nmslib faiss
   fi
   travis_retry $PIP install -e .
 


### PR DESCRIPTION
OSX builds are failing on travis for python version 3. Attempt to fix.
Also move build matrix to python 3.7/3.8 and drop python 3.5