### PR TITLE
Fix als test_rank_items on GPU

### DIFF
--- a/implicit/gpu/knn.cu
+++ b/implicit/gpu/knn.cu
@@ -195,7 +195,7 @@ __global__ void argpartition_kernel(const int * indices, const float * distances
             keys[i] = distances[rowid * cols + colid];
             values[i] = indices == NULL ? colid : indices[rowid * cols + colid];
         } else {
-            keys[i] = FLT_MIN;
+            keys[i] = -FLT_MAX;
             values[i] = -1;
         }
     }

--- a/implicit/gpu/matrix_factorization_base.py
+++ b/implicit/gpu/matrix_factorization_base.py
@@ -70,8 +70,6 @@ class MatrixFactorizationBase(RecommenderBase):
         ids, scores = self._knn.topk(item_factors, user, len(selected_items))
         ids = np.array(selected_items)[ids]
 
-        print(ids)
-        print(scores)
         return list(zip(ids[0], scores[0]))
 
     rank_items.__doc__ = RecommenderBase.rank_items.__doc__

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -247,7 +247,9 @@ if HAS_CUDA:
 
     class GPUALSTest(unittest.TestCase, RecommenderBaseTestMixin):
         def _get_model(self):
-            return AlternatingLeastSquares(factors=32, regularization=0, random_state=23)
+            return AlternatingLeastSquares(
+                factors=32, regularization=0, random_state=23, use_gpu=True
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We had an issue where we were filtering out scores < 0 in the gpu code,
which caused a bug in the gpu test_rank_items code for ALS. Fix, and
ensure that the unittest is actually working on the GPU