### PR TITLE
Switch to using pytest parameterize in als/bpr tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/implicit/gpu/matrix_factorization_base.py
+++ b/implicit/gpu/matrix_factorization_base.py
@@ -39,6 +39,7 @@ class MatrixFactorizationBase(RecommenderBase):
     ):
         if recalculate_user:
             raise NotImplementedError("recalculate_user isn't support on GPU yet")
+
         liked = set()
         if filter_already_liked_items:
             liked.update(user_items[userid].indices)

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -3,244 +3,18 @@ from __future__ import print_function
 import unittest
 
 import numpy as np
+import pytest
 from scipy.sparse import csr_matrix, random
 
 from implicit.als import AlternatingLeastSquares
 from implicit.gpu import HAS_CUDA
 
-from .recommender_base_test import RecommenderBaseTestMixin
+from .recommender_base_test import RecommenderBaseTestMixin, get_checker_board
 
 
 class ALSTest(unittest.TestCase, RecommenderBaseTestMixin):
     def _get_model(self):
         return AlternatingLeastSquares(factors=3, regularization=0, use_gpu=False, random_state=23)
-
-    def test_cg_nan(self):
-        # test issue with CG code that was causing NaN values in output:
-        # https://github.com/benfred/implicit/issues/19#issuecomment-283164905
-        raw = [
-            [0.0, 2.0, 1.5, 1.33333333, 1.25, 1.2, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-            [0.0, 0.0, 2.0, 1.5, 1.33333333, 1.25, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 2.0, 1.5, 1.33333333, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 0.0, 2.0, 1.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 1.5, 1.33333333, 1.25, 1.2],
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 1.5, 1.33333333, 1.25],
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 1.5, 1.33333333],
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 1.5],
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0],
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-        ]
-        counts = csr_matrix(raw, dtype=np.float64)
-        for use_native in (True, False):
-            model = AlternatingLeastSquares(
-                factors=3,
-                regularization=0.01,
-                dtype=np.float64,
-                use_native=use_native,
-                use_cg=True,
-                use_gpu=False,
-                random_state=23,
-            )
-            model.fit(counts, show_progress=False)
-            rows, cols = model.item_factors, model.user_factors
-
-            self.assertFalse(np.isnan(np.sum(cols)))
-            self.assertFalse(np.isnan(np.sum(rows)))
-
-    def test_cg_nan2(self):
-        # test out Nan appearing in CG code (from https://github.com/benfred/implicit/issues/106)
-        Ciu = random(
-            m=100,
-            n=100,
-            density=0.0005,
-            format="coo",
-            dtype=np.float32,
-            random_state=42,
-            data_rvs=None,
-        ).T.tocsr()
-
-        configs = [{"use_native": True, "use_gpu": False}, {"use_native": False, "use_gpu": False}]
-        if HAS_CUDA:
-            configs.append({"use_gpu": True})
-
-        for options in configs:
-            model = AlternatingLeastSquares(
-                factors=32,
-                regularization=10,
-                iterations=10,
-                dtype=np.float32,
-                random_state=23,
-                **options
-            )
-            model.fit(Ciu, show_progress=False)
-
-            item_factors, user_factors = model.item_factors, model.user_factors
-            if options["use_gpu"]:
-                item_factors, user_factors = item_factors.to_numpy(), user_factors.to_numpy()
-
-            self.assertTrue(np.isfinite(item_factors).all())
-            self.assertTrue(np.isfinite(user_factors).all())
-
-    def test_factorize(self):
-        counts = csr_matrix(
-            [
-                [1, 1, 0, 1, 0, 0],
-                [0, 1, 1, 1, 0, 0],
-                [1, 0, 1, 0, 0, 0],
-                [1, 1, 0, 0, 0, 0],
-                [0, 0, 1, 1, 0, 1],
-                [0, 1, 0, 0, 0, 1],
-                [0, 0, 0, 0, 1, 1],
-            ],
-            dtype=np.float64,
-        )
-        user_items = counts * 2
-
-        # try all 8 variants of native/python, cg/cholesky, and
-        # 64 vs 32 bit factors
-        options = [
-            (dtype, cg, native, False)
-            for dtype in (np.float32, np.float64)
-            for cg in (False, True)
-            for native in (False, True)
-        ]
-
-        # also try out GPU support if available
-        if HAS_CUDA:
-            options.append((np.float32, False, False, True))
-
-        for dtype, use_cg, use_native, use_gpu in options:
-            try:
-                model = AlternatingLeastSquares(
-                    factors=6,
-                    regularization=0,
-                    dtype=dtype,
-                    use_native=use_native,
-                    use_cg=use_cg,
-                    use_gpu=use_gpu,
-                    random_state=42,
-                )
-                model.fit(user_items, show_progress=False)
-                rows, cols = model.item_factors, model.user_factors
-
-                if use_gpu:
-                    rows, cols = rows.to_numpy(), cols.to_numpy()
-
-            except Exception as e:
-                self.fail(
-                    msg="failed to factorize matrix. Error=%s"
-                    " dtype=%s, cg=%s, native=%s gpu=%s" % (e, dtype, use_cg, use_native, use_gpu)
-                )
-
-            reconstructed = rows.dot(cols.T)
-            for i in range(counts.shape[0]):
-                for j in range(counts.shape[1]):
-                    self.assertAlmostEqual(
-                        counts[i, j],
-                        reconstructed[i, j],
-                        delta=0.0001,
-                        msg="failed to reconstruct row=%s, col=%s,"
-                        " value=%.5f, dtype=%s, cg=%s, native=%s gpu=%s"
-                        % (i, j, reconstructed[i, j], dtype, use_cg, use_native, use_gpu),
-                    )
-
-    def test_explain(self):
-        counts = csr_matrix(
-            [
-                [1, 1, 0, 1, 0, 0],
-                [0, 1, 1, 1, 0, 0],
-                [1, 4, 1, 0, 7, 0],
-                [1, 1, 0, 0, 0, 0],
-                [9, 0, 4, 1, 0, 1],
-                [0, 1, 0, 0, 0, 1],
-                [0, 0, 2, 0, 1, 1],
-            ],
-            dtype=np.float64,
-        )
-        user_items = counts * 2
-        item_users = user_items.T
-
-        model = AlternatingLeastSquares(
-            factors=4,
-            regularization=20,
-            use_native=False,
-            use_cg=False,
-            use_gpu=False,
-            iterations=100,
-            random_state=23,
-        )
-        model.fit(user_items, show_progress=False)
-
-        userid = 0
-
-        # Assert recommendation is the the same if we recompute user vectors
-        recs = model.recommend(userid, item_users, N=10)
-        recalculated_recs = model.recommend(userid, item_users, N=10, recalculate_user=True)
-        for (item1, score1), (item2, score2) in zip(recs, recalculated_recs):
-            self.assertEqual(item1, item2)
-            self.assertAlmostEqual(score1, score2, 4)
-
-        # Assert explanation makes sense
-        top_rec, score = recalculated_recs[0]
-        score_explained, contributions, W = model.explain(userid, item_users, itemid=top_rec)
-        scores = [s for _, s in contributions]
-        items = [i for i, _ in contributions]
-        self.assertAlmostEqual(score, score_explained, 4)
-        self.assertAlmostEqual(score, sum(scores), 4)
-        self.assertEqual(scores, sorted(scores, reverse=True), "Scores not in order")
-        self.assertEqual([0, 2, 3, 4], sorted(items), "Items not seen by user")
-
-        # Assert explanation with precomputed user weights is correct
-        top_score_explained, top_contributions, W = model.explain(
-            userid, item_users, itemid=top_rec, user_weights=W, N=2
-        )
-        top_scores = [s for _, s in top_contributions]
-        top_items = [i for i, _ in top_contributions]
-        self.assertEqual(2, len(top_contributions))
-        self.assertAlmostEqual(score, top_score_explained, 4)
-        self.assertEqual(scores[:2], top_scores)
-        self.assertEqual(items[:2], top_items)
-
-    def test_recommend_all(self):
-        item_users = self.get_checker_board(50)
-        user_items = item_users.T.tocsr()
-
-        model = self._get_model()
-        model.fit(item_users, show_progress=False)
-
-        recs = model.recommend_all(user_items, N=1, show_progress=False)
-        for userid in range(50):
-            self.assertEqual(len(recs[userid]), 1)
-
-            # the top item recommended should be the same as the userid:
-            # its the one withheld item for the user that is liked by
-            # all the other similar users
-            self.assertEqual(recs[userid][0], userid)
-
-        offset = 2
-        recs = model.recommend_all(
-            user_items[[2, 3, 4]], N=1, show_progress=False, users_items_offset=offset
-        )
-
-        for userid in range(2, 5):
-            self.assertEqual(len(recs[userid - offset]), 1)
-            self.assertEqual(recs[userid - offset][0], userid)
-
-        # try asking for more items than possible
-        self.assertRaises(ValueError, model.recommend_all, user_items, N=10000, show_progress=False)
-        self.assertRaises(
-            ValueError,
-            model.recommend_all,
-            user_items,
-            filter_items=list(range(10000)),
-            show_progress=False,
-        )
-
-        # filter recommended items using an additional filter list
-        recs = model.recommend_all(user_items, N=1, filter_items=[0], show_progress=False)
-        self.assertTrue(0 not in recs)
 
 
 if HAS_CUDA:
