### PR TITLE
Pytest 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,4 +47,4 @@ jobs:
         python setup.py develop
     - name: Run unittests
       run: |
-        pytest tests
+        python -m pytest tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         isort -c .
     - name: Build
       run: |
-        python setup.py install
+        python setup.py develop
     - name: Run unittests
       run: |
         pytest tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 isort cpplint black
+        pip install flake8 isort cpplint black pytest
         pip install -r requirements.txt
     - name: Lint with flake8
       run: |
@@ -47,4 +47,4 @@ jobs:
         python setup.py install
     - name: Run unittests
       run: |
-        python setup.py test
+        pytest tests

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -8,10 +8,10 @@ from scipy.sparse import csr_matrix, random
 from implicit.als import AlternatingLeastSquares
 from implicit.gpu import HAS_CUDA
 
-from .recommender_base_test import TestRecommenderBaseMixin
+from .recommender_base_test import RecommenderBaseTestMixin
 
 
-class ALSTest(unittest.TestCase, TestRecommenderBaseMixin):
+class ALSTest(unittest.TestCase, RecommenderBaseTestMixin):
     def _get_model(self):
         return AlternatingLeastSquares(factors=3, regularization=0, use_gpu=False, random_state=23)
 
@@ -238,7 +238,7 @@ class ALSTest(unittest.TestCase, TestRecommenderBaseMixin):
 
 if HAS_CUDA:
 
-    class GPUALSTest(unittest.TestCase, TestRecommenderBaseMixin):
+    class GPUALSTest(unittest.TestCase, RecommenderBaseTestMixin):
         def _get_model(self):
             return AlternatingLeastSquares(factors=32, regularization=0, random_state=23)
 

--- a/tests/approximate_als_test.py
+++ b/tests/approximate_als_test.py
@@ -9,13 +9,13 @@ from implicit.approximate_als import (
 )
 from implicit.gpu import HAS_CUDA
 
-from .recommender_base_test import TestRecommenderBaseMixin
+from .recommender_base_test import RecommenderBaseTestMixin
 
 # don't require annoy/faiss/nmslib to be installed
 try:
     import annoy  # noqa
 
-    class AnnoyALSTest(unittest.TestCase, TestRecommenderBaseMixin):
+    class AnnoyALSTest(unittest.TestCase, RecommenderBaseTestMixin):
         def _get_model(self):
             return AnnoyAlternatingLeastSquares(factors=2, regularization=0, random_state=23)
 
@@ -30,7 +30,7 @@ except ImportError:
 try:
     import nmslib  # noqa
 
-    class NMSLibALSTest(unittest.TestCase, TestRecommenderBaseMixin):
+    class NMSLibALSTest(unittest.TestCase, RecommenderBaseTestMixin):
         def _get_model(self):
             return NMSLibAlternatingLeastSquares(
                 factors=2, regularization=0, index_params={"post": 2}, random_state=23
@@ -47,7 +47,7 @@ except ImportError:
 try:
     import faiss  # noqa
 
-    class FaissALSTest(unittest.TestCase, TestRecommenderBaseMixin):
+    class FaissALSTest(unittest.TestCase, RecommenderBaseTestMixin):
         def _get_model(self):
             return FaissAlternatingLeastSquares(
                 nlist=1, nprobe=1, factors=2, regularization=0, use_gpu=False, random_state=23
@@ -59,7 +59,7 @@ try:
 
     if HAS_CUDA:
 
-        class FaissALSGPUTest(unittest.TestCase, TestRecommenderBaseMixin):
+        class FaissALSGPUTest(unittest.TestCase, RecommenderBaseTestMixin):
             __regularization = 0
 
             def _get_model(self):

--- a/tests/bpr_test.py
+++ b/tests/bpr_test.py
@@ -5,10 +5,10 @@ from scipy.sparse import csr_matrix
 from implicit.bpr import BayesianPersonalizedRanking
 from implicit.gpu import HAS_CUDA
 
-from .recommender_base_test import TestRecommenderBaseMixin
+from .recommender_base_test import RecommenderBaseTestMixin
 
 
-class BPRTest(unittest.TestCase, TestRecommenderBaseMixin):
+class BPRTest(unittest.TestCase, RecommenderBaseTestMixin):
     def _get_model(self):
         return BayesianPersonalizedRanking(
             factors=3, regularization=0, use_gpu=False, random_state=42
@@ -27,7 +27,7 @@ class BPRTest(unittest.TestCase, TestRecommenderBaseMixin):
 
 if HAS_CUDA:
 
-    class BPRGPUTest(unittest.TestCase, TestRecommenderBaseMixin):
+    class BPRGPUTest(unittest.TestCase, RecommenderBaseTestMixin):
         def _get_model(self):
             return BayesianPersonalizedRanking(
                 factors=31, regularization=0, use_gpu=True, learning_rate=0.02, random_state=42

--- a/tests/knn_test.py
+++ b/tests/knn_test.py
@@ -7,20 +7,20 @@ from scipy.sparse import csr_matrix
 
 import implicit
 
-from .recommender_base_test import TestRecommenderBaseMixin
+from .recommender_base_test import RecommenderBaseTestMixin
 
 
-class BM25Test(unittest.TestCase, TestRecommenderBaseMixin):
+class BM25Test(unittest.TestCase, RecommenderBaseTestMixin):
     def _get_model(self):
         return implicit.nearest_neighbours.BM25Recommender(K=50)
 
 
-class TFIDFTest(unittest.TestCase, TestRecommenderBaseMixin):
+class TFIDFTest(unittest.TestCase, RecommenderBaseTestMixin):
     def _get_model(self):
         return implicit.nearest_neighbours.TFIDFRecommender(K=50)
 
 
-class CosineTest(unittest.TestCase, TestRecommenderBaseMixin):
+class CosineTest(unittest.TestCase, RecommenderBaseTestMixin):
     def _get_model(self):
         return implicit.nearest_neighbours.CosineRecommender(K=50)
 

--- a/tests/lmf_test.py
+++ b/tests/lmf_test.py
@@ -2,10 +2,10 @@ import unittest
 
 from implicit.lmf import LogisticMatrixFactorization
 
-from .recommender_base_test import TestRecommenderBaseMixin
+from .recommender_base_test import RecommenderBaseTestMixin
 
 
-class LMFTest(unittest.TestCase, TestRecommenderBaseMixin):
+class LMFTest(unittest.TestCase, RecommenderBaseTestMixin):
     def _get_model(self):
         return LogisticMatrixFactorization(
             factors=3, regularization=0, use_gpu=False, random_state=43

--- a/tests/recommender_base_test.py
+++ b/tests/recommender_base_test.py
@@ -11,7 +11,7 @@ from implicit.evaluation import precision_at_k
 from implicit.nearest_neighbours import ItemItemRecommender
 
 
-class TestRecommenderBaseMixin(object):
+class RecommenderBaseTestMixin(object):
     """Mixin to test a bunch of common functionality in models
     deriving from RecommenderBase"""
 


### PR DESCRIPTION
Rename the test mixin so that pytest doesn't get mixed up - and start using pytest in the CI rather than the deprecated 'python setup.py test' command we were using before.