### PR TITLE
Fix GPU dot product when the # of factors wasn't warp aligned

### DIFF
--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -61,20 +61,6 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
 
         super(AlternatingLeastSquares, self).__init__()
 
-        # currently there are some issues when training on the GPU when some of the warps
-        # don't have full factors. Round up to be warp aligned.
-        # TODO: figure out where the issue is (best guess is in the
-        # the 'dot' function in 'implicit/gpu/utils.cuh)
-        if factors % 32:
-            padding = 32 - factors % 32
-            log.warning(
-                "GPU training requires factor size to be a multiple of 32."
-                " Increasing factors from %i to %i.",
-                factors,
-                factors + padding,
-            )
-            factors += padding
-
         # parameters on how to factorize
         self.factors = factors
         self.regularization = regularization

--- a/implicit/gpu/bpr.py
+++ b/implicit/gpu/bpr.py
@@ -61,16 +61,6 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
         if not implicit.gpu.HAS_CUDA:
             raise ValueError("No CUDA extension has been built, can't train on GPU.")
 
-        if (factors + 1) % 32:
-            padding = 32 - (factors + 1) % 32
-            log.warning(
-                "GPU training requires factor size to be a multiple of 32 - 1."
-                " Increasing factors from %i to %i.",
-                factors,
-                factors + padding,
-            )
-            factors += padding
-
         self.factors = factors
         self.learning_rate = learning_rate
         self.iterations = iterations

--- a/implicit/gpu/utils.cuh
+++ b/implicit/gpu/utils.cuh
@@ -90,8 +90,9 @@ float dot(const float * a, const float * b) {
     }
 
     // otherwise reduce again in the first warp
-    val = (threadIdx.x < blockDim.x / WARP_SIZE) ? shared[lane] : 0;
     if (warp == 0) {
+        int num_warps = (blockDim.x + WARP_SIZE - 1) / WARP_SIZE;
+        val = (lane  < num_warps) ? shared[lane] : 0;
         val = warp_reduce_sum(val);
         // broadcast back to shared memory
         if (threadIdx.x == 0) {


### PR DESCRIPTION
Our MF algorithms produced incorrect results when the number of factors
wasn't warp aligned (like a multiple of 32).

This fixes a problem where we weren't correctly calculating the number of
warps in the dot function - meaning that we weren't including the results
of the last partial warp in the reduction.

Closes #262