@@ -252,5 +26,213 @@ if HAS_CUDA:
             )
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.parametrize("use_native", [True, False])
+def test_cg_nan(use_native):
+    # test issue with CG code that was causing NaN values in output:
+    # https://github.com/benfred/implicit/issues/19#issuecomment-283164905
+    raw = [
+        [0.0, 2.0, 1.5, 1.33333333, 1.25, 1.2, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 2.0, 1.5, 1.33333333, 1.25, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 2.0, 1.5, 1.33333333, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 2.0, 1.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 1.5, 1.33333333, 1.25, 1.2],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 1.5, 1.33333333, 1.25],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 1.5, 1.33333333],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 1.5],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    ]
+    counts = csr_matrix(raw, dtype=np.float64)
+    model = AlternatingLeastSquares(
+        factors=3,
+        regularization=0.01,
+        dtype=np.float64,
+        use_native=use_native,
+        use_cg=True,
+        use_gpu=False,
+        random_state=23,
+    )
+    model.fit(counts, show_progress=False)
+    rows, cols = model.item_factors, model.user_factors
+
+    assert not np.isnan(np.sum(cols))
+    assert not np.isnan(np.sum(rows))
+
+
+@pytest.mark.parametrize("use_native", [True, False])
+@pytest.mark.parametrize("use_gpu", [True, False] if HAS_CUDA else [False])
+def test_cg_nan2(use_native, use_gpu):
+    # test out Nan appearing in CG code (from https://github.com/benfred/implicit/issues/106)
+    Ciu = random(
+        m=100,
+        n=100,
+        density=0.0005,
+        format="coo",
+        dtype=np.float32,
+        random_state=42,
+        data_rvs=None,
+    ).T.tocsr()
+
+    model = AlternatingLeastSquares(
+        factors=32,
+        regularization=10,
+        iterations=10,
+        dtype=np.float32,
+        random_state=23,
+        use_native=use_native,
+        use_gpu=use_gpu,
+    )
+    model.fit(Ciu, show_progress=False)
+
+    item_factors, user_factors = model.item_factors, model.user_factors
+    if use_gpu:
+        item_factors, user_factors = item_factors.to_numpy(), user_factors.to_numpy()
+
+    assert np.isfinite(item_factors).all()
+    assert np.isfinite(user_factors).all()
+
+
+@pytest.mark.parametrize("use_native", [True, False])
+@pytest.mark.parametrize("use_gpu", [True, False] if HAS_CUDA else [False])
+@pytest.mark.parametrize("use_cg", [True, False])
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_factorize(use_native, use_gpu, use_cg, dtype):
+    if use_gpu and (not use_cg or dtype != np.float32 or not use_native):
+        return
+
+    counts = csr_matrix(
+        [
+            [1, 1, 0, 1, 0, 0],
+            [0, 1, 1, 1, 0, 0],
+            [1, 0, 1, 0, 0, 0],
+            [1, 1, 0, 0, 0, 0],
+            [0, 0, 1, 1, 0, 1],
+            [0, 1, 0, 0, 0, 1],
+            [0, 0, 0, 0, 1, 1],
+        ],
+        dtype=np.float64,
+    )
+    user_items = counts * 2
+
+    model = AlternatingLeastSquares(
+        factors=6,
+        regularization=0,
+        dtype=dtype,
+        use_native=use_native,
+        use_cg=use_cg,
+        use_gpu=use_gpu,
+        random_state=42,
+    )
+    model.fit(user_items, show_progress=False)
+    rows, cols = model.item_factors, model.user_factors
+
+    if use_gpu:
+        rows, cols = rows.to_numpy(), cols.to_numpy()
+
+    reconstructed = rows.dot(cols.T)
+    for i in range(counts.shape[0]):
+        for j in range(counts.shape[1]):
+            assert pytest.approx(counts[i, j], abs=1e-4) == reconstructed[i, j], (
+                "failed to reconstruct row=%s, col=%s,"
+                " value=%.5f, dtype=%s, cg=%s, native=%s gpu=%s"
+                % (i, j, reconstructed[i, j], dtype, use_cg, use_native, use_gpu)
+            )
+
+
+def test_explain():
+    counts = csr_matrix(
+        [
+            [1, 1, 0, 1, 0, 0],
+            [0, 1, 1, 1, 0, 0],
+            [1, 4, 1, 0, 7, 0],
+            [1, 1, 0, 0, 0, 0],
+            [9, 0, 4, 1, 0, 1],
+            [0, 1, 0, 0, 0, 1],
+            [0, 0, 2, 0, 1, 1],
+        ],
+        dtype=np.float64,
+    )
+    user_items = counts * 2
+    item_users = user_items.T
+
+    model = AlternatingLeastSquares(
+        factors=4,
+        regularization=20,
+        use_native=False,
+        use_cg=False,
+        use_gpu=False,
+        iterations=100,
+        random_state=23,
+    )
+    model.fit(user_items, show_progress=False)
+
+    userid = 0
+
+    # Assert recommendation is the the same if we recompute user vectors
+    recs = model.recommend(userid, item_users, N=10)
+    recalculated_recs = model.recommend(userid, item_users, N=10, recalculate_user=True)
+    for (item1, score1), (item2, score2) in zip(recs, recalculated_recs):
+        assert item1 == item2
+        assert pytest.approx(score1, abs=1e-4) == score2
+
+    # Assert explanation makes sense
+    top_rec, score = recalculated_recs[0]
+    score_explained, contributions, W = model.explain(userid, item_users, itemid=top_rec)
+    scores = [s for _, s in contributions]
+    items = [i for i, _ in contributions]
+    assert pytest.approx(score, abs=1e-4) == score_explained
+    assert pytest.approx(score, abs=1e-4) == sum(scores)
+    assert scores == sorted(scores, reverse=True)
+
+    assert scores == sorted(scores, reverse=True), "Scores not in order"
+    assert [0, 2, 3, 4] == sorted(items), "Items not seen by user"
+
+    # Assert explanation with precomputed user weights is correct
+    top_score_explained, top_contributions, W = model.explain(
+        userid, item_users, itemid=top_rec, user_weights=W, N=2
+    )
+    top_scores = [s for _, s in top_contributions]
+    top_items = [i for i, _ in top_contributions]
+
+    assert len(top_contributions) == 2
+    assert pytest.approx(score, abs=1e-4) == top_score_explained
+    assert scores[:2] == top_scores
+    assert items[:2] == top_items
+
+
+def test_recommend_all():
+    item_users = get_checker_board(50)
+    user_items = item_users.T.tocsr()
+
+    model = AlternatingLeastSquares(factors=3, regularization=0, use_gpu=False, random_state=23)
+    model.fit(item_users, show_progress=False)
+
+    recs = model.recommend_all(user_items, N=1, show_progress=False)
+    for userid in range(50):
+        assert len(recs[userid]) == 1
+
+        # the top item recommended should be the same as the userid:
+        # its the one withheld item for the user that is liked by
+        # all the other similar users
+        assert recs[userid][0] == userid
+
+    offset = 2
+    recs = model.recommend_all(
+        user_items[[2, 3, 4]], N=1, show_progress=False, users_items_offset=offset
+    )
+
+    for userid in range(2, 5):
+        assert len(recs[userid - offset]) == 1
+        assert recs[userid - offset][0] == userid
+
+    # try asking for more items than possible
+    with pytest.raises(ValueError):
+        model.recommend_all(user_items, N=10000, show_progress=False)
+    with pytest.raises(ValueError):
+        model.recommend_all(user_items, filter_items=list(range(10000)), show_progress=False)
+
+    # filter recommended items using an additional filter list
+    recs = model.recommend_all(user_items, N=1, filter_items=[0], show_progress=False)
+    assert 0 not in recs

