### PR TITLE
fix(als.py): No need to convert user_items or react_users to csr if t…

### DIFF
--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -193,6 +193,17 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         self._check_fit_errors()
 
     def recalculate_user(self, userid, user_items):
+        if user_items.getformat() == 'csr':
+            return user_factor(
+                self.item_factors,
+                self.YtY,
+                user_items,
+                userid,
+                self.regularization,
+                self.factors,
+            )
+        
+        # if the format of user_items is not 'csr' then convert to 'csr'
         return user_factor(
             self.item_factors,
             self.YtY,
@@ -203,6 +214,17 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         )
 
     def recalculate_item(self, itemid, react_users):
+        if react_users.getformat() == 'csr':
+            return item_factor(
+                self.user_factors,
+                self.XtX,
+                react_users,
+                itemid,
+                self.regularization,
+                self.factors,
+            )
+        
+        # if the format of react_users is not 'csr' then convert to 'csr'
         return item_factor(
             self.user_factors,
             self.XtX,


### PR DESCRIPTION
…hey are already in csr format

Added conditional return statements to recalculate_user and recalculate_item functions. This bypasses the time expenditure during csr conversion. Helpful when one has to calculate user and item latent vectors for hundreds of thousands of items,