### PR TITLE
update recommend function in recommender_base for issue #365

### DIFF
--- a/implicit/recommender_base.pyx
+++ b/implicit/recommender_base.pyx
@@ -172,7 +172,7 @@ class MatrixFactorizationBase(RecommenderBase):
 
         liked = set()
         if filter_already_liked_items:
-            liked.update(user_items[userid].indices)
+            liked.update(user_items[userid].nonzero()[1])
         if filter_items:
             liked.update(filter_items)
 


### PR DESCRIPTION
filter_already_liked_items was not working as expected as mentioned https://github.com/benfred/implicit/issues/365. 

In recommend function users liked items need to be corrected. It's not extracting user's liked item indices correctly. It's always returning array of 0s instead of indices of liked items

Small change has been made to recommend function, which can resolve this problem.