--- a/tests/approximate_als_test.py
+++ b/tests/approximate_als_test.py
@@ -9,7 +9,7 @@ from implicit.approximate_als import (
 )
 from implicit.gpu import HAS_CUDA
 
-from .recommender_base_test import RecommenderBaseTestMixin
+from .recommender_base_test import RecommenderBaseTestMixin, get_checker_board
 
 # don't require annoy/faiss/nmslib to be installed
 try:
@@ -86,7 +86,7 @@ try:
             def test_large_recommend(self):
                 # the GPU version of FAISS can't return more than 1K result (and will assert/exit)
                 # this tests out that we fall back in this case to the exact version and don't die
-                plays = self.get_checker_board(2048)
+                plays = get_checker_board(2048)
                 model = self._get_model()
                 model.fit(plays, show_progress=False)
 

--- a/tests/bpr_test.py
+++ b/tests/bpr_test.py
@@ -14,25 +14,27 @@ class BPRTest(unittest.TestCase, RecommenderBaseTestMixin):
             factors=3, regularization=0, use_gpu=False, random_state=42
         )
 
-    # Test issue #264 causing crashes on empty matrices
-    def test_fit_empty_matrix(self):
-        raw = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
-        return BayesianPersonalizedRanking(use_gpu=False).fit(csr_matrix(raw), show_progress=False)
-
-    # Test issue #264 causing crashes on almost empty matrices
-    def test_fit_almost_empty_matrix(self):
-        raw = [[0, 0, 0], [0, 1, 0], [0, 0, 0]]
-        return BayesianPersonalizedRanking(use_gpu=False).fit(csr_matrix(raw), show_progress=False)
-
 
 if HAS_CUDA:
 
     class BPRGPUTest(unittest.TestCase, RecommenderBaseTestMixin):
         def _get_model(self):
             return BayesianPersonalizedRanking(
-                factors=31, regularization=0, use_gpu=True, learning_rate=0.02, random_state=42
+                factors=3,
+                regularization=0,
+                use_gpu=True,
+                learning_rate=0.05,
+                random_state=42,
             )
 
 
