### PR TITLE
Add custom GPU inference code / remove cupy dependency

### DIFF
--- a/cuda_setup.py
+++ b/cuda_setup.py
@@ -34,14 +34,16 @@ def locate_cuda():
         nvcc_bin = "nvcc.exe"
 
     # first check if the CUDAHOME env variable is in use
+    nvcc = None
     if "CUDAHOME" in os.environ:
         home = os.environ["CUDAHOME"]
         nvcc = os.path.join(home, "bin", nvcc_bin)
     elif "CUDA_PATH" in os.environ:
         home = os.environ["CUDA_PATH"]
         nvcc = os.path.join(home, "bin", nvcc_bin)
-    else:
-        # otherwise, search the PATH for NVCC
+
+    # otherwise, search the PATH for NVCC
+    if not nvcc or not os.path.exists(nvcc):
         nvcc = find_in_path(nvcc_bin, os.environ["PATH"])
         if nvcc is None:
             logging.warning(
@@ -62,7 +64,7 @@ def locate_cuda():
     }
 
     post_args = [
-        "-arch=sm_50",
+        "-arch=sm_60",
         "-gencode=arch=compute_50,code=sm_50",
         "-gencode=arch=compute_52,code=sm_52",
         "-gencode=arch=compute_60,code=sm_60",
@@ -70,6 +72,7 @@ def locate_cuda():
         "-gencode=arch=compute_70,code=sm_70",
         "-gencode=arch=compute_70,code=compute_70",
         "--ptxas-options=-v",
+        "--extended-lambda",
         "-O2",
     ]
 

--- a/examples/lastfm.py
+++ b/examples/lastfm.py
@@ -52,11 +52,12 @@ def get_model(model_name):
 
     # some default params
     if model_name.endswith("als"):
-        params = {"factors": 64, "dtype": np.float32}
+        params = {"factors": 64, "dtype": np.float32, "use_gpu": True}
     elif model_name == "bm25":
         params = {"K1": 100, "B": 0.5}
     elif model_name == "bpr":
-        params = {"factors": 63}
+        params = {"factors": 63, "verify_negative_samples": False, "use_gpu": True,
+        "regularization": 0.15, "learning_rate": 0.1}
     elif model_name == "lmf":
         params = {"factors": 30, "iterations": 40, "regularization": 1.5}
     else:
@@ -121,7 +122,7 @@ def calculate_recommendations(output_filename, model_name="als"):
 
     # if we're training an ALS based model, weight input for last.fm
     # by bm25
-    if issubclass(model.__class__, AlternatingLeastSquares):
+    if model_name.endswith("als"):
         # lets weight these models by bm25weight.
         logging.debug("weighting matrix by bm25_weight")
         plays = bm25_weight(plays, K1=100, B=0.8)

--- a/examples/lastfm.py
+++ b/examples/lastfm.py
@@ -52,12 +52,11 @@ def get_model(model_name):
 
     # some default params
     if model_name.endswith("als"):
-        params = {"factors": 64, "dtype": np.float32, "use_gpu": True}
+        params = {"factors": 64, "dtype": np.float32}
     elif model_name == "bm25":
         params = {"K1": 100, "B": 0.5}
     elif model_name == "bpr":
-        params = {"factors": 63, "verify_negative_samples": False, "use_gpu": True,
-        "regularization": 0.15, "learning_rate": 0.1}
+        params = {"factors": 63}
     elif model_name == "lmf":
         params = {"factors": 30, "iterations": 40, "regularization": 1.5}
     else:

