### PR TITLE
Rename cuda C++ classes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/implicit/gpu/_cuda.pyx
+++ b/implicit/gpu/_cuda.pyx
@@ -6,13 +6,13 @@ from cython.operator import dereference
 from libcpp cimport bool
 from libcpp.utility cimport pair
 
-from .matrix cimport CSRMatrix as CppCSRMatrix
+from .als cimport LeastSquaresSolver as CppLeastSquaresSolver
+from .bpr cimport bpr_update as cpp_bpr_update
 from .matrix cimport COOMatrix as CppCOOMatrix
+from .matrix cimport CSRMatrix as CppCSRMatrix
 from .matrix cimport Matrix as CppMatrix
 from .matrix cimport Vector as CppVector
 
-from .bpr cimport bpr_update as cpp_bpr_update
-from .als cimport LeastSquaresSolver as CppLeastSquaresSolver
 
 cdef class Matrix(object):
     cdef CppMatrix * c_matrix

--- a/implicit/gpu/_cuda.pyx
+++ b/implicit/gpu/_cuda.pyx
@@ -54,7 +54,7 @@ cdef class CSRMatrix(object):
         cdef int[:] indices = X.indices
         cdef float[:] data = X.data.astype(np.float32)
         self.c_matrix = new CppCSRMatrix(X.shape[0], X.shape[1], len(X.data),
-                                          &indptr[0], &indices[0], &data[0])
+                                         &indptr[0], &indices[0], &data[0])
 
     def __dealloc__(self):
         del self.c_matrix
@@ -67,7 +67,7 @@ cdef class COOMatrix(object):
         cdef int[:] col = X.col
         cdef float[:] data = X.data.astype(np.float32)
         self.c_matrix = new CppCOOMatrix(X.shape[0], X.shape[1], len(X.data),
-                                          &row[0], &col[0], &data[0])
+                                         &row[0], &col[0], &data[0])
 
     def __dealloc__(self):
         del self.c_matrix