-if __name__ == "__main__":
-    unittest.main()
+# Test issue #264 causing crashes on empty matrices
+def test_fit_empty_matrix():
+    raw = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+    return BayesianPersonalizedRanking(use_gpu=False).fit(csr_matrix(raw), show_progress=False)
+
+
+# Test issue #264 causing crashes on almost empty matrices
+def test_fit_almost_empty_matrix():
+    raw = [[0, 0, 0], [0, 1, 0], [0, 0, 0]]
+    return BayesianPersonalizedRanking(use_gpu=False).fit(csr_matrix(raw), show_progress=False)

--- a/tests/knn_test.py
+++ b/tests/knn_test.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import unittest
 
 import numpy as np
+import pytest
 from scipy.sparse import csr_matrix
 
 import implicit
@@ -25,42 +26,33 @@ class CosineTest(unittest.TestCase, RecommenderBaseTestMixin):
         return implicit.nearest_neighbours.CosineRecommender(K=50)
 
 
-class NearestNeighboursTest(unittest.TestCase):
-    def test_all_pairs_knn(self):
-        counts = csr_matrix(
-            [
-                [5, 1, 0, 9, 0, 0],
-                [0, 2, 1, 1, 0, 0],
-                [7, 0, 3, 0, 0, 0],
-                [1, 8, 0, 0, 0, 0],
-                [0, 0, 4, 4, 0, 0],
-                [0, 3, 0, 0, 0, 2],
-                [0, 0, 0, 0, 6, 0],
-            ],
-            dtype=np.float64,
+def test_all_pairs_knn():
+    counts = csr_matrix(
+        [
+            [5, 1, 0, 9, 0, 0],
+            [0, 2, 1, 1, 0, 0],
+            [7, 0, 3, 0, 0, 0],
+            [1, 8, 0, 0, 0, 0],
+            [0, 0, 4, 4, 0, 0],
+            [0, 3, 0, 0, 0, 2],
+            [0, 0, 0, 0, 6, 0],
+        ],
+        dtype=np.float64,
+    )
+    counts = implicit.nearest_neighbours.tfidf_weight(counts).tocsr()
+
+    # compute all neighbours using matrix dot product
+    all_neighbours = counts.dot(counts.T).tocsr()
+    K = 3
+    knn = implicit.nearest_neighbours.all_pairs_knn(counts, K, show_progress=False).tocsr()
+
+    for rowid in range(counts.shape[0]):
+        # make sure values match
+        for colid, data in zip(knn[rowid].indices, knn[rowid].data):
+            pytest.approx(all_neighbours[rowid, colid]) == data
+
+        # make sure top K selected
+        row = all_neighbours[rowid]
+        assert set(knn[rowid].indices) == set(
+            colid for colid, _ in sorted(zip(row.indices, row.data), key=lambda x: -x[1])[:K]
         )
-        counts = implicit.nearest_neighbours.tfidf_weight(counts).tocsr()
-
-        # compute all neighbours using matrix dot product
-        all_neighbours = counts.dot(counts.T).tocsr()
-        K = 3
-        knn = implicit.nearest_neighbours.all_pairs_knn(counts, K, show_progress=False).tocsr()
-
-        for rowid in range(counts.shape[0]):
-            # make sure values match
-            for colid, data in zip(knn[rowid].indices, knn[rowid].data):
-                self.assertAlmostEqual(all_neighbours[rowid, colid], data)
-
-            # make sure top K selected
-            row = all_neighbours[rowid]
-            self.assertEqual(
-                set(knn[rowid].indices),
-                set(
-                    colid
-                    for colid, _ in sorted(zip(row.indices, row.data), key=lambda x: -x[1])[:K]
-                ),
-            )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/lmf_test.py
+++ b/tests/lmf_test.py
@@ -10,7 +10,3 @@ class LMFTest(unittest.TestCase, RecommenderBaseTestMixin):
         return LogisticMatrixFactorization(
             factors=3, regularization=0, use_gpu=False, random_state=43
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/recommender_base_test.py
+++ b/tests/recommender_base_test.py
@@ -11,6 +11,17 @@ from implicit.evaluation import precision_at_k
 from implicit.nearest_neighbours import ItemItemRecommender
 
 
+def get_checker_board(X):
+    """Returns a 'checkerboard' matrix: where every even userid has liked
+    every even itemid and every odd userid has liked every odd itemid.
+    The diagonal is withheld for testing recommend methods"""
+    ret = np.zeros((X, X))
+    for i in range(X):
+        for j in range(i % 2, X, 2):
+            ret[i, j] = 1.0
+    return csr_matrix(ret - np.eye(X))
+
+
 class RecommenderBaseTestMixin(object):
     """Mixin to test a bunch of common functionality in models
     deriving from RecommenderBase"""
@@ -19,7 +30,7 @@ class RecommenderBaseTestMixin(object):
         raise NotImplementedError()
 
     def test_recommend(self):
-        item_users = self.get_checker_board(50)
+        item_users = get_checker_board(50)
         user_items = item_users.T.tocsr()
 
         model = self._get_model()
@@ -46,7 +57,7 @@ class RecommenderBaseTestMixin(object):
         self.assertTrue(0 not in dict(recs))
 
     def test_recalculate_user(self):
-        item_users = self.get_checker_board(50)
+        item_users = get_checker_board(50)
         user_items = item_users.T.tocsr()
 
         model = self._get_model()
@@ -73,7 +84,7 @@ class RecommenderBaseTestMixin(object):
                 pass
 
     def test_evaluation(self):
-        item_users = self.get_checker_board(50)
+        item_users = get_checker_board(50)
         user_items = item_users.T.tocsr()
 
         model = self._get_model()
@@ -92,7 +103,7 @@ class RecommenderBaseTestMixin(object):
         # calculating similar users in nearest-neighbours is not implemented yet
         if isinstance(model, ItemItemRecommender):
             return
-        model.fit(self.get_checker_board(50), show_progress=False)
+        model.fit(get_checker_board(50), show_progress=False)
         for userid in range(50):
             recs = model.similar_users(userid, N=10)
             for r, _ in recs:
@@ -100,7 +111,7 @@ class RecommenderBaseTestMixin(object):
 
     def test_similar_items(self):
         model = self._get_model()
-        model.fit(self.get_checker_board(256), show_progress=False)
+        model.fit(get_checker_board(256), show_progress=False)
         for itemid in range(50):
             recs = model.similar_items(itemid, N=10)
             for r, _ in recs:
@@ -108,7 +119,7 @@ class RecommenderBaseTestMixin(object):
 
     def test_zero_length_row(self):
         # get a matrix where a row/column is 0
-        item_users = self.get_checker_board(50).todense()
+        item_users = get_checker_board(50).todense()
         item_users[42] = 0
         item_users[:, 42] = 0
 
@@ -127,7 +138,7 @@ class RecommenderBaseTestMixin(object):
 
     def test_dtype(self):
         # models should be able to accept input of either float32 or float64
-        item_users = self.get_checker_board(50)
+        item_users = get_checker_board(50)
         model = self._get_model()
         model.fit(item_users.astype(np.float64), show_progress=False)
 
@@ -135,7 +146,7 @@ class RecommenderBaseTestMixin(object):
         model.fit(item_users.astype(np.float32), show_progress=False)
 
     def test_rank_items(self):
-        item_users = self.get_checker_board(50)
+        item_users = get_checker_board(50)
         user_items = item_users.T.tocsr()
 
         model = self._get_model()
@@ -162,7 +173,7 @@ class RecommenderBaseTestMixin(object):
                 model.rank_items(userid, user_items, wrong_item_list)
 
     def test_pickle(self):
-        item_users = self.get_checker_board(50)
+        item_users = get_checker_board(50)
         model = self._get_model()
         model.fit(item_users, show_progress=False)
 


### PR DESCRIPTION
Switch over to rely more on pytest for parameterizing tests, instead of
defining all the different parameters in a loop in the ALS tests