--- a/implicit/cpu/bpr.pyx
+++ b/implicit/cpu/bpr.pyx
@@ -199,7 +199,7 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
                 total = len(user_items.data)
                 if total != 0 and total != skipped:
                     progress.set_postfix(
-                        {"correct": "%.2f%%" % (100.0 * correct / (total - skipped)),
+                        {"train_auc": "%.2f%%" % (100.0 * correct / (total - skipped)),
                          "skipped": "%.2f%%" % (100.0 * skipped / total)})
 
         self._check_fit_errors()

--- a/implicit/datasets/lastfm.py
+++ b/implicit/datasets/lastfm.py
@@ -28,6 +28,7 @@ def get_lastfm():
     with h5py.File(filename, "r") as f:
         m = f.get("artist_user_plays")
         plays = csr_matrix((m.get("data"), m.get("indices"), m.get("indptr")))
+        print(f["artist"].__class__)
         return np.array(f["artist"]), np.array(f["user"]), plays
 
 

--- a/implicit/datasets/lastfm.py
+++ b/implicit/datasets/lastfm.py
@@ -28,7 +28,6 @@ def get_lastfm():
     with h5py.File(filename, "r") as f:
         m = f.get("artist_user_plays")
         plays = csr_matrix((m.get("data"), m.get("indices"), m.get("indptr")))
-        print(f["artist"].__class__)
         return np.array(f["artist"]), np.array(f["user"]), plays
 
 

--- a/implicit/gpu/__init__.py
+++ b/implicit/gpu/__init__.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import
 
 try:
-    import cupy  # noqa
-
     from ._cuda import *  # noqa
 
     HAS_CUDA = True
 except ImportError:
     HAS_CUDA = False
+    raise

--- a/implicit/gpu/__init__.py
+++ b/implicit/gpu/__init__.py
@@ -6,4 +6,3 @@ try:
     HAS_CUDA = True
 except ImportError:
     HAS_CUDA = False
-    raise

--- a/implicit/gpu/_cuda.pyx
+++ b/implicit/gpu/_cuda.pyx
@@ -1,25 +1,84 @@
 """ Various thin cython wrappers on top of CUDA functions """
+
 import cython
 import numpy as np
 from cython.operator import dereference
+from cython cimport view
 
 from libcpp cimport bool
-from libcpp.utility cimport pair
+from libcpp.utility cimport move, pair
 
 from .als cimport LeastSquaresSolver as CppLeastSquaresSolver
 from .bpr cimport bpr_update as cpp_bpr_update
-from .matrix cimport COOMatrix as CppCOOMatrix
-from .matrix cimport CSRMatrix as CppCSRMatrix
-from .matrix cimport Matrix as CppMatrix
-from .matrix cimport Vector as CppVector
+from .matrix cimport CSRMatrix as CppCSRMatrix, COOMatrix as CppCOOMatrix
+from .matrix cimport Matrix as CppMatrix, Vector as CppVector
+from .matrix cimport calculate_norms as cpp_calculate_norms
+from .knn cimport KnnQuery as CppKnnQuery
+from .random cimport RandomState as CppRandomState
+
+
+cdef class RandomState(object):
+    cdef CppRandomState * c_random
+
+    def __cinit__(self, long seed=42):
+        self.c_random = new CppRandomState(seed)
+
+    def uniform(self, rows, cols, float low=0, float high=1.0):
+        ret = Matrix(None)
+        ret.c_matrix = new CppMatrix(self.c_random.uniform(rows, cols, low, high))
+        return ret
+
+    def randn(self, rows, cols, float mean=0, float stddev=1):
+        ret = Matrix(None)
+        ret.c_matrix = new CppMatrix(self.c_random.randn(rows, cols, mean, stddev))
+        return ret
+
+    def __dealloc__(self):
+        del self.c_random
+
+
+cdef class KnnQuery(object):
+    cdef CppKnnQuery * c_knn
+
+    def __cinit__(self, size_t max_temp_memory=500_000_000):
+        self.c_knn = new CppKnnQuery(max_temp_memory)
+
+    def __dealloc__(self):
+        del self.c_knn
+
+    def topk(self, Matrix items, Matrix m, int k, Matrix item_norms=None):
+        cdef CppMatrix * queries = m.c_matrix
+        cdef int rows = queries.rows
+        cdef int[:, :] x
+        cdef float[:, :] y
+
+        cdef float * c_item_norms = NULL
+        if item_norms:
+            c_item_norms = item_norms.c_matrix.data
+
+        indices = np.zeros((rows, k), dtype="int32")
+        distances = np.zeros((rows, k), dtype="float32")
+        x = indices
+        y = distances
+
+        self.c_knn.topk(dereference(items.c_matrix), dereference(queries), k,
+                        &x[0, 0], &y[0, 0], c_item_norms)
+
+        return indices, distances
 
 
 cdef class Matrix(object):
     cdef CppMatrix * c_matrix
 
     def __cinit__(self, X):
+        if X is None:
+            self.c_matrix = NULL
+            return
+
         cdef float[:, :] c_X
         cdef long data
+
+        # see if the input support CAI (cupy/pytorch/cudf etc)
         cai = getattr(X, "__cuda_array_interface__", None)
         if cai:
             shape = cai["shape"]
@@ -30,11 +89,59 @@ cdef class Matrix(object):
             c_X = X
             self.c_matrix = new CppMatrix(X.shape[0], X.shape[1], &c_X[0, 0], True)
 
-    def to_host(self, float[:, :] X):
-        self.c_matrix.to_host(&X[0, 0])
+    @property
+    def shape(self):
+        return self.c_matrix.rows, self.c_matrix.cols
+
+    def __getitem__(self, idx):
+        cdef int i
+        cdef IntVector ids
+        ret = Matrix(None)
+        if isinstance(idx, slice):
+            if idx.step and idx.step != 1:
+                raise ValueError(f"Can't slice matrix with step {idx.step} yet")
+
+            start = idx.start if idx.start is not None else 0
+            stop = idx.stop if idx.stop is not None else self.c_matrix.rows
+            ret.c_matrix = new CppMatrix(dereference(self.c_matrix), start, stop)
+
+        elif isinstance(idx, int):
+            i = idx
+            ret.c_matrix = new CppMatrix(dereference(self.c_matrix), i)
+
+        else:
+            try:
+                idx = np.array(idx).astype("int32")
+            except Exception:
+                raise ValueError(f"don't know how to handle __getitem__ on {idx}")
+
+            if len(idx.shape) != 1:
+                raise ValueError(f"don't know how to handle __getitem__ on {idx}")
+
+            if ((idx < 0) | (idx >= self.c_matrix.rows)).any():
+                raise ValueError(f"row id out of range for selecting items from matrix")
+
+            ids = IntVector(idx)
+            ret.c_matrix = new CppMatrix(dereference(self.c_matrix), dereference(ids.c_vector))
+
+        return ret
+
+    def to_numpy(self):
+        ret = np.zeros((self.c_matrix.rows, self.c_matrix.cols), dtype="float32")
+        cdef float[:, :] temp = ret
+        self.c_matrix.to_host(&temp[0, 0])
+        return ret
+
+    def __repr__(self):
+        return f"Matrix({str(self.to_numpy())})"
+
+    def __str__(self):
+        return str(self.to_numpy())
 
     def __dealloc__(self):
-        del self.c_matrix
+        if self.c_matrix is not NULL:
+            del self.c_matrix
+
 
 cdef class IntVector(object):
     cdef CppVector[int] * c_vector
@@ -92,6 +199,12 @@ cdef class LeastSquaresSolver(object):
 
     def __dealloc__(self):
         del self.c_solver
+
+
+def calculate_norms(Matrix items):
+    ret = Matrix(None)
+    ret.c_matrix = new CppMatrix(cpp_calculate_norms(dereference(items.c_matrix)))
+    return ret
 
 
 def bpr_update(IntVector userids, IntVector itemids, IntVector indptr,

--- a/implicit/gpu/_cuda.pyx
+++ b/implicit/gpu/_cuda.pyx
@@ -3,17 +3,19 @@
 import cython
 import numpy as np
 from cython.operator import dereference
-from cython cimport view
 
+from cython cimport view
 from libcpp cimport bool
 from libcpp.utility cimport move, pair
 
 from .als cimport LeastSquaresSolver as CppLeastSquaresSolver
 from .bpr cimport bpr_update as cpp_bpr_update
-from .matrix cimport CSRMatrix as CppCSRMatrix, COOMatrix as CppCOOMatrix
-from .matrix cimport Matrix as CppMatrix, Vector as CppVector
-from .matrix cimport calculate_norms as cpp_calculate_norms
 from .knn cimport KnnQuery as CppKnnQuery
+from .matrix cimport COOMatrix as CppCOOMatrix
+from .matrix cimport CSRMatrix as CppCSRMatrix
+from .matrix cimport Matrix as CppMatrix
+from .matrix cimport Vector as CppVector
+from .matrix cimport calculate_norms as cpp_calculate_norms
 from .random cimport RandomState as CppRandomState
 
 

--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -1,11 +1,6 @@
 import logging
 import time
 
-try:
-    import cupy as cp
-except ImportError:
-    pass
-
 import numpy as np
 import scipy
 import scipy.sparse
@@ -121,11 +116,13 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
 
         # Initialize the variables randomly if they haven't already been set
         if self.user_factors is None:
-            self.user_factors = random_state.rand(users, self.factors, dtype=cp.float32) - 0.5
-            self.user_factors /= self.factors
+            self.user_factors = random_state.uniform(
+                users, self.factors, low=-0.5 / self.factors, high=0.5 / self.factors
+            )
         if self.item_factors is None:
-            self.item_factors = random_state.rand(items, self.factors, dtype=cp.float32) - 0.5
-            self.item_factors /= self.factors
+            self.item_factors = random_state.uniform(
+                items, self.factors, low=-0.5 / self.factors, high=0.5 / self.factors
+            )
 
         log.debug("Initialized factors in %s", time.time() - s)
 
@@ -134,8 +131,8 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
 
         Ciu = implicit.gpu.CSRMatrix(Ciu)
         Cui = implicit.gpu.CSRMatrix(Cui)
-        X = implicit.gpu.Matrix(self.user_factors)
-        Y = implicit.gpu.Matrix(self.item_factors)
+        X = self.user_factors
+        Y = self.item_factors
 
         solver = implicit.gpu.LeastSquaresSolver(self.factors)
         log.debug("Running %i ALS iterations", self.iterations)

--- a/implicit/gpu/bpr.cu
+++ b/implicit/gpu/bpr.cu
@@ -87,15 +87,6 @@ __global__ void bpr_update_kernel(int samples, unsigned int * random_likes, unsi
     }
 }
 
-#define CHECK_CURAND(code) { checkCurand((code), __FILE__, __LINE__); }
-inline void checkCurand(curandStatus_t code, const char *file, int line) {
-    if (code != CURAND_STATUS_SUCCESS) {
-        std::stringstream err;
-        err << "CURAND error: " << code << " (" << file << ":" << line << ")";
-        throw std::runtime_error(err.str());
-    }
-}
-
 std::pair<int, int> bpr_update(const Vector<int> & userids,
                                const Vector<int> & itemids,
                                const Vector<int> & indptr,

--- a/implicit/gpu/bpr.py
+++ b/implicit/gpu/bpr.py
@@ -5,9 +5,8 @@ from tqdm.auto import tqdm
 
 import implicit.gpu
 
-from .matrix_factorization_base import MatrixFactorizationBase
-
 from ..utils import check_random_state
+from .matrix_factorization_base import MatrixFactorizationBase
 
 log = logging.getLogger("implicit")
 

--- a/implicit/gpu/bpr.py
+++ b/implicit/gpu/bpr.py
@@ -1,15 +1,13 @@
 import logging
 
-try:
-    import cupy as cp
-except ImportError:
-    pass
 import numpy as np
 from tqdm.auto import tqdm
 
 import implicit.gpu
 
-from .matrix_factorization_base import MatrixFactorizationBase, check_random_state
+from .matrix_factorization_base import MatrixFactorizationBase
+
+from ..utils import check_random_state
 
 log = logging.getLogger("implicit")
 
@@ -105,21 +103,23 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
         # Note: the final dimension is for the item bias term - which is set to a 1 for all users
         # this simplifies interfacing with approximate nearest neighbours libraries etc
         if self.item_factors is None:
-            self.item_factors = rs.rand(items, self.factors + 1, dtype=cp.float32) - 0.5
-            self.item_factors /= self.factors
+            item_factors = rs.rand(items, self.factors + 1).astype("float32") - 0.5
+            item_factors /= self.factors
 
             # set factors to all zeros for items without any ratings
             item_counts = np.bincount(user_items.indices, minlength=items)
-            self.item_factors[item_counts == 0] = cp.zeros(self.factors + 1)
+            item_factors[item_counts == 0] = np.zeros(self.factors + 1)
+            self.item_factors = implicit.gpu.Matrix(item_factors)
 
         if self.user_factors is None:
-            self.user_factors = rs.rand(users, self.factors + 1, dtype=cp.float32) - 0.5
-            self.user_factors /= self.factors
+            user_factors = rs.rand(users, self.factors + 1).astype("float32") - 0.5
+            user_factors /= self.factors
 
             # set factors to all zeros for users without any ratings
-            self.user_factors[user_counts == 0] = cp.zeros(self.factors + 1)
+            user_factors[user_counts == 0] = np.zeros(self.factors + 1)
+            user_factors[:, self.factors] = 1.0
 
-            self.user_factors[:, self.factors] = 1.0
+            self.user_factors = implicit.gpu.Matrix(user_factors)
 
         self._item_norms = self._user_norms = None
 
@@ -127,8 +127,8 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
         itemids = implicit.gpu.IntVector(user_items.indices)
         indptr = implicit.gpu.IntVector(user_items.indptr)
 
-        X = implicit.gpu.Matrix(self.user_factors)
-        Y = implicit.gpu.Matrix(self.item_factors)
+        X = self.user_factors
+        Y = self.item_factors
 
         log.debug("Running %i BPR training epochs", self.iterations)
         with tqdm(total=self.iterations, disable=not show_progress) as progress:
@@ -149,7 +149,7 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
                 if total != 0 and total != skipped:
                     progress.set_postfix(
                         {
-                            "correct": "%.2f%%" % (100.0 * correct / (total - skipped)),
+                            "train_auc": "%.2f%%" % (100.0 * correct / (total - skipped)),
                             "skipped": "%.2f%%" % (100.0 * skipped / total),
                         }
                     )

--- a/implicit/gpu/device_buffer.cu
+++ b/implicit/gpu/device_buffer.cu
@@ -1,0 +1,36 @@
+#include <cuda_runtime.h>
+#include <iostream>
+
+#include "implicit/gpu/utils.cuh"
+#include "implicit/gpu/device_buffer.h"
+
+namespace implicit { namespace gpu {
+
+template <typename T>
+DeviceBuffer<T>::DeviceBuffer(size_t size) : size_(size) {
+    // TODO: support custom allocators (rmm etc) ?
+    CHECK_CUDA(cudaMalloc(&data, size * sizeof(T)));
+}
+
+template <typename T>
+DeviceBuffer<T>::~DeviceBuffer() {
+    auto err = cudaFree(data);
+    if (err != cudaSuccess) {
+        std::cerr << "Failed to call cudaFree in ~DeviceBuffer:" << cudaGetErrorString(err) << std::endl;
+    }
+}
+
+template <typename T>
+DeviceBuffer<T>::DeviceBuffer(DeviceBuffer<T> && other) {
+    if (this != &other) {
+        data = other.data;
+        size_ = other.size_;
+        other.data = NULL;
+        other.size_ = 0;
+    }
+}
+
+template struct DeviceBuffer<int>;
+template struct DeviceBuffer<float>;
+template struct DeviceBuffer<char>;
+}}  // namespace implicit::gpu

--- a/implicit/gpu/device_buffer.h
+++ b/implicit/gpu/device_buffer.h
@@ -1,0 +1,27 @@
+#ifndef IMPLICIT_GPU_DEVICE_BUFFER_H_
+#define IMPLICIT_GPU_DEVICE_BUFFER_H_
+
+namespace implicit { namespace gpu {
+
+template <typename T>
+class DeviceBuffer {
+public:
+    explicit DeviceBuffer(size_t size);
+    DeviceBuffer(size_t size, const T * elements);
+    ~DeviceBuffer();
+
+    const T * get() const { return data; }
+    T * get() { return data; }
+    size_t size() const { return size_; }
+
+    DeviceBuffer(DeviceBuffer<T> && other);
+
+    DeviceBuffer(const DeviceBuffer<T> &) = delete;
+    DeviceBuffer<T> & operator=(const DeviceBuffer<T> &) = delete;
+
+protected:
+    size_t size_;
+    T * data;
+};
+}}  // namespace implicit/gpu
+#endif  // IMPLICIT_GPU_DEVICE_BUFFER_H_

--- a/implicit/gpu/knn.cu
+++ b/implicit/gpu/knn.cu
@@ -1,0 +1,250 @@
+#include <vector>
+#include <cuda_runtime.h>
+#include <cublas_v2.h>
+
+#include <thrust/transform.h>
+#include <thrust/functional.h>
+#include <thrust/device_ptr.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+
+#include <cub/iterator/counting_input_iterator.cuh>
+#include <cub/iterator/transform_input_iterator.cuh>
+#include <cub/device/device_segmented_radix_sort.cuh>
+#include <cub/device/device_radix_sort.cuh>
+
+#include "implicit/gpu/utils.cuh"
+#include "implicit/gpu/knn.h"
+#include "implicit/gpu/device_buffer.h"
+
+namespace implicit { namespace gpu {
+
+bool is_host_memory(void * address) {
+    cudaPointerAttributes attr;
+    auto err = cudaPointerGetAttributes(&attr, address);
+    if (err == cudaErrorInvalidValue) {
+        return true;
+    }
+
+#if __CUDACC_VER_MAJOR__ >= 10
+    return attr.type == cudaMemoryTypeHost || attr.type == cudaMemoryTypeUnregistered;
+#else
+    return attr.memoryType == cudaMemoryTypeHost || attr.memoryType == cudaMemoryTypeUnregistered;
+#endif
+}
+
+
+class StackAllocator {
+public:
+    StackAllocator(size_t bytes) : memory(bytes), allocated(0) {}
+    void * allocate(size_t bytes) {
+        size_t padding = bytes % 128;
+        if (padding) {
+            bytes += 128 - padding;
+        }
+        if (allocated + bytes >= memory.size()) {
+            throw std::invalid_argument("stack allocator: out of memory");
+        }
+        allocations.push_back(bytes);
+        void * ret = memory.get() + allocated;
+        allocated += bytes;
+        return ret;
+    }
+
+    void deallocate(void * ptr) {
+        size_t bytes = allocations.back();
+        if (ptr != memory.get() + allocated - bytes) {
+            throw std::invalid_argument("stack allocator: free called out of order");
+        }
+        allocations.pop_back();
+        allocated -= bytes;
+    }
+
+protected:
+    std::vector<size_t> allocations;
+    DeviceBuffer<char> memory;
+    size_t allocated;
+};
+
+template <typename T>
+void copy_columns(const T * input, int rows, int cols, T * output, int output_cols) {
+    auto count = thrust::make_counting_iterator<int>(0);
+    thrust::for_each(count, count + (rows * output_cols),
+       [=] __device__(int i) {
+         int col = i % output_cols;
+         int row = i / output_cols;
+         output[col + row * output_cols] = input[col + row * cols];
+    });
+}
+
+KnnQuery::KnnQuery(size_t temp_memory)
+    : max_temp_memory(temp_memory),
+    alloc(new StackAllocator(temp_memory)) {
+    CHECK_CUBLAS(cublasCreate(&blas_handle));
+}
+
+void KnnQuery::topk(const Matrix & items, const Matrix & query, int k,
+                    int * indices, float * distances, float * item_norms) {
+    if (query.cols != items.cols) {
+        throw std::invalid_argument("Must have same number of columns in each matrix for topk");
+    }
+
+    size_t available_temp_memory = max_temp_memory;
+
+    float * host_distances = NULL;
+    size_t distances_size = query.rows * k * sizeof(float);
+    if (is_host_memory(distances)) {
+        host_distances = distances;
+        distances = reinterpret_cast<float *>(alloc->allocate(distances_size));
+        available_temp_memory -= distances_size;
+    }
+
+    int * host_indices = NULL;
+    size_t indices_size = query.rows * k * sizeof(int);
+    if (is_host_memory(indices)) {
+        host_indices = indices;
+        indices = reinterpret_cast<int *>(alloc->allocate(indices_size));
+        available_temp_memory -= indices_size;
+    }
+
+    // We need 6 copies of the matrix for argsort code - and then some
+    // extra memory per SM as well.
+    int batch_size = 0.15 * available_temp_memory / (sizeof(float) * items.rows);
+    batch_size = std::min(batch_size, query.rows);
+    batch_size = std::max(batch_size, 1);
+
+    // Create temporary memory for storing results
+    void * temp_mem = alloc->allocate(batch_size * items.rows * sizeof(float));
+    Matrix temp_distances(batch_size, items.rows, reinterpret_cast<float *>(temp_mem), false);
+
+    for (int start = 0; start < query.rows; start += batch_size) {
+        auto end = std::min(query.rows, start + batch_size);
+
+        Matrix batch(query, start, end);
+        temp_distances.rows = batch.rows;
+
+        // matrix multiple the items by the batch, store in distances
+        float alpha = 1.0, beta = 0.;
+
+        CHECK_CUBLAS(cublasSgemm(blas_handle, CUBLAS_OP_T, CUBLAS_OP_N,
+                                 items.rows, batch.rows, items.cols,
+                                 &alpha,
+                                 items.data, items.cols,
+                                 batch.data, batch.cols,
+                                 &beta,
+                                 temp_distances.data, temp_distances.cols));
+
+        // If we have norms (cosine distance etc) normalize the results here
+        if (item_norms != NULL) {
+            auto count = thrust::make_counting_iterator<int>(0);
+            int cols = temp_distances.cols;
+            float * data = temp_distances.data;
+            thrust::for_each(count, count + (temp_distances.rows * temp_distances.cols),
+               [=] __device__(int i) {
+                 data[i] /= item_norms[i % cols];
+            });
+        }
+
+        argpartition(temp_distances, k, indices + start * k, distances + start * k);
+
+        // TODO: callback per batch (show progress etc)
+    }
+    alloc->deallocate(temp_mem);
+
+    if (host_indices) {
+        CHECK_CUDA(cudaMemcpy(host_indices, indices, indices_size, cudaMemcpyDeviceToHost));
+        alloc->deallocate(indices);
+    }
+
+    if (host_distances) {
+        CHECK_CUDA(cudaMemcpy(host_distances, distances, distances_size, cudaMemcpyDeviceToHost));
+        alloc->deallocate(distances);
+    }
+}
+
+void KnnQuery::argpartition(const Matrix & items, int k, int * indices, float * distances) {
+    k = std::min(k, items.cols);
+
+    int * temp_indices = reinterpret_cast<int *>(alloc->allocate(items.rows * items.cols * sizeof(int)));
+    float * temp_distances = reinterpret_cast<float *>(alloc->allocate(items.rows * items.cols * sizeof(float)));
+    argsort(items, temp_indices, temp_distances);
+    copy_columns(temp_distances, items.rows, items.cols, distances, k);
+    copy_columns(temp_indices, items.rows, items.cols, indices, k);
+    alloc->deallocate(temp_distances);
+    alloc->deallocate(temp_indices);
+}
+
+void KnnQuery::argsort(const Matrix & items, int * indices, float * distances) {
+    // We can't do this in place https://github.com/NVIDIA/cub/issues/238 ?
+    // so generate temp memory for this
+    auto temp_indices = reinterpret_cast<int *>(alloc->allocate(items.rows * items.cols * sizeof(int)));
+
+    thrust::transform(
+        thrust::make_counting_iterator<int>(0),
+        thrust::make_counting_iterator<int>(items.rows * items.cols),
+        thrust::make_constant_iterator<int>(items.cols),
+        thrust::device_pointer_cast(temp_indices),
+        thrust::modulus<int>());
+
+    auto segment_offsets = thrust::make_transform_iterator(thrust::make_counting_iterator<int>(0),
+                                                           thrust::placeholders::_1 *= items.cols);
+
+    void * temp_mem = NULL;
+
+    // sort the values.
+    if (items.rows > 1) {
+        size_t temp_size = 0;
+        auto err = cub::DeviceSegmentedRadixSort::SortPairsDescending(NULL,
+            temp_size,
+            items.data,
+            distances,
+            temp_indices,
+            indices,
+            items.rows * items.cols,
+            items.rows,
+            segment_offsets,
+            segment_offsets + 1);
+        CHECK_CUDA(err);
+        temp_mem = alloc->allocate(temp_size);
+        err = cub::DeviceSegmentedRadixSort::SortPairsDescending(temp_mem,
+            temp_size,
+            items.data,
+            distances,
+            temp_indices,
+            indices,
+            items.rows * items.cols,
+            items.rows,
+            segment_offsets,
+            segment_offsets + 1);
+        CHECK_CUDA(err);
+    } else {
+        size_t temp_size = 0;
+        auto err = cub::DeviceRadixSort::SortPairsDescending(NULL,
+            temp_size,
+            items.data,
+            distances,
+            temp_indices,
+            indices,
+            items.cols);
+        CHECK_CUDA(err);
+        temp_mem = alloc->allocate(temp_size);
+        err = cub::DeviceRadixSort::SortPairsDescending(temp_mem,
+            temp_size,
+            items.data,
+            distances,
+            temp_indices,
+            indices,
+            items.cols);
+        CHECK_CUDA(err);
+    }
+    alloc->deallocate(temp_mem);
+    alloc->deallocate(temp_indices);
+}
+
+KnnQuery::~KnnQuery() {
+    // TODO: don't check this, there isn't anything we can do here anyways
+    CHECK_CUBLAS(cublasDestroy(blas_handle));
+}
+
+}}  // namespace implicit::gpu

--- a/implicit/gpu/knn.h
+++ b/implicit/gpu/knn.h
@@ -1,0 +1,30 @@
+#ifndef IMPLICIT_GPU_KNN_H_
+#define IMPLICIT_GPU_KNN_H_
+#include <memory>
+
+#include "implicit/gpu/matrix.h"
+
+struct cublasContext;
+
+namespace implicit { namespace gpu {
+struct StackAllocator;
+
+class KnnQuery {
+public:
+    KnnQuery(size_t temp_memory=500000000);
+    ~KnnQuery();
+    cublasContext * blas_handle;
+
+    void topk(const Matrix & items, const Matrix & query, int k,
+              int * indices, float * distances,
+              float * item_norms = NULL);
+
+protected:
+    void argpartition(const Matrix & items, int k, int * indices, float * distances);
+    void argsort(const Matrix & items, int * indices, float * distances);
+
+    size_t max_temp_memory;
+    std::unique_ptr<StackAllocator> alloc;
+};
+}}  // namespace implicit/gpu
+#endif  // IMPLICIT_GPU_KNN_H_

--- a/implicit/gpu/knn.h
+++ b/implicit/gpu/knn.h
@@ -11,7 +11,7 @@ struct StackAllocator;
 
 class KnnQuery {
 public:
-    KnnQuery(size_t temp_memory=500000000);
+    KnnQuery(size_t temp_memory=512000000);
     ~KnnQuery();
     cublasContext * blas_handle;
 

--- a/implicit/gpu/knn.pxd
+++ b/implicit/gpu/knn.pxd
@@ -1,0 +1,9 @@
+from .matrix cimport Matrix
+
+
+cdef extern from "knn.h" namespace "implicit::gpu" nogil:
+    cdef cppclass KnnQuery:
+        KnnQuery(size_t max_temp_memory) except +
+
+        void topk(const Matrix & items, const Matrix & query, int k,
+                  int * indices, float * distances, float * item_norms) except +

--- a/implicit/gpu/matrix.cu
+++ b/implicit/gpu/matrix.cu
@@ -1,55 +1,118 @@
-
 #include <cuda_runtime.h>
-#include "cublas_v2.h"
+#include <thrust/transform.h>
+#include <thrust/functional.h>
+#include <thrust/iterator/counting_iterator.h>
+
 
 #include "implicit/gpu/matrix.h"
 #include "implicit/gpu/utils.cuh"
 
 namespace implicit { namespace gpu {
+// TODO: this class doesn't seem to offer much on top of devicebuffer itself
 template <typename T>
 Vector<T>::Vector(int size, const T * host_data)
-    : size(size) {
-    CHECK_CUDA(cudaMalloc(&data, size * sizeof(T)));
+    : size(size), storage(new DeviceBuffer<T>(size)), data(storage->get()) {
     if (host_data) {
         CHECK_CUDA(cudaMemcpy(data, host_data, size * sizeof(T), cudaMemcpyHostToDevice));
     }
 }
 
-
 template <typename T>
-Vector<T>::~Vector() {
-    CHECK_CUDA(cudaFree(data));
+void Vector<T>::to_host(T * out) const {
+    CHECK_CUDA(cudaMemcpy(out, data, size * sizeof(T), cudaMemcpyDeviceToHost));
 }
 
+template struct Vector<char>;
 template struct Vector<int>;
 template struct Vector<float>;
 
-Matrix::Matrix(int rows, int cols, float * host_data, bool cpu)
+Matrix::Matrix(const Matrix & other, int rowid)
+    : rows(1), cols(other.cols), data(other.data + rowid * other.cols), storage(other.storage) {
+    if (rowid >= other.rows) {
+        throw std::invalid_argument("row index out of bounds for matrix");
+    }
+}
+
+Matrix::Matrix(const Matrix & other, int start_rowid, int end_rowid)
+    : rows(end_rowid - start_rowid), cols(other.cols), data(other.data + start_rowid * other.cols), storage(other.storage) {
+    if (end_rowid < start_rowid) {
+        throw std::invalid_argument("end_rowid < start_rowid for matrix slice");
+    }
+    if (end_rowid > other.rows) {
+        throw std::invalid_argument("row index out of bounds for matrix");
+    }
+}
+
+void copy_rowids(const float * input, const int * rowids, int rows, int cols, float * output) {
+    // copy rows over
+    auto count = thrust::make_counting_iterator<int>(0);
+    thrust::for_each(count, count + (rows * cols),
+        [=] __device__(int i) {
+            int col = i % cols;
+            int row = rowids[i / cols];
+            output[i] = input[col + row * cols];
+        });
+}
+
+Matrix::Matrix(const Matrix & other, const Vector<int> & rowids)
+    : rows(rowids.size), cols(other.cols) {
+    storage.reset(new DeviceBuffer<float>(rows * cols));
+    data = storage->get();
+    copy_rowids(other.data, rowids.data, rows, cols, data);
+}
+
+Matrix::Matrix(int rows, int cols, float * host_data, bool allocate)
     : rows(rows), cols(cols) {
-    if (cpu) {
-        CHECK_CUDA(cudaMalloc(&data, rows * cols * sizeof(float)));
+    if (allocate) {
+        storage.reset(new DeviceBuffer<float>(rows * cols));
+        data = storage->get();
         if (host_data) {
             CHECK_CUDA(cudaMemcpy(data, host_data, rows * cols * sizeof(float), cudaMemcpyHostToDevice));
         }
-        owns_data = true;
     } else {
         data = host_data;
-        owns_data = false;
     }
+}
+
+__global__ void calculate_norms_kernel(const float * input, int rows, int cols, float * output) {
+    static __shared__ float shared[32];
+    for (int i = blockIdx.x; i < rows; i += gridDim.x) {
+        float value = input[i * cols + threadIdx.x];
+	float squared_norm = dot(value, value, shared);
+	if (threadIdx.x == 0) {
+            output[i] = sqrt(squared_norm);
+            if (output[i] == 0) {
+                output[i] = 1e-10;
+            }
+	}
+    }
+}
+
+Matrix calculate_norms(const Matrix & input) {
+    int devId;
+    CHECK_CUDA(cudaGetDevice(&devId));
+
+    int multiprocessor_count;
+    CHECK_CUDA(cudaDeviceGetAttribute(&multiprocessor_count,
+                                      cudaDevAttrMultiProcessorCount,
+                                      devId));
+
+    int block_count = 256 * multiprocessor_count;
+    int thread_count = input.cols;
+
+    Matrix output(1, input.rows, NULL);
+    calculate_norms_kernel<<<block_count, thread_count>>>(input.data, input.rows, input.cols, output.data);
+
+    CHECK_CUDA(cudaDeviceSynchronize());
+    return output;
 }
 
 void Matrix::to_host(float * out) const {
     CHECK_CUDA(cudaMemcpy(out, data, rows * cols * sizeof(float), cudaMemcpyDeviceToHost));
 }
 
-Matrix::~Matrix() {
-    if (owns_data) {
-        CHECK_CUDA(cudaFree(data));
-    }
-}
-
 CSRMatrix::CSRMatrix(int rows, int cols, int nonzeros,
-                             const int * indptr_, const int * indices_, const float * data_)
+                     const int * indptr_, const int * indices_, const float * data_)
     : rows(rows), cols(cols), nonzeros(nonzeros) {
 
     CHECK_CUDA(cudaMalloc(&indptr, (rows + 1) * sizeof(int)));
@@ -69,7 +132,7 @@ CSRMatrix::~CSRMatrix() {
 }
 
 COOMatrix::COOMatrix(int rows, int cols, int nonzeros,
-                             const int * row_, const int * col_, const float * data_)
+                     const int * row_, const int * col_, const float * data_)
     : rows(rows), cols(cols), nonzeros(nonzeros) {
 
     CHECK_CUDA(cudaMalloc(&row, nonzeros * sizeof(int)));

--- a/implicit/gpu/matrix.h
+++ b/implicit/gpu/matrix.h
@@ -1,16 +1,49 @@
 #ifndef IMPLICIT_GPU_MATRIX_H_
 #define IMPLICIT_GPU_MATRIX_H_
+#include <memory>
+
+#include "implicit/gpu/device_buffer.h"
 
 namespace implicit { namespace gpu {
-/// Thin wrappers of CUDA memory: copies to from host, frees in destructor
+// Thin wrappers of CUDA memory: copies to from host, frees in destructor etc
 template <typename T>
 struct Vector {
-    Vector(int size, const T * elements = NULL);
-    ~Vector();
+    Vector(int size, const T * data = NULL);
+    void to_host(T * output) const;
 
+    std::shared_ptr<DeviceBuffer<T> > storage;
     int size;
     T * data;
 };
+
+struct Matrix {
+    // Create a new matrix of shape (rows, cols) - copying from `data to the device
+    // (if allocate=True and data != null). If allocate=false, this assumes the data is
+    // preallocated on the gpu (cupy etc) and doesn't allocate any new storage
+    Matrix(int rows, int cols, float * data=NULL, bool allocate=true);
+
+    // Create a new Matrix by slicing a single row from an existing one. The underlying
+    // storage buffer is shared in this case.
+    Matrix(const Matrix & other, int rowid);
+
+    // Slice a contiguous series of rows from this Matrix. The underlying storge buffer
+    // is shared here.
+    Matrix(const Matrix & other, int start_rowid, int end_rowid);
+
+    // select a bunch of rows from this matrix. this creates a copy
+    Matrix(const Matrix & other, const Vector<int> & rowids);
+
+    Matrix() : rows(0), cols(0), data(NULL) {}
+
+    // Copy the Matrix to host memory.
+    void to_host(float * output) const;
+
+    int rows, cols;
+    float * data;
+    std::shared_ptr<DeviceBuffer<float> > storage;
+};
+
+Matrix calculate_norms(const Matrix & input);
 
 struct CSRMatrix {
     CSRMatrix(int rows, int cols, int nonzeros,
@@ -30,15 +63,5 @@ struct COOMatrix {
     int rows, cols, nonzeros;
 };
 
-struct Matrix {
-    Matrix(int rows, int cols, float * data, bool host=true);
-    ~Matrix();
-
-    void to_host(float * output) const;
-
-    int rows, cols;
-    float * data;
-    bool owns_data;
-};
 }}  // namespace implicit/gpu
 #endif  // IMPLICIT_GPU_MATRIX_H_

--- a/implicit/gpu/matrix.pxd
+++ b/implicit/gpu/matrix.pxd
@@ -11,8 +11,26 @@ cdef extern from "matrix.h" namespace "implicit::gpu" nogil:
                   const int * row, const int * col, const float * data) except +
 
     cdef cppclass Vector[T]:
-        Vector(int size, T * data)
+        Vector(int size, T * data) except +
+        void to_host(T * output) except +
+        T * data
+        int size
 
     cdef cppclass Matrix:
         Matrix(int rows, int cols, float * data, bool host) except +
+        Matrix(const Matrix & other, int rowid) except +
+        Matrix(const Matrix & other, int start, int end) except +
+        Matrix(const Matrix & other, const Vector[int] & rowids) except +
+        Matrix(Matrix && other) except +
         void to_host(float * output) except +
+        int rows, cols
+        float * data
+
+    Matrix calculate_norms(const Matrix & items) except +
+
+    cdef cppclass KnnQuery:
+        KnnQuery()
+        void query(const Matrix & items, const Matrix & queries, int k,
+                   int * indices, float * distances) except +
+        void argpartition(const Matrix & items, int k, int * indices, float * distances) except +
+        void argsort(Matrix * items, int * indices) except +

--- a/implicit/gpu/matrix_factorization_base.py
+++ b/implicit/gpu/matrix_factorization_base.py
@@ -1,26 +1,22 @@
-try:
-    import cupy as cp
-except ImportError:
-    pass
-
 import itertools
+import time
 
 import numpy as np
 
 from ..recommender_base import RecommenderBase
+from . import _cuda
 
 
 class MatrixFactorizationBase(RecommenderBase):
     """Base class for MF models running on the GPU.
 
     This adds support for inference to run on the GPU as well as training.
-    Factors are stored as cupy arrays.
 
     Attributes
     ----------
-    item_factors : cupy.array
+    item_factors : _cuda.Matrix
         Array of latent factors for each item in the training set
-    user_factors : cupy.array
+    user_factors : _cuda.Matrix
         Array of latent factors for each user in the training set
     """
 
@@ -29,6 +25,7 @@ class MatrixFactorizationBase(RecommenderBase):
         self.user_factors = None
         self._item_norms = None
         self._user_norms = None
+        self._knn = _cuda.KnnQuery()
 
     def recommend(
         self,
@@ -41,26 +38,19 @@ class MatrixFactorizationBase(RecommenderBase):
     ):
         if recalculate_user:
             raise NotImplementedError("recalculate_user isn't support on GPU yet")
-
-        user = self.user_factors[userid]
-
         liked = set()
         if filter_already_liked_items:
             liked.update(user_items[userid].indices)
         if filter_items:
             liked.update(filter_items)
+        count = N + len(liked)
 
         # calculate the top N items, removing the users own liked items from the results
-        scores = self.item_factors.dot(user)
-
-        count = N + len(liked)
-        if count < len(scores):
-            ids = cp.argpartition(scores, -count)[-count:]
-            best = sorted(zip(ids.tolist(), scores[ids].tolist()), key=lambda x: -x[1])
-        else:
-            best = sorted(enumerate(scores.tolist()), key=lambda x: -x[1])
-
-        return list(itertools.islice((rec for rec in best if rec[0] not in liked), N))
+        # TODO: own like filtering (direct in topk class
+        ids, scores = self._knn.topk(self.item_factors, self.user_factors[userid], count)
+        return list(
+            itertools.islice((rec for rec in zip(ids[0], scores[0]) if rec[0] not in liked), N)
+        )
 
     recommend.__doc__ = RecommenderBase.recommend.__doc__
 
@@ -68,56 +58,65 @@ class MatrixFactorizationBase(RecommenderBase):
         if recalculate_user:
             raise NotImplementedError("recalculate_user isn't support on GPU yet")
 
-        user = self.user_factors[userid]
-
         # check selected items are  in the model
         if max(selected_items) >= self.item_factors.shape[0] or min(selected_items) < 0:
             raise IndexError("Some of selected itemids are not in the model")
 
         item_factors = self.item_factors[selected_items]
-        # calculate relevance scores of given items w.r.t the user
-        scores = item_factors.dot(user)
+        user = self.user_factors[userid]
 
-        # return sorted results
-        return sorted(zip(selected_items, scores), key=lambda x: -x[1])
+        # once we have item_factors here, this should work
+        ids, scores = self._knn.topk(item_factors, user, len(selected_items))
+        ids = np.array(selected_items)[ids]
+
+        print(ids)
+        print(scores)
+        return list(zip(ids[0], scores[0]))
 
     rank_items.__doc__ = RecommenderBase.rank_items.__doc__
 
     @property
     def user_norms(self):
         if self._user_norms is None:
-            self._user_norms = cp.linalg.norm(self.user_factors, axis=-1)
-            # don't divide by zero in similar_items, replace with small value
-            self._user_norms[self._user_norms == 0] = 1e-10
+            self._user_norms = _cuda.calculate_norms(self.user_factors)
+            self._user_norms_host = self._user_norms.to_numpy().reshape(self._user_norms.shape[1])
         return self._user_norms
 
     @property
     def item_norms(self):
         if self._item_norms is None:
-            self._item_norms = cp.linalg.norm(self.item_factors, axis=-1)
-            # don't divide by zero in similar_items, replace with small value
-            self._item_norms[self._item_norms == 0] = 1e-10
+            self._item_norms = _cuda.calculate_norms(self.item_factors)
+            self._item_norms_host = self._item_norms.to_numpy().reshape(self._item_norms.shape[1])
         return self._item_norms
 
     def similar_users(self, userid, N=10):
-        factor = self.user_factors[userid]
-        norm = self.user_norms[userid]
-        scores = self.user_factors.dot(factor) / (norm * self.user_norms)
-        best = cp.argpartition(scores, -N)[-N:]
-        return sorted(zip(best.tolist(), scores[best].tolist()), key=lambda x: -x[1])
+        ids, scores = self._knn.topk(
+            self.user_factors, self.user_factors[int(userid)], N, self.user_norms
+        )
+        scores /= self._user_norms_host[userid]
+        return list(zip(ids[0], scores[0]))
 
     similar_users.__doc__ = RecommenderBase.similar_users.__doc__
 
     def similar_items(self, itemid, N=10, react_users=None, recalculate_item=False):
         if recalculate_item:
             raise NotImplementedError("recalculate_item isn't support on GPU yet")
-        factor = self.item_factors[itemid]
-        norm = self.item_norms[itemid]
-        scores = self.item_factors.dot(factor) / (norm * self.item_norms)
-        best = cp.argpartition(scores, -N)[-N:]
-        return sorted(zip(best.tolist(), scores[best].tolist()), key=lambda x: -x[1])
+        ids, scores = self._knn.topk(
+            self.item_factors, self.item_factors[int(itemid)], N, self.item_norms
+        )
+        scores /= self._item_norms_host[itemid]
+        return list(zip(ids[0], scores[0]))
 
     similar_items.__doc__ = RecommenderBase.similar_items.__doc__
+
+    def __getstate__(self):
+        return {
+            "item_factors": self.item_factors.to_numpy() if self.item_factors else None,
+            "user_factors": self.user_factors.to_numpy() if self.user_factors else None,
+        }
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
 
 
 def check_random_state(random_state):
@@ -130,15 +129,12 @@ def check_random_state(random_state):
     ----------
     random_state : int, None or RandomState
         The existing RandomState. If None, or an int, will be used
-        to seed a new cupy RandomState.
+        to seed a new curand RandomState generator
     """
-    if isinstance(random_state, cp.random.RandomState):
-        return random_state
-
     if isinstance(random_state, np.random.RandomState):
-        # we need to convert from numpy random state to cupy random state.
-        return cp.random.RandomState(random_state.randint(2 ** 63))
+        # we need to convert from numpy random state our internal random state
+        return _cuda.RandomState(random_state.randint(2 ** 31))
 
     # otherwise try to initialize a new one, and let it fail through
     # on the numpy side if it doesn't work
-    return cp.random.RandomState(random_state)
+    return _cuda.RandomState(random_state or int(time.time()))

--- a/implicit/gpu/matrix_factorization_base.py
+++ b/implicit/gpu/matrix_factorization_base.py
@@ -3,8 +3,9 @@ import time
 
 import numpy as np
 
+import implicit.gpu
+
 from ..recommender_base import RecommenderBase
-from . import _cuda
 
 
 class MatrixFactorizationBase(RecommenderBase):
@@ -14,9 +15,9 @@ class MatrixFactorizationBase(RecommenderBase):
 
     Attributes
     ----------
-    item_factors : _cuda.Matrix
+    item_factors : implicit.gpu.Matrix
         Array of latent factors for each item in the training set
-    user_factors : _cuda.Matrix
+    user_factors : implicit.gpu.Matrix
         Array of latent factors for each user in the training set
     """
 
@@ -25,7 +26,7 @@ class MatrixFactorizationBase(RecommenderBase):
         self.user_factors = None
         self._item_norms = None
         self._user_norms = None
-        self._knn = _cuda.KnnQuery()
+        self._knn = implicit.gpu.KnnQuery()
 
     def recommend(
         self,
@@ -78,14 +79,14 @@ class MatrixFactorizationBase(RecommenderBase):
     @property
     def user_norms(self):
         if self._user_norms is None:
-            self._user_norms = _cuda.calculate_norms(self.user_factors)
+            self._user_norms = implicit.gpu.calculate_norms(self.user_factors)
             self._user_norms_host = self._user_norms.to_numpy().reshape(self._user_norms.shape[1])
         return self._user_norms
 
     @property
     def item_norms(self):
         if self._item_norms is None:
-            self._item_norms = _cuda.calculate_norms(self.item_factors)
+            self._item_norms = implicit.gpu.calculate_norms(self.item_factors)
             self._item_norms_host = self._item_norms.to_numpy().reshape(self._item_norms.shape[1])
         return self._item_norms
 
@@ -133,8 +134,8 @@ def check_random_state(random_state):
     """
     if isinstance(random_state, np.random.RandomState):
         # we need to convert from numpy random state our internal random state
-        return _cuda.RandomState(random_state.randint(2 ** 31))
+        return implicit.gpu.RandomState(random_state.randint(2 ** 31))
 
     # otherwise try to initialize a new one, and let it fail through
     # on the numpy side if it doesn't work
-    return _cuda.RandomState(random_state or int(time.time()))
+    return implicit.gpu.RandomState(random_state or int(time.time()))

--- a/implicit/gpu/random.cu
+++ b/implicit/gpu/random.cu
@@ -1,0 +1,40 @@
+#include <cuda_runtime.h>
+#include <curand.h>
+
+#include <thrust/transform.h>
+#include <thrust/functional.h>
+#include <thrust/device_ptr.h>
+
+#include "implicit/gpu/utils.cuh"
+#include "implicit/gpu/random.h"
+
+namespace implicit { namespace gpu {
+
+RandomState::RandomState(long seed) {
+    CHECK_CURAND(curandCreateGenerator(&rng, CURAND_RNG_PSEUDO_DEFAULT));
+    CHECK_CURAND(curandSetPseudoRandomGeneratorSeed(rng, seed));
+}
+
+Matrix RandomState::uniform(int rows, int cols, float low, float high) {
+    Matrix ret(rows, cols, NULL);
+    CHECK_CURAND(curandGenerateUniform(rng, ret.data, rows*cols));
+
+    if ((low != 0.0) || (high != 1.0)) {
+        auto start = thrust::device_pointer_cast(ret.data);
+        thrust::transform(start, start + rows*cols, start, 
+            thrust::placeholders::_1 = thrust::placeholders::_1 * (high - low) + low);
+    }
+
+    return ret;
+}
+
+Matrix RandomState::randn(int rows, int cols, float mean, float stddev) {
+    Matrix ret(rows, cols, NULL);
+    CHECK_CURAND(curandGenerateNormal(rng, ret.data, rows*cols, mean, stddev));
+    return ret;
+}
+
+RandomState::~RandomState() {
+    curandDestroyGenerator(rng);
+}
+}}  // namespace implicit::gpu

--- a/implicit/gpu/random.h
+++ b/implicit/gpu/random.h
@@ -1,0 +1,22 @@
+#ifndef IMPLICIT_GPU_RANDOM_H_
+#define IMPLICIT_GPU_RANDOM_H_
+#include <curand.h>
+
+#include "implicit/gpu/matrix.h"
+
+namespace implicit { namespace gpu {
+
+struct RandomState {
+    RandomState(long seed);
+    ~RandomState();
+
+    Matrix uniform(int rows, int cols, float low=0.0, float high=1.0);
+    Matrix randn(int rows, int cols, float mean=0, float stddev=1);
+
+    RandomState(const RandomState&) = delete;
+    RandomState& operator=(const RandomState&) = delete;
+
+    curandGenerator_t rng;
+};
+}}  // namespace implicit/gpu
+#endif  // IMPLICIT_GPU_RANDOM_H_

--- a/implicit/gpu/random.pxd
+++ b/implicit/gpu/random.pxd
@@ -1,0 +1,7 @@
+from .matrix cimport Matrix
+
+cdef extern from "random.h" namespace "implicit::gpu" nogil:
+    cdef cppclass RandomState:
+        RandomState(long rows) except +
+        Matrix uniform(int rows, int cols, float low, float high) except +
+        Matrix randn(int rows, int cols, float mean, float stdev) except +

--- a/implicit/gpu/random.pxd
+++ b/implicit/gpu/random.pxd
@@ -1,5 +1,6 @@
 from .matrix cimport Matrix
 
+
 cdef extern from "random.h" namespace "implicit::gpu" nogil:
     cdef cppclass RandomState:
         RandomState(long rows) except +

--- a/implicit/gpu/utils.cuh
+++ b/implicit/gpu/utils.cuh
@@ -2,6 +2,8 @@
 #define IMPLICIT_GPU_UTILS_CUH_
 #include <stdexcept>
 #include <sstream>
+#include <cublas_v2.h>
+#include <curand.h>
 
 namespace implicit { namespace gpu {
 using std::invalid_argument;
@@ -38,6 +40,16 @@ inline void checkCublas(cublasStatus_t code, const char * file, int line) {
         std::stringstream err;
         err << "cublas error: " << cublasGetErrorString(code)
             << " (" << file << ":" << line << ")";
+        throw std::runtime_error(err.str());
+    }
+}
+
+
+#define CHECK_CURAND(code) { checkCurand((code), __FILE__, __LINE__); }
+inline void checkCurand(curandStatus_t code, const char *file, int line) {
+    if (code != CURAND_STATUS_SUCCESS) {
+        std::stringstream err;
+        err << "CURAND error: " << code << " (" << file << ":" << line << ")";
         throw std::runtime_error(err.str());
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,13 @@ def define_extensions():
     )
 
     if CUDA:
+        conda_prefix = os.getenv("CONDA_PREFIX")
+        include_dirs = [CUDA["include"], "."]
+        library_dirs = [CUDA["lib64"]]
+        if conda_prefix:
+            include_dirs.append(os.path.join(conda_prefix, "include"))
+            library_dirs.append(os.path.join(conda_prefix, "lib"))
+
         modules.append(
             Extension(
                 "implicit.gpu._cuda",
@@ -90,13 +97,16 @@ def define_extensions():
                     os.path.join("implicit", "gpu", "als.cu"),
                     os.path.join("implicit", "gpu", "bpr.cu"),
                     os.path.join("implicit", "gpu", "matrix.cu"),
+                    os.path.join("implicit", "gpu", "device_buffer.cu"),
+                    os.path.join("implicit", "gpu", "random.cu"),
+                    os.path.join("implicit", "gpu", "knn.cu"),
                 ],
                 language="c++",
                 extra_compile_args=compile_args,
                 extra_link_args=link_args,
-                library_dirs=[CUDA["lib64"]],
+                library_dirs=library_dirs,
                 libraries=["cudart", "cublas", "curand"],
-                include_dirs=[CUDA["include"], "."],
+                include_dirs=include_dirs,
             )
         )
     else:

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -76,8 +76,12 @@ class ALSTest(unittest.TestCase, RecommenderBaseTestMixin):
             )
             model.fit(Ciu, show_progress=False)
 
-            self.assertTrue(np.isfinite(model.item_factors).all())
-            self.assertTrue(np.isfinite(model.user_factors).all())
+            item_factors, user_factors = model.item_factors, model.user_factors
+            if options["use_gpu"]:
+                item_factors, user_factors = item_factors.to_numpy(), user_factors.to_numpy()
+
+            self.assertTrue(np.isfinite(item_factors).all())
+            self.assertTrue(np.isfinite(user_factors).all())
 
     def test_factorize(self):
         counts = csr_matrix(
@@ -120,6 +124,9 @@ class ALSTest(unittest.TestCase, RecommenderBaseTestMixin):
                 )
                 model.fit(user_items, show_progress=False)
                 rows, cols = model.item_factors, model.user_factors
+
+                if use_gpu:
+                    rows, cols = rows.to_numpy(), cols.to_numpy()
 
             except Exception as e:
                 self.fail(

--- a/tests/gpu_test.py
+++ b/tests/gpu_test.py
@@ -1,8 +1,8 @@
-import pytest
-import implicit
 import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
 
-from numpy.testing import assert_array_equal, assert_allclose
+import implicit
 
 
 @pytest.mark.skipif(not implicit.gpu.HAS_CUDA, reason="needs cuda build")

--- a/tests/gpu_test.py
+++ b/tests/gpu_test.py
@@ -1,0 +1,63 @@
+import pytest
+import implicit
+import numpy as np
+
+from numpy.testing import assert_array_equal, assert_allclose
+
+
+@pytest.mark.skipif(not implicit.gpu.HAS_CUDA, reason="needs cuda build")
+@pytest.mark.parametrize("k", [4, 16, 64, 128, 1000])
+@pytest.mark.parametrize("batch", [1, 10, 100])
+@pytest.mark.parametrize("temp_memory", [500_000_000, 5_000_000])
+def test_topk_ascending(k, batch, temp_memory):
+    num_items = 10000
+    factors = 10
+    items = np.arange(num_items * factors).reshape((num_items, factors)).astype("float32")
+    queries = np.arange(batch * factors).reshape((batch, factors)).astype("float32")
+    _check_knn_queries(items, queries, k, max_temp_memory=temp_memory)
+
+
+@pytest.mark.skipif(not implicit.gpu.HAS_CUDA, reason="needs cuda build")
+@pytest.mark.parametrize("k", [4, 64, 128])
+@pytest.mark.parametrize("batch", [1, 10, 100])
+@pytest.mark.parametrize("temp_memory", [500_000_000, 500_000])
+def test_topk_random(k, batch, temp_memory):
+    num_items = 1000
+    factors = 10
+    np.random.seed(0)
+    items = np.random.uniform(size=(num_items, factors)).astype("float32")
+    queries = np.random.uniform(size=(batch, factors)).astype("float32")
+    _check_knn_queries(items, queries, k, max_temp_memory=temp_memory)
+
+
+def _check_knn_queries(items, queries, k=5, max_temp_memory=500_000_000):
+    # compute distances on the gpu
+    knn = implicit.gpu._cuda.KnnQuery(max_temp_memory=max_temp_memory)
+    ids, distances = knn.topk(
+        implicit.gpu._cuda.Matrix(items), implicit.gpu._cuda.Matrix(queries), k
+    )
+
+    # compute on the cpu
+    batch = queries.dot(items.T)
+    exact_ids = np.flip(np.argsort(batch)[:, -k:], axis=1)
+    exact_distances = np.zeros(exact_ids.shape)
+    for r in range(batch.shape[0]):
+        exact_distances[r] = batch[r][exact_ids[r]]
+
+    # make sure that we match
+    assert_array_equal(ids, exact_ids)
+    assert_allclose(distances, exact_distances, rtol=1e-06)
+
+
+@pytest.mark.skipif(not implicit.gpu.HAS_CUDA, reason="needs cuda build")
+def test_calculate_norms():
+    num_items = 100
+    factors = 8
+    items = np.arange(num_items * factors).reshape((num_items, factors)).astype("float32")
+    norms = (
+        implicit.gpu._cuda.calculate_norms(implicit.gpu._cuda.Matrix(items))
+        .to_numpy()
+        .reshape(num_items)
+    )
+    np_norms = np.linalg.norm(items, axis=1)
+    assert_allclose(norms, np_norms)


### PR DESCRIPTION
Add a KnnQuery class for querying top-k related items on the GPU. This lets us remove
the cupy dependency, which for the small amount of functionality we need (top-k / random
/ matrix multiplication) required a 900+mb package to be installed.

Currently this is only slightly faster than the cupy version (20%) but will become faster
as we move towards batch processing and faster top-k selection algorithms for small k.