### PR TITLE
Add recall@k to ranking metrics

### DIFF
--- a/implicit/evaluation.pyx
+++ b/implicit/evaluation.pyx
@@ -269,6 +269,7 @@ def precision_at_k(model, train_user_items, test_user_items, int K=10,
     return ranking_metrics_at_k(
         model, train_user_items, test_user_items, K, show_progress, num_threads)['precision']
 
+
 @cython.boundscheck(False)
 def recall_at_k(model, train_user_items, test_user_items, int K=10,
                 show_progress=True, int num_threads=1):

--- a/tests/recommender_base_test.py
+++ b/tests/recommender_base_test.py
@@ -7,7 +7,7 @@ import pickle
 import numpy as np
 from scipy.sparse import csr_matrix
 
-from implicit.evaluation import precision_at_k
+from implicit.evaluation import precision_at_k, recall_at_k
 from implicit.nearest_neighbours import ItemItemRecommender
 
 
@@ -82,6 +82,20 @@ class TestRecommenderBaseMixin(object):
         # we've withheld the diagnoal for testing, and have verified that in test_recommend
         # it is returned for each user. So p@1 should be 1.0
         p = precision_at_k(
+            model, user_items.tocsr(), csr_matrix(np.eye(50)), K=1, show_progress=False
+        )
+        self.assertEqual(p, 1)
+
+    def test_evaluation_recall(self):
+        item_users = self.get_checker_board(50)
+        user_items = item_users.T.tocsr()
+
+        model = self._get_model()
+        model.fit(item_users, show_progress=False)
+
+        # we've withheld the diagnoal for testing, and have verified that in test_recommend
+        # it is returned for each user. So r@1 should be 1.0
+        p = recall_at_k(
             model, user_items.tocsr(), csr_matrix(np.eye(50)), K=1, show_progress=False
         )
         self.assertEqual(p, 1)

--- a/tests/recommender_base_test.py
+++ b/tests/recommender_base_test.py
@@ -95,9 +95,7 @@ class TestRecommenderBaseMixin(object):
 
         # we've withheld the diagnoal for testing, and have verified that in test_recommend
         # it is returned for each user. So r@1 should be 1.0
-        p = recall_at_k(
-            model, user_items.tocsr(), csr_matrix(np.eye(50)), K=1, show_progress=False
-        )
+        p = recall_at_k(model, user_items.tocsr(), csr_matrix(np.eye(50)), K=1, show_progress=False)
         self.assertEqual(p, 1)
 
     def test_similar_users(self):


### PR DESCRIPTION
Very simple addition of recall@k by using the total relevant items instead of `min(k, likes.sizes())`.