### PR TITLE
Block radix select

### DIFF
--- a/implicit/gpu/knn.cu
+++ b/implicit/gpu/knn.cu
@@ -115,7 +115,7 @@ void KnnQuery::topk(const Matrix & items, const Matrix & query, int k,
     // We need 6 copies of the matrix for argsort code - and then some
     // extra memory per SM as well.
     int batch_size = available_temp_memory / (sizeof(float) * items.rows);
-    if (k > MAX_SELECT_K) {
+    if (k >= MAX_SELECT_K) {
         batch_size *= 0.15;
     } else {
         batch_size *= 0.5;
@@ -212,7 +212,7 @@ __global__ void argpartition_kernel(const int * indices, const float * distances
 void KnnQuery::argpartition(const Matrix & items, int k, int * indices, float * distances) {
     k = std::min(k, items.cols);
 
-    if (k > MAX_SELECT_K) {
+    if (k >= MAX_SELECT_K) {
         int * temp_indices = reinterpret_cast<int *>(alloc->allocate(items.rows * items.cols * sizeof(int)));
         float * temp_distances = reinterpret_cast<float *>(alloc->allocate(items.rows * items.cols * sizeof(float)));
         argsort(items, temp_indices, temp_distances);

--- a/implicit/gpu/knn.cu
+++ b/implicit/gpu/knn.cu
@@ -13,6 +13,8 @@
 #include <cub/iterator/transform_input_iterator.cuh>
 #include <cub/device/device_segmented_radix_sort.cuh>
 #include <cub/device/device_radix_sort.cuh>
+#include <cub/block/block_radix_sort.cuh>
+
 
 #include "implicit/gpu/utils.cuh"
 #include "implicit/gpu/knn.h"
@@ -84,6 +86,8 @@ KnnQuery::KnnQuery(size_t temp_memory)
     CHECK_CUBLAS(cublasCreate(&blas_handle));
 }
 
+const static int MAX_SELECT_K = 128;
+
 void KnnQuery::topk(const Matrix & items, const Matrix & query, int k,
                     int * indices, float * distances, float * item_norms) {
     if (query.cols != items.cols) {
@@ -110,7 +114,13 @@ void KnnQuery::topk(const Matrix & items, const Matrix & query, int k,
 
     // We need 6 copies of the matrix for argsort code - and then some
     // extra memory per SM as well.
-    int batch_size = 0.15 * available_temp_memory / (sizeof(float) * items.rows);
+    int batch_size = available_temp_memory / (sizeof(float) * items.rows);
+    if (k > MAX_SELECT_K) {
+        batch_size *= 0.15;
+    } else {
+        batch_size *= 0.5;
+    }
+
     batch_size = std::min(batch_size, query.rows);
     batch_size = std::max(batch_size, 1);
 
@@ -163,23 +173,117 @@ void KnnQuery::topk(const Matrix & items, const Matrix & query, int k,
     }
 }
 
+
+static const int ARGPARTITION_BLOCK_DIM_X = 128;
+static const int ARGPARTITION_ITEMS_PER_THREAD = 16;
+static const int ARGPARTITION_SORT_SIZE = ARGPARTITION_BLOCK_DIM_X * ARGPARTITION_ITEMS_PER_THREAD;
+
+__global__ void argpartition_kernel(const int * indices, const float * distances,
+                                    int rows, int cols, int k,
+                                    int * out_indices,
+                                    float * out_distances) {
+    using BlockRadixSort = cub::BlockRadixSort<float, ARGPARTITION_BLOCK_DIM_X, ARGPARTITION_ITEMS_PER_THREAD, int>;
+    __shared__ typename BlockRadixSort::TempStorage shared_mem;
+
+    float keys[ARGPARTITION_ITEMS_PER_THREAD];
+    int values[ARGPARTITION_ITEMS_PER_THREAD];
+
+    int rowid = blockIdx.y;
+    for (int i = 0; i < ARGPARTITION_ITEMS_PER_THREAD; i++) {
+        int colid = blockIdx.x * blockDim.x + threadIdx.x + i * (blockDim.x * gridDim.x);
+        if (colid < cols) {
+            keys[i] = distances[rowid * cols + colid];
+            values[i] = indices == NULL ? colid : indices[rowid * cols + colid];
+        } else {
+            keys[i] = FLT_MIN;
+            values[i] = -1;
+        }
+    }
+
+    BlockRadixSort(shared_mem).SortDescendingBlockedToStriped(keys, values);
+
+    if (threadIdx.x < k) {
+        int out_col = threadIdx.x + blockIdx.x * k;
+        out_distances[out_col + rowid * k * gridDim.x] = keys[0];
+        out_indices[out_col + rowid * k * gridDim.x] = values[0];
+    }
+}
+
 void KnnQuery::argpartition(const Matrix & items, int k, int * indices, float * distances) {
     k = std::min(k, items.cols);
 
-    int * temp_indices = reinterpret_cast<int *>(alloc->allocate(items.rows * items.cols * sizeof(int)));
-    float * temp_distances = reinterpret_cast<float *>(alloc->allocate(items.rows * items.cols * sizeof(float)));
-    argsort(items, temp_indices, temp_distances);
-    copy_columns(temp_distances, items.rows, items.cols, distances, k);
-    copy_columns(temp_indices, items.rows, items.cols, indices, k);
-    alloc->deallocate(temp_distances);
-    alloc->deallocate(temp_indices);
+    if (k > MAX_SELECT_K) {
+        int * temp_indices = reinterpret_cast<int *>(alloc->allocate(items.rows * items.cols * sizeof(int)));
+        float * temp_distances = reinterpret_cast<float *>(alloc->allocate(items.rows * items.cols * sizeof(float)));
+        argsort(items, temp_indices, temp_distances);
+        copy_columns(temp_distances, items.rows, items.cols, distances, k);
+        copy_columns(temp_indices, items.rows, items.cols, indices, k);
+        alloc->deallocate(temp_distances);
+        alloc->deallocate(temp_indices);
+        return;
+    }
+
+    int rows = items.rows;
+    int cols = items.cols;
+
+    int blocks_per_row = (cols + ARGPARTITION_SORT_SIZE - 1) / ARGPARTITION_SORT_SIZE;
+
+    // maintain a double buffer of input/output indices and distances
+    float * distA = reinterpret_cast<float *>(alloc->allocate(rows * k * blocks_per_row * sizeof(float)));
+    int * indA = reinterpret_cast<int *>(alloc->allocate(rows * k * blocks_per_row * sizeof(int)));
+    blocks_per_row = (blocks_per_row * k + ARGPARTITION_SORT_SIZE - 1) / ARGPARTITION_SORT_SIZE;
+    float * distB = reinterpret_cast<float *>(alloc->allocate(rows * k * blocks_per_row * sizeof(float)));
+    int * indB = reinterpret_cast<int *>(alloc->allocate(rows * k * blocks_per_row * sizeof(int)));
+
+    const float * input_distances = items.data;
+    const int * input_indices = NULL;
+    float * output_distances = distA;
+    int * output_indices = indA;
+    bool outputA = true;
+
+    while (true) {
+        int blocks_per_row = (cols + ARGPARTITION_SORT_SIZE - 1) / ARGPARTITION_SORT_SIZE;
+        dim3 block_count(blocks_per_row, items.rows, 1);
+
+        bool final = block_count.x <= 1;
+        if (final) {
+            output_distances = distances;
+            output_indices = indices;
+        }
+
+        argpartition_kernel<<<block_count, ARGPARTITION_BLOCK_DIM_X>>>(
+            input_indices, input_distances,
+            rows, cols, k,
+            output_indices, output_distances);
+
+        if (final) break;
+
+        // reduce the number of columns we process next iteration to the output of the current
+        // input
+        cols = block_count.x * k;
+
+        // set the input of the next run to the output of the current run
+        // (and the output to an unused block of memory)
+        input_distances = output_distances;
+        input_indices = output_indices;
+        output_distances = outputA ? distB : distA;
+        output_indices = outputA ? indB : indA;
+        outputA = !outputA;
+    }
+
+    CHECK_CUDA(cudaDeviceSynchronize());
+
+    // Free up temp memory
+    alloc->deallocate(indB);
+    alloc->deallocate(distB);
+    alloc->deallocate(indA);
+    alloc->deallocate(distA);
 }
 
 void KnnQuery::argsort(const Matrix & items, int * indices, float * distances) {
     // We can't do this in place https://github.com/NVIDIA/cub/issues/238 ?
     // so generate temp memory for this
     auto temp_indices = reinterpret_cast<int *>(alloc->allocate(items.rows * items.cols * sizeof(int)));
-
     thrust::transform(
         thrust::make_counting_iterator<int>(0),
         thrust::make_counting_iterator<int>(items.rows * items.cols),
@@ -187,9 +291,11 @@ void KnnQuery::argsort(const Matrix & items, int * indices, float * distances) {
         thrust::device_pointer_cast(temp_indices),
         thrust::modulus<int>());
 
+    int cols = items.cols;
     auto segment_offsets = thrust::make_transform_iterator(thrust::make_counting_iterator<int>(0),
-                                                           thrust::placeholders::_1 *= items.cols);
-
+                                                           [=] __device__(int i) {
+                                                               return i * cols;
+                                                           });
     void * temp_mem = NULL;
 
     // sort the values.

--- a/implicit/gpu/knn.h
+++ b/implicit/gpu/knn.h
@@ -19,10 +19,10 @@ public:
               int * indices, float * distances,
               float * item_norms = NULL);
 
-protected:
     void argpartition(const Matrix & items, int k, int * indices, float * distances);
     void argsort(const Matrix & items, int * indices, float * distances);
 
+protected:
     size_t max_temp_memory;
     std::unique_ptr<StackAllocator> alloc;
 };

--- a/implicit/gpu/matrix_factorization_base.py
+++ b/implicit/gpu/matrix_factorization_base.py
@@ -117,7 +117,8 @@ class MatrixFactorizationBase(RecommenderBase):
         }
 
     def __setstate__(self, state):
-        self.__dict__.update(state)
+        self.item_factors = implicit.gpu.Matrix(state["item_factors"])
+        self.user_factors = implicit.gpu.Matrix(state["user_factors"])
 
 
 def check_random_state(random_state):


### PR DESCRIPTION
Add a basic top-k algorithm using cub BlockRadixSort. Sort a series of
1024 element blocks with cub, and take the top K from each block repeating until
there is only 1 block to sort. On a single item this increases queries to around
3K QPS on the lastfm dataset, and using batch queries can get up to 25K QPS.