### PR TITLE
Fix random output with LMF/BPR models

### DIFF
--- a/implicit/cpu/bpr.cpp
+++ b/implicit/cpu/bpr.cpp
@@ -6400,7 +6400,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_2bpr_update(CYTHON_UNUSED PyObject
  *     with nogil, parallel(num_threads=num_threads):
  * 
  *         thread_id = get_thread_num()             # <<<<<<<<<<<<<<
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)
  */
                 __pyx_v_thread_id = implicit::get_thread_num();
@@ -6408,7 +6408,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_2bpr_update(CYTHON_UNUSED PyObject
                 /* "implicit/cpu/bpr.pyx":226
  * 
  *         thread_id = get_thread_num()
- *         for i in prange(samples, schedule='guided'):             # <<<<<<<<<<<<<<
+ *         for i in prange(samples, schedule='static'):             # <<<<<<<<<<<<<<
  *             liked_index = rng.generate(thread_id)
  *             liked_id = itemids[liked_index]
  */
@@ -6419,7 +6419,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_2bpr_update(CYTHON_UNUSED PyObject
                     if (__pyx_t_4 > 0)
                     {
                         #ifdef _OPENMP
-                        #pragma omp for lastprivate(__pyx_v_disliked) lastprivate(__pyx_v_disliked_id) lastprivate(__pyx_v_disliked_index) firstprivate(__pyx_v_i) lastprivate(__pyx_v_i) lastprivate(__pyx_v_j) lastprivate(__pyx_v_liked) lastprivate(__pyx_v_liked_id) lastprivate(__pyx_v_liked_index) lastprivate(__pyx_v_score) lastprivate(__pyx_v_temp) lastprivate(__pyx_v_user) lastprivate(__pyx_v_z) schedule(guided)
+                        #pragma omp for lastprivate(__pyx_v_disliked) lastprivate(__pyx_v_disliked_id) lastprivate(__pyx_v_disliked_index) firstprivate(__pyx_v_i) lastprivate(__pyx_v_i) lastprivate(__pyx_v_j) lastprivate(__pyx_v_liked) lastprivate(__pyx_v_liked_id) lastprivate(__pyx_v_liked_index) lastprivate(__pyx_v_score) lastprivate(__pyx_v_temp) lastprivate(__pyx_v_user) lastprivate(__pyx_v_z) schedule(static)
                         #endif /* _OPENMP */
                         for (__pyx_t_3 = 0; __pyx_t_3 < __pyx_t_4; __pyx_t_3++){
                             {
@@ -6439,7 +6439,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_2bpr_update(CYTHON_UNUSED PyObject
 
                                 /* "implicit/cpu/bpr.pyx":227
  *         thread_id = get_thread_num()
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)             # <<<<<<<<<<<<<<
  *             liked_id = itemids[liked_index]
  * 
@@ -6447,7 +6447,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_2bpr_update(CYTHON_UNUSED PyObject
                                 __pyx_v_liked_index = __pyx_f_8implicit_3cpu_3bpr_9RNGVector_generate(__pyx_v_rng, __pyx_v_thread_id);
 
                                 /* "implicit/cpu/bpr.pyx":228
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)
  *             liked_id = itemids[liked_index]             # <<<<<<<<<<<<<<
  * 
@@ -7045,7 +7045,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_4bpr_update(CYTHON_UNUSED PyObject
  *     with nogil, parallel(num_threads=num_threads):
  * 
  *         thread_id = get_thread_num()             # <<<<<<<<<<<<<<
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)
  */
                 __pyx_v_thread_id = implicit::get_thread_num();
@@ -7053,7 +7053,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_4bpr_update(CYTHON_UNUSED PyObject
                 /* "implicit/cpu/bpr.pyx":226
  * 
  *         thread_id = get_thread_num()
- *         for i in prange(samples, schedule='guided'):             # <<<<<<<<<<<<<<
+ *         for i in prange(samples, schedule='static'):             # <<<<<<<<<<<<<<
  *             liked_index = rng.generate(thread_id)
  *             liked_id = itemids[liked_index]
  */
@@ -7064,7 +7064,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_4bpr_update(CYTHON_UNUSED PyObject
                     if (__pyx_t_4 > 0)
                     {
                         #ifdef _OPENMP
-                        #pragma omp for lastprivate(__pyx_v_disliked) lastprivate(__pyx_v_disliked_id) lastprivate(__pyx_v_disliked_index) firstprivate(__pyx_v_i) lastprivate(__pyx_v_i) lastprivate(__pyx_v_j) lastprivate(__pyx_v_liked) lastprivate(__pyx_v_liked_id) lastprivate(__pyx_v_liked_index) lastprivate(__pyx_v_score) lastprivate(__pyx_v_temp) lastprivate(__pyx_v_user) lastprivate(__pyx_v_z) schedule(guided)
+                        #pragma omp for lastprivate(__pyx_v_disliked) lastprivate(__pyx_v_disliked_id) lastprivate(__pyx_v_disliked_index) firstprivate(__pyx_v_i) lastprivate(__pyx_v_i) lastprivate(__pyx_v_j) lastprivate(__pyx_v_liked) lastprivate(__pyx_v_liked_id) lastprivate(__pyx_v_liked_index) lastprivate(__pyx_v_score) lastprivate(__pyx_v_temp) lastprivate(__pyx_v_user) lastprivate(__pyx_v_z) schedule(static)
                         #endif /* _OPENMP */
                         for (__pyx_t_3 = 0; __pyx_t_3 < __pyx_t_4; __pyx_t_3++){
                             {
@@ -7084,7 +7084,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_4bpr_update(CYTHON_UNUSED PyObject
 
                                 /* "implicit/cpu/bpr.pyx":227
  *         thread_id = get_thread_num()
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)             # <<<<<<<<<<<<<<
  *             liked_id = itemids[liked_index]
  * 
@@ -7092,7 +7092,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_4bpr_update(CYTHON_UNUSED PyObject
                                 __pyx_v_liked_index = __pyx_f_8implicit_3cpu_3bpr_9RNGVector_generate(__pyx_v_rng, __pyx_v_thread_id);
 
                                 /* "implicit/cpu/bpr.pyx":228
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)
  *             liked_id = itemids[liked_index]             # <<<<<<<<<<<<<<
  * 
@@ -7690,7 +7690,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_6bpr_update(CYTHON_UNUSED PyObject
  *     with nogil, parallel(num_threads=num_threads):
  * 
  *         thread_id = get_thread_num()             # <<<<<<<<<<<<<<
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)
  */
                 __pyx_v_thread_id = implicit::get_thread_num();
@@ -7698,7 +7698,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_6bpr_update(CYTHON_UNUSED PyObject
                 /* "implicit/cpu/bpr.pyx":226
  * 
  *         thread_id = get_thread_num()
- *         for i in prange(samples, schedule='guided'):             # <<<<<<<<<<<<<<
+ *         for i in prange(samples, schedule='static'):             # <<<<<<<<<<<<<<
  *             liked_index = rng.generate(thread_id)
  *             liked_id = itemids[liked_index]
  */
@@ -7709,7 +7709,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_6bpr_update(CYTHON_UNUSED PyObject
                     if (__pyx_t_4 > 0)
                     {
                         #ifdef _OPENMP
-                        #pragma omp for lastprivate(__pyx_v_disliked) lastprivate(__pyx_v_disliked_id) lastprivate(__pyx_v_disliked_index) firstprivate(__pyx_v_i) lastprivate(__pyx_v_i) lastprivate(__pyx_v_j) lastprivate(__pyx_v_liked) lastprivate(__pyx_v_liked_id) lastprivate(__pyx_v_liked_index) lastprivate(__pyx_v_score) lastprivate(__pyx_v_temp) lastprivate(__pyx_v_user) lastprivate(__pyx_v_z) schedule(guided)
+                        #pragma omp for lastprivate(__pyx_v_disliked) lastprivate(__pyx_v_disliked_id) lastprivate(__pyx_v_disliked_index) firstprivate(__pyx_v_i) lastprivate(__pyx_v_i) lastprivate(__pyx_v_j) lastprivate(__pyx_v_liked) lastprivate(__pyx_v_liked_id) lastprivate(__pyx_v_liked_index) lastprivate(__pyx_v_score) lastprivate(__pyx_v_temp) lastprivate(__pyx_v_user) lastprivate(__pyx_v_z) schedule(static)
                         #endif /* _OPENMP */
                         for (__pyx_t_3 = 0; __pyx_t_3 < __pyx_t_4; __pyx_t_3++){
                             {
@@ -7729,7 +7729,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_6bpr_update(CYTHON_UNUSED PyObject
 
                                 /* "implicit/cpu/bpr.pyx":227
  *         thread_id = get_thread_num()
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)             # <<<<<<<<<<<<<<
  *             liked_id = itemids[liked_index]
  * 
@@ -7737,7 +7737,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_6bpr_update(CYTHON_UNUSED PyObject
                                 __pyx_v_liked_index = __pyx_f_8implicit_3cpu_3bpr_9RNGVector_generate(__pyx_v_rng, __pyx_v_thread_id);
 
                                 /* "implicit/cpu/bpr.pyx":228
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)
  *             liked_id = itemids[liked_index]             # <<<<<<<<<<<<<<
  * 
@@ -8335,7 +8335,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_8bpr_update(CYTHON_UNUSED PyObject
  *     with nogil, parallel(num_threads=num_threads):
  * 
  *         thread_id = get_thread_num()             # <<<<<<<<<<<<<<
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)
  */
                 __pyx_v_thread_id = implicit::get_thread_num();
@@ -8343,7 +8343,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_8bpr_update(CYTHON_UNUSED PyObject
                 /* "implicit/cpu/bpr.pyx":226
  * 
  *         thread_id = get_thread_num()
- *         for i in prange(samples, schedule='guided'):             # <<<<<<<<<<<<<<
+ *         for i in prange(samples, schedule='static'):             # <<<<<<<<<<<<<<
  *             liked_index = rng.generate(thread_id)
  *             liked_id = itemids[liked_index]
  */
@@ -8354,7 +8354,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_8bpr_update(CYTHON_UNUSED PyObject
                     if (__pyx_t_4 > 0)
                     {
                         #ifdef _OPENMP
-                        #pragma omp for lastprivate(__pyx_v_disliked) lastprivate(__pyx_v_disliked_id) lastprivate(__pyx_v_disliked_index) firstprivate(__pyx_v_i) lastprivate(__pyx_v_i) lastprivate(__pyx_v_j) lastprivate(__pyx_v_liked) lastprivate(__pyx_v_liked_id) lastprivate(__pyx_v_liked_index) lastprivate(__pyx_v_score) lastprivate(__pyx_v_temp) lastprivate(__pyx_v_user) lastprivate(__pyx_v_z) schedule(guided)
+                        #pragma omp for lastprivate(__pyx_v_disliked) lastprivate(__pyx_v_disliked_id) lastprivate(__pyx_v_disliked_index) firstprivate(__pyx_v_i) lastprivate(__pyx_v_i) lastprivate(__pyx_v_j) lastprivate(__pyx_v_liked) lastprivate(__pyx_v_liked_id) lastprivate(__pyx_v_liked_index) lastprivate(__pyx_v_score) lastprivate(__pyx_v_temp) lastprivate(__pyx_v_user) lastprivate(__pyx_v_z) schedule(static)
                         #endif /* _OPENMP */
                         for (__pyx_t_3 = 0; __pyx_t_3 < __pyx_t_4; __pyx_t_3++){
                             {
@@ -8374,7 +8374,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_8bpr_update(CYTHON_UNUSED PyObject
 
                                 /* "implicit/cpu/bpr.pyx":227
  *         thread_id = get_thread_num()
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)             # <<<<<<<<<<<<<<
  *             liked_id = itemids[liked_index]
  * 
@@ -8382,7 +8382,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_8bpr_update(CYTHON_UNUSED PyObject
                                 __pyx_v_liked_index = __pyx_f_8implicit_3cpu_3bpr_9RNGVector_generate(__pyx_v_rng, __pyx_v_thread_id);
 
                                 /* "implicit/cpu/bpr.pyx":228
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)
  *             liked_id = itemids[liked_index]             # <<<<<<<<<<<<<<
  * 
@@ -8978,7 +8978,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_10bpr_update(CYTHON_UNUSED PyObjec
  *     with nogil, parallel(num_threads=num_threads):
  * 
  *         thread_id = get_thread_num()             # <<<<<<<<<<<<<<
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)
  */
                 __pyx_v_thread_id = implicit::get_thread_num();
@@ -8986,7 +8986,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_10bpr_update(CYTHON_UNUSED PyObjec
                 /* "implicit/cpu/bpr.pyx":226
  * 
  *         thread_id = get_thread_num()
- *         for i in prange(samples, schedule='guided'):             # <<<<<<<<<<<<<<
+ *         for i in prange(samples, schedule='static'):             # <<<<<<<<<<<<<<
  *             liked_index = rng.generate(thread_id)
  *             liked_id = itemids[liked_index]
  */
@@ -8997,7 +8997,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_10bpr_update(CYTHON_UNUSED PyObjec
                     if (__pyx_t_4 > 0)
                     {
                         #ifdef _OPENMP
-                        #pragma omp for lastprivate(__pyx_v_disliked) lastprivate(__pyx_v_disliked_id) lastprivate(__pyx_v_disliked_index) firstprivate(__pyx_v_i) lastprivate(__pyx_v_i) lastprivate(__pyx_v_j) lastprivate(__pyx_v_liked) lastprivate(__pyx_v_liked_id) lastprivate(__pyx_v_liked_index) lastprivate(__pyx_v_score) lastprivate(__pyx_v_temp) lastprivate(__pyx_v_user) lastprivate(__pyx_v_z) schedule(guided)
+                        #pragma omp for lastprivate(__pyx_v_disliked) lastprivate(__pyx_v_disliked_id) lastprivate(__pyx_v_disliked_index) firstprivate(__pyx_v_i) lastprivate(__pyx_v_i) lastprivate(__pyx_v_j) lastprivate(__pyx_v_liked) lastprivate(__pyx_v_liked_id) lastprivate(__pyx_v_liked_index) lastprivate(__pyx_v_score) lastprivate(__pyx_v_temp) lastprivate(__pyx_v_user) lastprivate(__pyx_v_z) schedule(static)
                         #endif /* _OPENMP */
                         for (__pyx_t_3 = 0; __pyx_t_3 < __pyx_t_4; __pyx_t_3++){
                             {
@@ -9017,7 +9017,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_10bpr_update(CYTHON_UNUSED PyObjec
 
                                 /* "implicit/cpu/bpr.pyx":227
  *         thread_id = get_thread_num()
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)             # <<<<<<<<<<<<<<
  *             liked_id = itemids[liked_index]
  * 
@@ -9025,7 +9025,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_10bpr_update(CYTHON_UNUSED PyObjec
                                 __pyx_v_liked_index = __pyx_f_8implicit_3cpu_3bpr_9RNGVector_generate(__pyx_v_rng, __pyx_v_thread_id);
 
                                 /* "implicit/cpu/bpr.pyx":228
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)
  *             liked_id = itemids[liked_index]             # <<<<<<<<<<<<<<
  * 
@@ -9621,7 +9621,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_12bpr_update(CYTHON_UNUSED PyObjec
  *     with nogil, parallel(num_threads=num_threads):
  * 
  *         thread_id = get_thread_num()             # <<<<<<<<<<<<<<
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)
  */
                 __pyx_v_thread_id = implicit::get_thread_num();
@@ -9629,7 +9629,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_12bpr_update(CYTHON_UNUSED PyObjec
                 /* "implicit/cpu/bpr.pyx":226
  * 
  *         thread_id = get_thread_num()
- *         for i in prange(samples, schedule='guided'):             # <<<<<<<<<<<<<<
+ *         for i in prange(samples, schedule='static'):             # <<<<<<<<<<<<<<
  *             liked_index = rng.generate(thread_id)
  *             liked_id = itemids[liked_index]
  */
@@ -9640,7 +9640,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_12bpr_update(CYTHON_UNUSED PyObjec
                     if (__pyx_t_4 > 0)
                     {
                         #ifdef _OPENMP
-                        #pragma omp for lastprivate(__pyx_v_disliked) lastprivate(__pyx_v_disliked_id) lastprivate(__pyx_v_disliked_index) firstprivate(__pyx_v_i) lastprivate(__pyx_v_i) lastprivate(__pyx_v_j) lastprivate(__pyx_v_liked) lastprivate(__pyx_v_liked_id) lastprivate(__pyx_v_liked_index) lastprivate(__pyx_v_score) lastprivate(__pyx_v_temp) lastprivate(__pyx_v_user) lastprivate(__pyx_v_z) schedule(guided)
+                        #pragma omp for lastprivate(__pyx_v_disliked) lastprivate(__pyx_v_disliked_id) lastprivate(__pyx_v_disliked_index) firstprivate(__pyx_v_i) lastprivate(__pyx_v_i) lastprivate(__pyx_v_j) lastprivate(__pyx_v_liked) lastprivate(__pyx_v_liked_id) lastprivate(__pyx_v_liked_index) lastprivate(__pyx_v_score) lastprivate(__pyx_v_temp) lastprivate(__pyx_v_user) lastprivate(__pyx_v_z) schedule(static)
                         #endif /* _OPENMP */
                         for (__pyx_t_3 = 0; __pyx_t_3 < __pyx_t_4; __pyx_t_3++){
                             {
@@ -9660,7 +9660,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_12bpr_update(CYTHON_UNUSED PyObjec
 
                                 /* "implicit/cpu/bpr.pyx":227
  *         thread_id = get_thread_num()
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)             # <<<<<<<<<<<<<<
  *             liked_id = itemids[liked_index]
  * 
@@ -9668,7 +9668,7 @@ static PyObject *__pyx_pf_8implicit_3cpu_3bpr_12bpr_update(CYTHON_UNUSED PyObjec
                                 __pyx_v_liked_index = __pyx_f_8implicit_3cpu_3bpr_9RNGVector_generate(__pyx_v_rng, __pyx_v_thread_id);
 
                                 /* "implicit/cpu/bpr.pyx":228
- *         for i in prange(samples, schedule='guided'):
+ *         for i in prange(samples, schedule='static'):
  *             liked_index = rng.generate(thread_id)
  *             liked_id = itemids[liked_index]             # <<<<<<<<<<<<<<
  * 

--- a/implicit/cpu/bpr.pyx
+++ b/implicit/cpu/bpr.pyx
@@ -223,7 +223,7 @@ def bpr_update(RNGVector rng,
     with nogil, parallel(num_threads=num_threads):
 
         thread_id = get_thread_num()
-        for i in prange(samples, schedule='guided'):
+        for i in prange(samples, schedule='static'):
             liked_index = rng.generate(thread_id)
             liked_id = itemids[liked_index]
 

--- a/implicit/lmf.cpp
+++ b/implicit/lmf.cpp
@@ -6472,7 +6472,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_2lmf_update(CYTHON_UNUSED PyObject *__p
  *         deriv = <floating*> malloc(sizeof(floating) * n_factors)
  *         thread_id = threadid()             # <<<<<<<<<<<<<<
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  */
                 #ifdef _OPENMP
                 __pyx_t_1 = omp_get_thread_num();
@@ -6485,7 +6485,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_2lmf_update(CYTHON_UNUSED PyObject *__p
  *         deriv = <floating*> malloc(sizeof(floating) * n_factors)
  *         thread_id = threadid()
  *         try:             # <<<<<<<<<<<<<<
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:
  */
                 /*try:*/ {
@@ -6493,7 +6493,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_2lmf_update(CYTHON_UNUSED PyObject *__p
                   /* "implicit/lmf.pyx":234
  *         thread_id = threadid()
  *         try:
- *             for u in prange(n_users, schedule='guided'):             # <<<<<<<<<<<<<<
+ *             for u in prange(n_users, schedule='static'):             # <<<<<<<<<<<<<<
  *                 if indptr[u] == indptr[u + 1]:
  *                     continue
  */
@@ -6504,7 +6504,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_2lmf_update(CYTHON_UNUSED PyObject *__p
                       if (__pyx_t_4 > 0)
                       {
                           #ifdef _OPENMP
-                          #pragma omp for lastprivate(__pyx_v__) lastprivate(__pyx_v_exp_r) lastprivate(__pyx_v_i) lastprivate(__pyx_v_index) firstprivate(__pyx_v_u) lastprivate(__pyx_v_u) lastprivate(__pyx_v_user_seen_item) lastprivate(__pyx_v_z) schedule(guided)
+                          #pragma omp for lastprivate(__pyx_v__) lastprivate(__pyx_v_exp_r) lastprivate(__pyx_v_i) lastprivate(__pyx_v_index) firstprivate(__pyx_v_u) lastprivate(__pyx_v_u) lastprivate(__pyx_v_user_seen_item) lastprivate(__pyx_v_z) schedule(static)
                           #endif /* _OPENMP */
                           for (__pyx_t_3 = 0; __pyx_t_3 < __pyx_t_4; __pyx_t_3++){
                               {
@@ -6519,7 +6519,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_2lmf_update(CYTHON_UNUSED PyObject *__p
 
                                   /* "implicit/lmf.pyx":235
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:             # <<<<<<<<<<<<<<
  *                     continue
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -6532,7 +6532,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_2lmf_update(CYTHON_UNUSED PyObject *__p
                                   if (__pyx_t_7) {
 
                                     /* "implicit/lmf.pyx":236
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:
  *                     continue             # <<<<<<<<<<<<<<
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -6542,7 +6542,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_2lmf_update(CYTHON_UNUSED PyObject *__p
 
                                     /* "implicit/lmf.pyx":235
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:             # <<<<<<<<<<<<<<
  *                     continue
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -7246,7 +7246,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_4lmf_update(CYTHON_UNUSED PyObject *__p
  *         deriv = <floating*> malloc(sizeof(floating) * n_factors)
  *         thread_id = threadid()             # <<<<<<<<<<<<<<
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  */
                 #ifdef _OPENMP
                 __pyx_t_1 = omp_get_thread_num();
@@ -7259,7 +7259,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_4lmf_update(CYTHON_UNUSED PyObject *__p
  *         deriv = <floating*> malloc(sizeof(floating) * n_factors)
  *         thread_id = threadid()
  *         try:             # <<<<<<<<<<<<<<
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:
  */
                 /*try:*/ {
@@ -7267,7 +7267,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_4lmf_update(CYTHON_UNUSED PyObject *__p
                   /* "implicit/lmf.pyx":234
  *         thread_id = threadid()
  *         try:
- *             for u in prange(n_users, schedule='guided'):             # <<<<<<<<<<<<<<
+ *             for u in prange(n_users, schedule='static'):             # <<<<<<<<<<<<<<
  *                 if indptr[u] == indptr[u + 1]:
  *                     continue
  */
@@ -7278,7 +7278,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_4lmf_update(CYTHON_UNUSED PyObject *__p
                       if (__pyx_t_3 > 0)
                       {
                           #ifdef _OPENMP
-                          #pragma omp for lastprivate(__pyx_v__) lastprivate(__pyx_v_exp_r) lastprivate(__pyx_v_i) lastprivate(__pyx_v_index) firstprivate(__pyx_v_u) lastprivate(__pyx_v_u) lastprivate(__pyx_v_user_seen_item) lastprivate(__pyx_v_z) schedule(guided)
+                          #pragma omp for lastprivate(__pyx_v__) lastprivate(__pyx_v_exp_r) lastprivate(__pyx_v_i) lastprivate(__pyx_v_index) firstprivate(__pyx_v_u) lastprivate(__pyx_v_u) lastprivate(__pyx_v_user_seen_item) lastprivate(__pyx_v_z) schedule(static)
                           #endif /* _OPENMP */
                           for (__pyx_t_2 = 0; __pyx_t_2 < __pyx_t_3; __pyx_t_2++){
                               {
@@ -7293,7 +7293,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_4lmf_update(CYTHON_UNUSED PyObject *__p
 
                                   /* "implicit/lmf.pyx":235
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:             # <<<<<<<<<<<<<<
  *                     continue
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -7306,7 +7306,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_4lmf_update(CYTHON_UNUSED PyObject *__p
                                   if (__pyx_t_6) {
 
                                     /* "implicit/lmf.pyx":236
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:
  *                     continue             # <<<<<<<<<<<<<<
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -7316,7 +7316,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_4lmf_update(CYTHON_UNUSED PyObject *__p
 
                                     /* "implicit/lmf.pyx":235
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:             # <<<<<<<<<<<<<<
  *                     continue
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -8021,7 +8021,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_6lmf_update(CYTHON_UNUSED PyObject *__p
  *         deriv = <floating*> malloc(sizeof(floating) * n_factors)
  *         thread_id = threadid()             # <<<<<<<<<<<<<<
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  */
                 #ifdef _OPENMP
                 __pyx_t_1 = omp_get_thread_num();
@@ -8034,7 +8034,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_6lmf_update(CYTHON_UNUSED PyObject *__p
  *         deriv = <floating*> malloc(sizeof(floating) * n_factors)
  *         thread_id = threadid()
  *         try:             # <<<<<<<<<<<<<<
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:
  */
                 /*try:*/ {
@@ -8042,7 +8042,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_6lmf_update(CYTHON_UNUSED PyObject *__p
                   /* "implicit/lmf.pyx":234
  *         thread_id = threadid()
  *         try:
- *             for u in prange(n_users, schedule='guided'):             # <<<<<<<<<<<<<<
+ *             for u in prange(n_users, schedule='static'):             # <<<<<<<<<<<<<<
  *                 if indptr[u] == indptr[u + 1]:
  *                     continue
  */
@@ -8053,7 +8053,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_6lmf_update(CYTHON_UNUSED PyObject *__p
                       if (__pyx_t_4 > 0)
                       {
                           #ifdef _OPENMP
-                          #pragma omp for lastprivate(__pyx_v__) lastprivate(__pyx_v_exp_r) lastprivate(__pyx_v_i) lastprivate(__pyx_v_index) firstprivate(__pyx_v_u) lastprivate(__pyx_v_u) lastprivate(__pyx_v_user_seen_item) lastprivate(__pyx_v_z) schedule(guided)
+                          #pragma omp for lastprivate(__pyx_v__) lastprivate(__pyx_v_exp_r) lastprivate(__pyx_v_i) lastprivate(__pyx_v_index) firstprivate(__pyx_v_u) lastprivate(__pyx_v_u) lastprivate(__pyx_v_user_seen_item) lastprivate(__pyx_v_z) schedule(static)
                           #endif /* _OPENMP */
                           for (__pyx_t_3 = 0; __pyx_t_3 < __pyx_t_4; __pyx_t_3++){
                               {
@@ -8068,7 +8068,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_6lmf_update(CYTHON_UNUSED PyObject *__p
 
                                   /* "implicit/lmf.pyx":235
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:             # <<<<<<<<<<<<<<
  *                     continue
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -8081,7 +8081,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_6lmf_update(CYTHON_UNUSED PyObject *__p
                                   if (__pyx_t_7) {
 
                                     /* "implicit/lmf.pyx":236
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:
  *                     continue             # <<<<<<<<<<<<<<
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -8091,7 +8091,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_6lmf_update(CYTHON_UNUSED PyObject *__p
 
                                     /* "implicit/lmf.pyx":235
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:             # <<<<<<<<<<<<<<
  *                     continue
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -8797,7 +8797,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_8lmf_update(CYTHON_UNUSED PyObject *__p
  *         deriv = <floating*> malloc(sizeof(floating) * n_factors)
  *         thread_id = threadid()             # <<<<<<<<<<<<<<
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  */
                 #ifdef _OPENMP
                 __pyx_t_1 = omp_get_thread_num();
@@ -8810,7 +8810,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_8lmf_update(CYTHON_UNUSED PyObject *__p
  *         deriv = <floating*> malloc(sizeof(floating) * n_factors)
  *         thread_id = threadid()
  *         try:             # <<<<<<<<<<<<<<
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:
  */
                 /*try:*/ {
@@ -8818,7 +8818,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_8lmf_update(CYTHON_UNUSED PyObject *__p
                   /* "implicit/lmf.pyx":234
  *         thread_id = threadid()
  *         try:
- *             for u in prange(n_users, schedule='guided'):             # <<<<<<<<<<<<<<
+ *             for u in prange(n_users, schedule='static'):             # <<<<<<<<<<<<<<
  *                 if indptr[u] == indptr[u + 1]:
  *                     continue
  */
@@ -8829,7 +8829,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_8lmf_update(CYTHON_UNUSED PyObject *__p
                       if (__pyx_t_4 > 0)
                       {
                           #ifdef _OPENMP
-                          #pragma omp for lastprivate(__pyx_v__) lastprivate(__pyx_v_exp_r) lastprivate(__pyx_v_i) lastprivate(__pyx_v_index) firstprivate(__pyx_v_u) lastprivate(__pyx_v_u) lastprivate(__pyx_v_user_seen_item) lastprivate(__pyx_v_z) schedule(guided)
+                          #pragma omp for lastprivate(__pyx_v__) lastprivate(__pyx_v_exp_r) lastprivate(__pyx_v_i) lastprivate(__pyx_v_index) firstprivate(__pyx_v_u) lastprivate(__pyx_v_u) lastprivate(__pyx_v_user_seen_item) lastprivate(__pyx_v_z) schedule(static)
                           #endif /* _OPENMP */
                           for (__pyx_t_3 = 0; __pyx_t_3 < __pyx_t_4; __pyx_t_3++){
                               {
@@ -8844,7 +8844,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_8lmf_update(CYTHON_UNUSED PyObject *__p
 
                                   /* "implicit/lmf.pyx":235
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:             # <<<<<<<<<<<<<<
  *                     continue
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -8857,7 +8857,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_8lmf_update(CYTHON_UNUSED PyObject *__p
                                   if (__pyx_t_7) {
 
                                     /* "implicit/lmf.pyx":236
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:
  *                     continue             # <<<<<<<<<<<<<<
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -8867,7 +8867,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_8lmf_update(CYTHON_UNUSED PyObject *__p
 
                                     /* "implicit/lmf.pyx":235
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:             # <<<<<<<<<<<<<<
  *                     continue
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -9571,7 +9571,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_10lmf_update(CYTHON_UNUSED PyObject *__
  *         deriv = <floating*> malloc(sizeof(floating) * n_factors)
  *         thread_id = threadid()             # <<<<<<<<<<<<<<
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  */
                 #ifdef _OPENMP
                 __pyx_t_1 = omp_get_thread_num();
@@ -9584,7 +9584,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_10lmf_update(CYTHON_UNUSED PyObject *__
  *         deriv = <floating*> malloc(sizeof(floating) * n_factors)
  *         thread_id = threadid()
  *         try:             # <<<<<<<<<<<<<<
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:
  */
                 /*try:*/ {
@@ -9592,7 +9592,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_10lmf_update(CYTHON_UNUSED PyObject *__
                   /* "implicit/lmf.pyx":234
  *         thread_id = threadid()
  *         try:
- *             for u in prange(n_users, schedule='guided'):             # <<<<<<<<<<<<<<
+ *             for u in prange(n_users, schedule='static'):             # <<<<<<<<<<<<<<
  *                 if indptr[u] == indptr[u + 1]:
  *                     continue
  */
@@ -9603,7 +9603,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_10lmf_update(CYTHON_UNUSED PyObject *__
                       if (__pyx_t_3 > 0)
                       {
                           #ifdef _OPENMP
-                          #pragma omp for lastprivate(__pyx_v__) lastprivate(__pyx_v_exp_r) lastprivate(__pyx_v_i) lastprivate(__pyx_v_index) firstprivate(__pyx_v_u) lastprivate(__pyx_v_u) lastprivate(__pyx_v_user_seen_item) lastprivate(__pyx_v_z) schedule(guided)
+                          #pragma omp for lastprivate(__pyx_v__) lastprivate(__pyx_v_exp_r) lastprivate(__pyx_v_i) lastprivate(__pyx_v_index) firstprivate(__pyx_v_u) lastprivate(__pyx_v_u) lastprivate(__pyx_v_user_seen_item) lastprivate(__pyx_v_z) schedule(static)
                           #endif /* _OPENMP */
                           for (__pyx_t_2 = 0; __pyx_t_2 < __pyx_t_3; __pyx_t_2++){
                               {
@@ -9618,7 +9618,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_10lmf_update(CYTHON_UNUSED PyObject *__
 
                                   /* "implicit/lmf.pyx":235
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:             # <<<<<<<<<<<<<<
  *                     continue
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -9631,7 +9631,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_10lmf_update(CYTHON_UNUSED PyObject *__
                                   if (__pyx_t_6) {
 
                                     /* "implicit/lmf.pyx":236
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:
  *                     continue             # <<<<<<<<<<<<<<
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -9641,7 +9641,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_10lmf_update(CYTHON_UNUSED PyObject *__
 
                                     /* "implicit/lmf.pyx":235
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:             # <<<<<<<<<<<<<<
  *                     continue
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -10346,7 +10346,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_12lmf_update(CYTHON_UNUSED PyObject *__
  *         deriv = <floating*> malloc(sizeof(floating) * n_factors)
  *         thread_id = threadid()             # <<<<<<<<<<<<<<
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  */
                 #ifdef _OPENMP
                 __pyx_t_1 = omp_get_thread_num();
@@ -10359,7 +10359,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_12lmf_update(CYTHON_UNUSED PyObject *__
  *         deriv = <floating*> malloc(sizeof(floating) * n_factors)
  *         thread_id = threadid()
  *         try:             # <<<<<<<<<<<<<<
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:
  */
                 /*try:*/ {
@@ -10367,7 +10367,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_12lmf_update(CYTHON_UNUSED PyObject *__
                   /* "implicit/lmf.pyx":234
  *         thread_id = threadid()
  *         try:
- *             for u in prange(n_users, schedule='guided'):             # <<<<<<<<<<<<<<
+ *             for u in prange(n_users, schedule='static'):             # <<<<<<<<<<<<<<
  *                 if indptr[u] == indptr[u + 1]:
  *                     continue
  */
@@ -10378,7 +10378,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_12lmf_update(CYTHON_UNUSED PyObject *__
                       if (__pyx_t_4 > 0)
                       {
                           #ifdef _OPENMP
-                          #pragma omp for lastprivate(__pyx_v__) lastprivate(__pyx_v_exp_r) lastprivate(__pyx_v_i) lastprivate(__pyx_v_index) firstprivate(__pyx_v_u) lastprivate(__pyx_v_u) lastprivate(__pyx_v_user_seen_item) lastprivate(__pyx_v_z) schedule(guided)
+                          #pragma omp for lastprivate(__pyx_v__) lastprivate(__pyx_v_exp_r) lastprivate(__pyx_v_i) lastprivate(__pyx_v_index) firstprivate(__pyx_v_u) lastprivate(__pyx_v_u) lastprivate(__pyx_v_user_seen_item) lastprivate(__pyx_v_z) schedule(static)
                           #endif /* _OPENMP */
                           for (__pyx_t_3 = 0; __pyx_t_3 < __pyx_t_4; __pyx_t_3++){
                               {
@@ -10393,7 +10393,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_12lmf_update(CYTHON_UNUSED PyObject *__
 
                                   /* "implicit/lmf.pyx":235
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:             # <<<<<<<<<<<<<<
  *                     continue
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -10406,7 +10406,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_12lmf_update(CYTHON_UNUSED PyObject *__
                                   if (__pyx_t_7) {
 
                                     /* "implicit/lmf.pyx":236
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:
  *                     continue             # <<<<<<<<<<<<<<
  *                 user_seen_item = indptr[u + 1] - indptr[u]
@@ -10416,7 +10416,7 @@ static PyObject *__pyx_pf_8implicit_3lmf_12lmf_update(CYTHON_UNUSED PyObject *__
 
                                     /* "implicit/lmf.pyx":235
  *         try:
- *             for u in prange(n_users, schedule='guided'):
+ *             for u in prange(n_users, schedule='static'):
  *                 if indptr[u] == indptr[u + 1]:             # <<<<<<<<<<<<<<
  *                     continue
  *                 user_seen_item = indptr[u + 1] - indptr[u]

--- a/implicit/lmf.pyx
+++ b/implicit/lmf.pyx
@@ -231,7 +231,7 @@ def lmf_update(RNGVector rng, floating[:, :] deriv_sum_sq,
         deriv = <floating*> malloc(sizeof(floating) * n_factors)
         thread_id = threadid()
         try:
-            for u in prange(n_users, schedule='guided'):
+            for u in prange(n_users, schedule='static'):
                 if indptr[u] == indptr[u + 1]:
                     continue
                 user_seen_item = indptr[u + 1] - indptr[u]


### PR DESCRIPTION
the LMF/BPR models were converging to different results each time,
even when the random_state parameter was being passed in. The
problem was that each thread was getting a different set of rows each
time, which affected how negative samples were sampled.

Fix by using a static openmp schedule.