### PR TITLE
Optionally output iteration loss as info log

### DIFF
--- a/benchmarks/benchmark_als.py
+++ b/benchmarks/benchmark_als.py
@@ -34,7 +34,12 @@ def benchmark_accuracy(plays):
 
     for steps in [2, 3, 4]:
         model = AlternatingLeastSquares(
-            factors=100, use_native=True, use_cg=True, regularization=0, iterations=25, calculate_training_loss=True
+            factors=100,
+            use_native=True,
+            use_cg=True,
+            regularization=0,
+            iterations=25,
+            calculate_training_loss=True,
         )
         model.cg_steps = steps
         model.fit_callback = store_loss("cg%i" % steps)
@@ -42,14 +47,24 @@ def benchmark_accuracy(plays):
 
     if has_cuda:
         model = AlternatingLeastSquares(
-            factors=100, use_native=True, use_gpu=True, regularization=0, iterations=25, calculate_training_loss=True
+            factors=100,
+            use_native=True,
+            use_gpu=True,
+            regularization=0,
+            iterations=25,
+            calculate_training_loss=True,
         )
         model.fit_callback = store_loss("gpu")
         model.use_gpu = True
         model.fit(plays)
 
     model = AlternatingLeastSquares(
-        factors=100, use_native=True, use_cg=False, regularization=0, iterations=25, calculate_training_loss=True
+        factors=100,
+        use_native=True,
+        use_cg=False,
+        regularization=0,
+        iterations=25,
+        calculate_training_loss=True,
     )
     model.fit_callback = store_loss("cholesky")
     model.fit(plays)

--- a/benchmarks/benchmark_als.py
+++ b/benchmarks/benchmark_als.py
@@ -26,9 +26,8 @@ except ImportError:
 def benchmark_accuracy(plays):
     output = defaultdict(list)
 
-    def store_loss(model, name):
-        def inner(iteration, elapsed):
-            loss = calculate_loss(plays, model.item_factors, model.user_factors, 0)
+    def store_loss(name):
+        def inner(iteration, elapsed, loss):
             print("model %s iteration %i loss %.5f" % (name, iteration, loss))
             output[name].append(loss)
 
@@ -39,21 +38,21 @@ def benchmark_accuracy(plays):
             factors=100, use_native=True, use_cg=True, regularization=0, iterations=25
         )
         model.cg_steps = steps
-        model.fit_callback = store_loss(model, "cg%i" % steps)
+        model.fit_callback = store_loss("cg%i" % steps)
         model.fit(plays)
 
     if has_cuda:
         model = AlternatingLeastSquares(
             factors=100, use_native=True, use_gpu=True, regularization=0, iterations=25
         )
-        model.fit_callback = store_loss(model, "gpu")
+        model.fit_callback = store_loss("gpu")
         model.use_gpu = True
         model.fit(plays)
 
     model = AlternatingLeastSquares(
         factors=100, use_native=True, use_cg=False, regularization=0, iterations=25
     )
-    model.fit_callback = store_loss(model, "cholesky")
+    model.fit_callback = store_loss("cholesky")
     model.fit(plays)
 
     return output
@@ -63,7 +62,7 @@ def benchmark_times(plays, iterations=3):
     times = defaultdict(lambda: defaultdict(list))
 
     def store_time(model, name):
-        def inner(iteration, elapsed):
+        def inner(iteration, elapsed, loss):
             print(name, model.factors, iteration, elapsed)
             times[name][model.factors].append(elapsed)
 

--- a/benchmarks/benchmark_als.py
+++ b/benchmarks/benchmark_als.py
@@ -11,7 +11,6 @@ import matplotlib.pyplot as plt
 import scipy.io
 import seaborn
 
-from implicit._als import calculate_loss
 from implicit.als import AlternatingLeastSquares
 from implicit.nearest_neighbours import bm25_weight
 
@@ -35,7 +34,7 @@ def benchmark_accuracy(plays):
 
     for steps in [2, 3, 4]:
         model = AlternatingLeastSquares(
-            factors=100, use_native=True, use_cg=True, regularization=0, iterations=25
+            factors=100, use_native=True, use_cg=True, regularization=0, iterations=25, calculate_training_loss=True
         )
         model.cg_steps = steps
         model.fit_callback = store_loss("cg%i" % steps)