@@ -95,8 +95,8 @@ cdef class LeastSquaresSolver(object):
 
 
 def bpr_update(IntVector userids, IntVector itemids, IntVector indptr,
-                  Matrix X, Matrix Y,
-                  float learning_rate, float regularization, long seed, bool verify_negative):
+               Matrix X, Matrix Y,
+               float learning_rate, float regularization, long seed, bool verify_negative):
     ret = cpp_bpr_update(dereference(userids.c_vector),
                          dereference(itemids.c_vector),
                          dereference(indptr.c_vector),

--- a/implicit/gpu/_cuda.pyx
+++ b/implicit/gpu/_cuda.pyx
@@ -6,44 +6,16 @@ from cython.operator import dereference
 from libcpp cimport bool
 from libcpp.utility cimport pair
 
+from .matrix cimport CSRMatrix as CppCSRMatrix
+from .matrix cimport COOMatrix as CppCOOMatrix
+from .matrix cimport Matrix as CppMatrix
+from .matrix cimport Vector as CppVector
 
-cdef extern from "als.h" namespace "implicit" nogil:
-    cdef cppclass CudaCSRMatrix:
-        CudaCSRMatrix(int rows, int cols, int nonzeros,
-                      const int * indptr, const int * indices, const float * data) except +
+from .bpr cimport bpr_update as cpp_bpr_update
+from .als cimport LeastSquaresSolver as CppLeastSquaresSolver
 
-    cdef cppclass CudaVector[T]:
-        CudaVector(int size, T * data)
-
-    cdef cppclass CudaCOOMatrix:
-        CudaCOOMatrix(int rows, int cols, int nonzeros,
-                      const int * row, const int * col, const float * data) except +
-
-    cdef cppclass CudaDenseMatrix:
-        CudaDenseMatrix(int rows, int cols, float * data, bool host) except +
-        void to_host(float * output) except +
-
-    cdef cppclass CudaLeastSquaresSolver:
-        CudaLeastSquaresSolver(int factors) except +
-        void least_squares(const CudaCSRMatrix & Cui, CudaDenseMatrix * X,
-                           const CudaDenseMatrix & Y, float regularization, int cg_steps) except +
-
-        float calculate_loss(const CudaCSRMatrix & Cui, const CudaDenseMatrix & X,
-                             const CudaDenseMatrix & Y, float regularization) except +
-
-
-cdef extern from "bpr.h" namespace "implicit" nogil:
-    cdef pair[int, int] bpr_update(const CudaVector[int] & userids,
-                                   const CudaVector[int] & itemids,
-                                   const CudaVector[int] & indptr,
-                                   CudaDenseMatrix * X,
-                                   CudaDenseMatrix * Y,
-                                   float learning_rate, float regularization, long seed,
-                                   bool verify_negative_samples) except +
-
-
-cdef class CuDenseMatrix(object):
-    cdef CudaDenseMatrix* c_matrix
+cdef class Matrix(object):
+    cdef CppMatrix * c_matrix
 
     def __cinit__(self, X):
         cdef float[:, :] c_X
@@ -52,11 +24,11 @@ cdef class CuDenseMatrix(object):
         if cai:
             shape = cai["shape"]
             data = cai["data"][0]
-            self.c_matrix = new CudaDenseMatrix(shape[0], shape[1], <float*>data, False)
+            self.c_matrix = new CppMatrix(shape[0], shape[1], <float*>data, False)
         else:
             # otherwise assume we're a buffer on host
             c_X = X
-            self.c_matrix = new CudaDenseMatrix(X.shape[0], X.shape[1], &c_X[0, 0], True)
+            self.c_matrix = new CppMatrix(X.shape[0], X.shape[1], &c_X[0, 0], True)
 
     def to_host(self, float[:, :] X):
         self.c_matrix.to_host(&X[0, 0])
@@ -64,55 +36,55 @@ cdef class CuDenseMatrix(object):
     def __dealloc__(self):
         del self.c_matrix
 
-cdef class CuIntVector(object):
-    cdef CudaVector[int] * c_vector
+cdef class IntVector(object):
+    cdef CppVector[int] * c_vector
 
     def __cinit__(self, int[:] data):
-        self.c_vector = new CudaVector[int](len(data), &data[0])
+        self.c_vector = new CppVector[int](len(data), &data[0])
 
     def __dealloc__(self):
         del self.c_vector
 
 
-cdef class CuCSRMatrix(object):
-    cdef CudaCSRMatrix* c_matrix
+cdef class CSRMatrix(object):
+    cdef CppCSRMatrix * c_matrix
 
     def __cinit__(self, X):
         cdef int[:] indptr = X.indptr
         cdef int[:] indices = X.indices
         cdef float[:] data = X.data.astype(np.float32)
-        self.c_matrix = new CudaCSRMatrix(X.shape[0], X.shape[1], len(X.data),
+        self.c_matrix = new CppCSRMatrix(X.shape[0], X.shape[1], len(X.data),
                                           &indptr[0], &indices[0], &data[0])
 
     def __dealloc__(self):
         del self.c_matrix
 
-cdef class CuCOOMatrix(object):
-    cdef CudaCOOMatrix* c_matrix
+cdef class COOMatrix(object):
+    cdef CppCOOMatrix* c_matrix
 
     def __cinit__(self, X):
         cdef int[:] row = X.row
         cdef int[:] col = X.col
         cdef float[:] data = X.data.astype(np.float32)
-        self.c_matrix = new CudaCOOMatrix(X.shape[0], X.shape[1], len(X.data),
+        self.c_matrix = new CppCOOMatrix(X.shape[0], X.shape[1], len(X.data),
                                           &row[0], &col[0], &data[0])
 
     def __dealloc__(self):
         del self.c_matrix
 
 
-cdef class CuLeastSquaresSolver(object):
-    cdef CudaLeastSquaresSolver * c_solver
+cdef class LeastSquaresSolver(object):
+    cdef CppLeastSquaresSolver * c_solver
 
     def __cinit__(self, int factors):
-        self.c_solver = new CudaLeastSquaresSolver(factors)
+        self.c_solver = new CppLeastSquaresSolver(factors)
 
-    def least_squares(self, CuCSRMatrix cui, CuDenseMatrix X, CuDenseMatrix Y,
+    def least_squares(self, CSRMatrix cui, Matrix X, Matrix Y,
                       float regularization, int cg_steps):
         self.c_solver.least_squares(dereference(cui.c_matrix), X.c_matrix, dereference(Y.c_matrix),
                                     regularization, cg_steps)
 
-    def calculate_loss(self, CuCSRMatrix cui, CuDenseMatrix X, CuDenseMatrix Y,
+    def calculate_loss(self, CSRMatrix cui, Matrix X, Matrix Y,
                        float regularization):
         return self.c_solver.calculate_loss(dereference(cui.c_matrix), dereference(X.c_matrix),
 
@@ -122,12 +94,12 @@ cdef class CuLeastSquaresSolver(object):
         del self.c_solver
 
 
-def cu_bpr_update(CuIntVector userids, CuIntVector itemids, CuIntVector indptr,
-                  CuDenseMatrix X, CuDenseMatrix Y,
+def bpr_update(IntVector userids, IntVector itemids, IntVector indptr,
+                  Matrix X, Matrix Y,
                   float learning_rate, float regularization, long seed, bool verify_negative):
-    ret = bpr_update(dereference(userids.c_vector),
-                     dereference(itemids.c_vector),
-                     dereference(indptr.c_vector),
-                     X.c_matrix, Y.c_matrix,
-                     learning_rate, regularization, seed, verify_negative)
+    ret = cpp_bpr_update(dereference(userids.c_vector),
+                         dereference(itemids.c_vector),
+                         dereference(indptr.c_vector),
+                         X.c_matrix, Y.c_matrix,
+                         learning_rate, regularization, seed, verify_negative)
     return ret.first, ret.second

--- a/implicit/gpu/als.h
+++ b/implicit/gpu/als.h
@@ -5,24 +5,24 @@
 // Forward ref: don't require the whole cublas definition here
 struct cublasContext;
 
-namespace implicit {
+namespace implicit { namespace gpu {
 
-struct CudaLeastSquaresSolver {
-    explicit CudaLeastSquaresSolver(int factors);
-    ~CudaLeastSquaresSolver();
+struct LeastSquaresSolver {
+    explicit LeastSquaresSolver(int factors);
+    ~LeastSquaresSolver();
 
-    void least_squares(const CudaCSRMatrix & Cui,
-                       CudaDenseMatrix * X, const CudaDenseMatrix & Y,
+    void least_squares(const CSRMatrix & Cui,
+                       Matrix * X, const Matrix & Y,
                        float regularization,
                        int cg_steps) const;
 
-    float calculate_loss(const CudaCSRMatrix & Cui,
-                        const CudaDenseMatrix & X,
-                        const CudaDenseMatrix & Y,
-                        float regularization);
+    float calculate_loss(const CSRMatrix & Cui,
+                         const Matrix & X,
+                         const Matrix & Y,
+                         float regularization);
 
-    CudaDenseMatrix YtY;
+    Matrix YtY;
     cublasContext * blas_handle;
 };
-}  // namespace implicit
+}}  // namespace implicit::gpu
 #endif  // IMPLICIT_GPU_ALS_H_

--- a/implicit/gpu/als.pxd
+++ b/implicit/gpu/als.pxd
@@ -1,0 +1,12 @@
+from .matrix cimport CSRMatrix, Matrix
+
+
+cdef extern from "als.h" namespace "implicit::gpu" nogil:
+    cdef cppclass LeastSquaresSolver:
+        LeastSquaresSolver(int factors) except +
+        void least_squares(const CSRMatrix & Cui, Matrix * X,
+                           const Matrix & Y, float regularization, int cg_steps) except +
+
+        float calculate_loss(const CSRMatrix & Cui, const Matrix & X,
+                             const Matrix & Y, float regularization) except +
+

--- a/implicit/gpu/als.pxd
+++ b/implicit/gpu/als.pxd
@@ -9,4 +9,3 @@ cdef extern from "als.h" namespace "implicit::gpu" nogil:
 
         float calculate_loss(const CSRMatrix & Cui, const Matrix & X,
                              const Matrix & Y, float regularization) except +
-

--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -132,12 +132,12 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         # invalidate cached norms and squared factors
         self._item_norms = self._user_norms = None
 
-        Ciu = implicit.gpu.CuCSRMatrix(Ciu)
-        Cui = implicit.gpu.CuCSRMatrix(Cui)
-        X = implicit.gpu.CuDenseMatrix(self.user_factors)
-        Y = implicit.gpu.CuDenseMatrix(self.item_factors)
+        Ciu = implicit.gpu.CSRMatrix(Ciu)
+        Cui = implicit.gpu.CSRMatrix(Cui)
+        X = implicit.gpu.Matrix(self.user_factors)
+        Y = implicit.gpu.Matrix(self.item_factors)
 
-        solver = implicit.gpu.CuLeastSquaresSolver(self.factors)
+        solver = implicit.gpu.LeastSquaresSolver(self.factors)
         log.debug("Running %i ALS iterations", self.iterations)
         with tqdm(total=self.iterations, disable=not show_progress) as progress:
             for iteration in range(self.iterations):

--- a/implicit/gpu/bpr.cu
+++ b/implicit/gpu/bpr.cu
@@ -8,7 +8,7 @@
 #include "implicit/gpu/als.h"
 #include "implicit/gpu/utils.cuh"
 
-namespace implicit {
+namespace implicit { namespace gpu {
 
 // TODO: we could use an n-ary search here instead, but
 // that will only be faster when the number of likes for a user is
@@ -96,11 +96,11 @@ inline void checkCurand(curandStatus_t code, const char *file, int line) {
     }
 }
 
-std::pair<int, int> bpr_update(const CudaVector<int> & userids,
-                               const CudaVector<int> & itemids,
-                               const CudaVector<int> & indptr,
-                               CudaDenseMatrix * X,
-                               CudaDenseMatrix * Y,
+std::pair<int, int> bpr_update(const Vector<int> & userids,
+                               const Vector<int> & itemids,
+                               const Vector<int> & indptr,
+                               Matrix * X,
+                               Matrix * Y,
                                float learning_rate, float reg, long seed,
                                bool verify_negative_samples) {
     if (X->cols != Y->cols) throw std::invalid_argument("X and Y should have the same number of columns");
@@ -164,4 +164,4 @@ std::pair<int, int> bpr_update(const CudaVector<int> & userids,
     curandDestroyGenerator(rng);
     return std::make_pair(output[0], output[1]);
 }
-}
+}} // namespace

--- a/implicit/gpu/bpr.h
+++ b/implicit/gpu/bpr.h
@@ -3,15 +3,15 @@
 #include "implicit/gpu/matrix.h"
 #include <utility>
 
-namespace implicit {
-std::pair<int, int>  bpr_update(const CudaVector<int> & userids,
-                                const CudaVector<int> & itemids,
-                                const CudaVector<int> & indptr,
-                                CudaDenseMatrix * X,
-                                CudaDenseMatrix * Y,
+namespace implicit { namespace gpu {
+std::pair<int, int>  bpr_update(const Vector<int> & userids,
+                                const Vector<int> & itemids,
+                                const Vector<int> & indptr,
+                                Matrix * X,
+                                Matrix * Y,
                                 float learning_rate,
                                 float regularization,
                                 long seed,
                                 bool verify_negative_samples);
-}  // namespace implicit
+}}  // namespace implicit::gpu
 #endif  // IMPLICIT_GPU_BPR_H_

--- a/implicit/gpu/bpr.pxd
+++ b/implicit/gpu/bpr.pxd
@@ -1,7 +1,8 @@
 from libcpp cimport bool
 from libcpp.utility cimport pair
 
-from .matrix cimport Vector, Matrix
+from .matrix cimport Matrix, Vector
+
 
 cdef extern from "bpr.h" namespace "implicit::gpu" nogil:
     cdef pair[int, int] bpr_update(const Vector[int] & userids,

--- a/implicit/gpu/bpr.pxd
+++ b/implicit/gpu/bpr.pxd
@@ -1,0 +1,13 @@
+from libcpp cimport bool
+from libcpp.utility cimport pair
+
+from .matrix cimport Vector, Matrix
+
+cdef extern from "bpr.h" namespace "implicit::gpu" nogil:
+    cdef pair[int, int] bpr_update(const Vector[int] & userids,
+                                   const Vector[int] & itemids,
+                                   const Vector[int] & indptr,
+                                   Matrix * X,
+                                   Matrix * Y,
+                                   float learning_rate, float regularization, long seed,
+                                   bool verify_negative_samples) except +

--- a/implicit/gpu/bpr.py
+++ b/implicit/gpu/bpr.py
@@ -123,17 +123,17 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
 
         self._item_norms = self._user_norms = None
 
-        userids = implicit.gpu.CuIntVector(userids)
-        itemids = implicit.gpu.CuIntVector(user_items.indices)
-        indptr = implicit.gpu.CuIntVector(user_items.indptr)
+        userids = implicit.gpu.IntVector(userids)
+        itemids = implicit.gpu.IntVector(user_items.indices)
+        indptr = implicit.gpu.IntVector(user_items.indptr)
 
-        X = implicit.gpu.CuDenseMatrix(self.user_factors)
-        Y = implicit.gpu.CuDenseMatrix(self.item_factors)
+        X = implicit.gpu.Matrix(self.user_factors)
+        Y = implicit.gpu.Matrix(self.item_factors)
 
         log.debug("Running %i BPR training epochs", self.iterations)
         with tqdm(total=self.iterations, disable=not show_progress) as progress:
             for epoch in range(self.iterations):
-                correct, skipped = implicit.gpu.cu_bpr_update(
+                correct, skipped = implicit.gpu.bpr_update(
                     userids,
                     itemids,
                     indptr,

--- a/implicit/gpu/matrix.cu
+++ b/implicit/gpu/matrix.cu
@@ -5,9 +5,9 @@
 #include "implicit/gpu/matrix.h"
 #include "implicit/gpu/utils.cuh"
 
-namespace implicit {
+namespace implicit { namespace gpu {
 template <typename T>
-CudaVector<T>::CudaVector(int size, const T * host_data)
+Vector<T>::Vector(int size, const T * host_data)
     : size(size) {
     CHECK_CUDA(cudaMalloc(&data, size * sizeof(T)));
     if (host_data) {
@@ -17,14 +17,14 @@ CudaVector<T>::CudaVector(int size, const T * host_data)
 
 
 template <typename T>
-CudaVector<T>::~CudaVector() {
+Vector<T>::~Vector() {
     CHECK_CUDA(cudaFree(data));
 }
 
-template struct CudaVector<int>;
-template struct CudaVector<float>;
+template struct Vector<int>;
+template struct Vector<float>;
 
-CudaDenseMatrix::CudaDenseMatrix(int rows, int cols, float * host_data, bool cpu)
+Matrix::Matrix(int rows, int cols, float * host_data, bool cpu)
     : rows(rows), cols(cols) {
     if (cpu) {
         CHECK_CUDA(cudaMalloc(&data, rows * cols * sizeof(float)));
@@ -37,17 +37,18 @@ CudaDenseMatrix::CudaDenseMatrix(int rows, int cols, float * host_data, bool cpu
         owns_data = false;
     }
 }
-void CudaDenseMatrix::to_host(float * out) const {
+
+void Matrix::to_host(float * out) const {
     CHECK_CUDA(cudaMemcpy(out, data, rows * cols * sizeof(float), cudaMemcpyDeviceToHost));
 }
 
-CudaDenseMatrix::~CudaDenseMatrix() {
+Matrix::~Matrix() {
     if (owns_data) {
         CHECK_CUDA(cudaFree(data));
     }
 }
 
-CudaCSRMatrix::CudaCSRMatrix(int rows, int cols, int nonzeros,
+CSRMatrix::CSRMatrix(int rows, int cols, int nonzeros,
                              const int * indptr_, const int * indices_, const float * data_)
     : rows(rows), cols(cols), nonzeros(nonzeros) {
 
@@ -61,13 +62,13 @@ CudaCSRMatrix::CudaCSRMatrix(int rows, int cols, int nonzeros,
     CHECK_CUDA(cudaMemcpy(data, data_, nonzeros * sizeof(int), cudaMemcpyHostToDevice));
 }
 
-CudaCSRMatrix::~CudaCSRMatrix() {
+CSRMatrix::~CSRMatrix() {
     CHECK_CUDA(cudaFree(indices));
     CHECK_CUDA(cudaFree(indptr));
     CHECK_CUDA(cudaFree(data));
 }
 
-CudaCOOMatrix::CudaCOOMatrix(int rows, int cols, int nonzeros,
+COOMatrix::COOMatrix(int rows, int cols, int nonzeros,
                              const int * row_, const int * col_, const float * data_)
     : rows(rows), cols(cols), nonzeros(nonzeros) {
 
@@ -81,9 +82,9 @@ CudaCOOMatrix::CudaCOOMatrix(int rows, int cols, int nonzeros,
     CHECK_CUDA(cudaMemcpy(data, data_, nonzeros * sizeof(int), cudaMemcpyHostToDevice));
 }
 
-CudaCOOMatrix::~CudaCOOMatrix() {
+COOMatrix::~COOMatrix() {
     CHECK_CUDA(cudaFree(row));
     CHECK_CUDA(cudaFree(col));
     CHECK_CUDA(cudaFree(data));
 }
-}  // namespace implicit
+}}  // namespace implicit::gpu

--- a/implicit/gpu/matrix.h
+++ b/implicit/gpu/matrix.h
@@ -1,38 +1,38 @@
 #ifndef IMPLICIT_GPU_MATRIX_H_
 #define IMPLICIT_GPU_MATRIX_H_
 
-namespace implicit {
+namespace implicit { namespace gpu {
 /// Thin wrappers of CUDA memory: copies to from host, frees in destructor
 template <typename T>
-struct CudaVector {
-    CudaVector(int size, const T * elements);
-    ~CudaVector();
+struct Vector {
+    Vector(int size, const T * elements = NULL);
+    ~Vector();
 
     int size;
     T * data;
 };
 
-struct CudaCSRMatrix {
-    CudaCSRMatrix(int rows, int cols, int nonzeros,
+struct CSRMatrix {
+    CSRMatrix(int rows, int cols, int nonzeros,
                   const int * indptr, const int * indices, const float * data);
-    ~CudaCSRMatrix();
+    ~CSRMatrix();
     int * indptr, * indices;
     float * data;
     int rows, cols, nonzeros;
 };
 
-struct CudaCOOMatrix {
-    CudaCOOMatrix(int rows, int cols, int nonzeros,
+struct COOMatrix {
+    COOMatrix(int rows, int cols, int nonzeros,
                   const int * row, const int * col, const float * data);
-    ~CudaCOOMatrix();
+    ~COOMatrix();
     int * row, * col;
     float * data;
     int rows, cols, nonzeros;
 };
 
-struct CudaDenseMatrix {
-    CudaDenseMatrix(int rows, int cols, float * data, bool host=true);
-    ~CudaDenseMatrix();
+struct Matrix {
+    Matrix(int rows, int cols, float * data, bool host=true);
+    ~Matrix();
 
     void to_host(float * output) const;
 
@@ -40,5 +40,5 @@ struct CudaDenseMatrix {
     float * data;
     bool owns_data;
 };
-}  // namespace implicit
+}}  // namespace implicit/gpu
 #endif  // IMPLICIT_GPU_MATRIX_H_

--- a/implicit/gpu/matrix.pxd
+++ b/implicit/gpu/matrix.pxd
@@ -1,5 +1,6 @@
 from libcpp cimport bool
 
+
 cdef extern from "matrix.h" namespace "implicit::gpu" nogil:
     cdef cppclass CSRMatrix:
         CSRMatrix(int rows, int cols, int nonzeros,

--- a/implicit/gpu/matrix.pxd
+++ b/implicit/gpu/matrix.pxd
@@ -1,0 +1,18 @@
+from libcpp cimport bool
+
+cdef extern from "matrix.h" namespace "implicit::gpu" nogil:
+    cdef cppclass CSRMatrix:
+        CSRMatrix(int rows, int cols, int nonzeros,
+                  const int * indptr, const int * indices, const float * data) except +
+
+    cdef cppclass COOMatrix:
+        COOMatrix(int rows, int cols, int nonzeros,
+                  const int * row, const int * col, const float * data) except +
+
+    cdef cppclass Vector[T]:
+        Vector(int size, T * data)
+
+    cdef cppclass Matrix:
+        Matrix(int rows, int cols, float * data, bool host) except +
+        void to_host(float * output) except +
+

--- a/implicit/gpu/matrix.pxd
+++ b/implicit/gpu/matrix.pxd
@@ -15,4 +15,3 @@ cdef extern from "matrix.h" namespace "implicit::gpu" nogil:
     cdef cppclass Matrix:
         Matrix(int rows, int cols, float * data, bool host) except +
         void to_host(float * output) except +
-

--- a/implicit/gpu/utils.cuh
+++ b/implicit/gpu/utils.cuh
@@ -3,7 +3,7 @@
 #include <stdexcept>
 #include <sstream>
 
-namespace implicit {
+namespace implicit { namespace gpu {
 using std::invalid_argument;
 
 // Error Checking utilities, checks status codes from cuda calls
@@ -98,5 +98,5 @@ float dot(float a, float b, float * shared) {
     __syncthreads();
     return shared[0];
 }
-}  // namespace implicit
+}}  // namespace implicit::gpu
 #endif  // IMPLICIT_GPU_UTILS_CUH_


### PR DESCRIPTION
Rename the CUDA c++ classes  by removing the 'Cuda' / 'Cu' prefixes and move c++ classes into implicit::gpu namespace.