@@ -43,14 +42,14 @@ def benchmark_accuracy(plays):
 
     if has_cuda:
         model = AlternatingLeastSquares(
-            factors=100, use_native=True, use_gpu=True, regularization=0, iterations=25
+            factors=100, use_native=True, use_gpu=True, regularization=0, iterations=25, calculate_training_loss=True
         )
         model.fit_callback = store_loss("gpu")
         model.use_gpu = True
         model.fit(plays)
 
     model = AlternatingLeastSquares(
-        factors=100, use_native=True, use_cg=False, regularization=0, iterations=25
+        factors=100, use_native=True, use_cg=False, regularization=0, iterations=25, calculate_training_loss=True
     )
     model.fit_callback = store_loss("cholesky")
     model.fit(plays)

--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -93,7 +93,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
 
         check_blas_config()
 
-    def fit(self, item_users, show_progress=True):
+    def fit(self, item_users, show_progress=True, output_loss_logs=False):
         """Factorizes the item_users matrix.
 
         After calling this method, the members 'user_factors' and 'item_factors' will be
@@ -183,6 +183,9 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
                         num_threads=self.num_threads,
                     )
                     progress.set_postfix({"loss": loss})
+
+                    if output_loss_logs:
+                        log.info("loss %.4f", loss)
 
                 if self.fit_callback:
                     self.fit_callback(iteration, time.time() - s)

--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -93,7 +93,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
 
         check_blas_config()
 
-    def fit(self, item_users, show_progress=True, output_loss_logs=False):
+    def fit(self, item_users, show_progress=True):
         """Factorizes the item_users matrix.
 
         After calling this method, the members 'user_factors' and 'item_factors' will be
@@ -174,6 +174,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
                 )
                 progress.update(1)
 
+                loss = None
                 if self.calculate_training_loss:
                     loss = _als.calculate_loss(
                         Cui,
@@ -184,11 +185,11 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
                     )
                     progress.set_postfix({"loss": loss})
 
-                    if output_loss_logs:
+                    if not show_progress:
                         log.info("loss %.4f", loss)
 
                 if self.fit_callback:
-                    self.fit_callback(iteration, time.time() - s)
+                    self.fit_callback(iteration, time.time() - s, loss)
 
         if self.calculate_training_loss:
             log.info("Final training loss %.4f", loss)

--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -67,7 +67,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         self.random_state = random_state
         self.cg_steps = 3
 
-    def fit(self, item_users, show_progress=True):
+    def fit(self, item_users, show_progress=True, output_loss_logs=False):
         """Factorizes the item_users matrix.
 
         After calling this method, the members 'user_factors' and 'item_factors' will be
@@ -149,6 +149,10 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
                 if self.calculate_training_loss:
                     loss = solver.calculate_loss(Cui, X, Y, self.regularization)
                     progress.set_postfix({"loss": loss})
+
+                    if output_loss_logs:
+                        log.info("loss %.4f", loss)
+
 
         if self.calculate_training_loss:
             log.info("Final training loss %.4f", loss)

--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -67,7 +67,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         self.random_state = random_state
         self.cg_steps = 3
 
-    def fit(self, item_users, show_progress=True, output_loss_logs=False):
+    def fit(self, item_users, show_progress=True):
         """Factorizes the item_users matrix.
 
         After calling this method, the members 'user_factors' and 'item_factors' will be
@@ -143,16 +143,16 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
                 solver.least_squares(Ciu, Y, X, self.regularization, self.cg_steps)
                 progress.update(1)
 
-                if self.fit_callback:
-                    self.fit_callback(iteration, time.time() - s)
-
+                loss = None
                 if self.calculate_training_loss:
                     loss = solver.calculate_loss(Cui, X, Y, self.regularization)
                     progress.set_postfix({"loss": loss})
 
-                    if output_loss_logs:
+                    if not show_progress:
                         log.info("loss %.4f", loss)
 
+                if self.fit_callback:
+                    self.fit_callback(iteration, time.time() - s, loss)
 
         if self.calculate_training_loss:
             log.info("Final training loss %.4f", loss)


### PR DESCRIPTION
I am running implicit als inside a Docker container as a custom AWS SageMaker algorithm. As it is now, the loss during fit iterations is not picked up as a metric properly by the SageMaker log parser when the loss is outputted using tqmd (which has a funky output format). This PR adds an optional parameter (default False) to the als fit function to also output each loss as a regular info log. This would make it possible for AWS SageMaker to pick up loss during iterations as a metric from the regular info logs.

What do you think about the idea to optionally output plain info logs?

Ideally I would like to choose either tqmd or plain info logs, but to my understanding if show_progress is False the whole function call will be skipped. So outputting individual info logs would only work when also showing progress with tqmd.

Thanks for a great module!