### PR TITLE
Make approximate nearest neighbours models composable.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 isort cpplint black pytest codespell h5py pylint
+        pip install annoy nmslib
         pip install -r requirements.txt
     - name: Lint with flake8
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 isort cpplint black pytest codespell h5py pylint
-        pip install annoy nmslib
         pip install -r requirements.txt
+    - Name: Install ANN Libraries
+      run: pip install annoy nmslib 
+      if: runner.os == 'Linux'
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 isort cpplint black pytest codespell h5py pylint
         pip install -r requirements.txt
-    - Name: Install ANN Libraries
+    - name: Install ANN Libraries
       run: pip install annoy nmslib 
       if: runner.os == 'Linux'
     - name: Lint with flake8

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,8 @@
 [MASTER]
 
-extension-pkg-whitelist=implicit.cpu._als,implicit._nearest_neighbours,implicit.gpu._cuda,implicit.cpu.bpr,implicit.cpu.topk,numpy.random.mtrand
+ignore-patterns=setup.py
+
+extension-pkg-whitelist=implicit.cpu._als,implicit._nearest_neighbours,implicit.gpu._cuda,implicit.cpu.bpr,implicit.cpu.topk,numpy.random.mtrand,nmslib,faiss
 
 [MESSAGES CONTROL]
 disable=fixme,
@@ -39,8 +41,9 @@ disable=fixme,
     no-name-in-module,
     arguments-renamed,
     import-self,
+    protected-access,
 
 [SIMILARITIES]
-min-similarity-lines=16
+min-similarity-lines=50
 ignore-docstrings=yes
 ignore-imports=yes

--- a/implicit/ann/annoy.py
+++ b/implicit/ann/annoy.py
@@ -1,0 +1,232 @@
+import logging
+
+import annoy
+import numpy as np
+
+import implicit.gpu
+from implicit.recommender_base import RecommenderBase
+from implicit.utils import _batch_call, _filter_items_from_results, augment_inner_product_matrix
+
+log = logging.getLogger("implicit")
+
+
+class AnnoyModel(RecommenderBase):
+
+    """Speeds up inference calls to MatrixFactorization models by using an
+    `Annoy <https://github.com/spotify/annoy>`_ index to calculate similar items and
+    recommend items.
+
+    Parameters
+    ----------
+    model : MatrixFactorizationBase
+        A matrix factorization model to use for the factors
+    n_trees : int, optional
+        The number of trees to use when building the Annoy index. More trees gives higher precision
+        when querying.
+    search_k : int, optional
+        Provides a way to search more trees at runtime, giving the ability to have more accurate
+        results at the cost of taking more time.
+    approximate_similar_items : bool, optional
+        whether or not to build an Annoy index for computing similar_items
+    approximate_recommend : bool, optional
+        whether or not to build an Annoy index for the recommend call
+
+    Attributes
+    ----------
+    similar_items_index : annoy.AnnoyIndex
+        Annoy index for looking up similar items in the cosine space formed by the latent
+        item_factors
+
+    recommend_index : annoy.AnnoyIndex
+        Annoy index for looking up similar items in the inner product space formed by the latent
+        item_factors
+    """
+
+    def __init__(
+        self,
+        model,
+        approximate_similar_items=True,
+        approximate_recommend=True,
+        n_trees=50,
+        search_k=-1,
+    ):
+        self.model = model
+
+        self.similar_items_index = None
+        self.recommend_index = None
+        self.max_norm = None
+
+        self.approximate_similar_items = approximate_similar_items
+        self.approximate_recommend = approximate_recommend
+
+        self.n_trees = n_trees
+        self.search_k = search_k
+
+    def fit(self, Cui, show_progress=True):
+        # train the model
+        self.model.fit(Cui, show_progress)
+
+        item_factors = self.model.item_factors
+        if implicit.gpu.HAS_CUDA and isinstance(item_factors, implicit.gpu.Matrix):
+            item_factors = item_factors.to_numpy()
+        item_factors = item_factors.astype("float32")
+
+        # build up an Annoy Index with all the item_factors (for calculating
+        # similar items)
+        if self.approximate_similar_items:
+            log.debug("Building annoy similar items index")
+
+            self.similar_items_index = annoy.AnnoyIndex(item_factors.shape[1], "angular")
+            for i, row in enumerate(item_factors):
+                self.similar_items_index.add_item(i, row)
+            self.similar_items_index.build(self.n_trees)
+
+        # build up a separate index for the inner product (for recommend
+        # methods)
+        if self.approximate_recommend:
+            log.debug("Building annoy recommendation index")
+            self.max_norm, extra = augment_inner_product_matrix(item_factors)
+            self.recommend_index = annoy.AnnoyIndex(extra.shape[1], "angular")
+            for i, row in enumerate(extra):
+                self.recommend_index.add_item(i, row)
+            self.recommend_index.build(self.n_trees)
+
+    def similar_items(
+        self, itemid, N=10, react_users=None, recalculate_item=False, filter_items=None, items=None
+    ):
+        if items is not None and self.approximate_similar_items:
+            raise NotImplementedError("using an items filter isn't supported with ANN lookup")
+
+        count = N
+        if filter_items is not None:
+            count += len(filter_items)
+
+        if not self.approximate_similar_items:
+            return self.model.similar_items(
+                itemid,
+                N,
+                react_users=react_users,
+                recalculate_item=recalculate_item,
+                filter_items=filter_items,
+                items=items,
+            )
+
+        # annoy doesn't have a batch mode we can use
+        if not np.isscalar(itemid):
+            return _batch_call(
+                self.similar_items,
+                itemid,
+                N=N,
+                react_users=react_users,
+                recalculate_item=recalculate_item,
+                filter_items=filter_items,
+            )
+
+        # support recalculate_item if possible. TODO: refactor this
+        if hasattr(self.model, "_item_factor"):
+            factor = self.model._item_factor(
+                itemid, react_users, recalculate_item
+            )  # pylint: disable=protected-access
+        elif recalculate_item:
+            raise NotImplementedError(f"recalculate_item isn't supported with {self.model}")
+        else:
+            factor = self.model.item_factors[itemid]
+            if implicit.gpu.HAS_CUDA and isinstance(factor, implicit.gpu.Matrix):
+                factor = factor.to_numpy()
+
+        if len(factor.shape) != 1:
+            factor = factor.squeeze()
+
+        ids, scores = self.similar_items_index.get_nns_by_vector(
+            factor, N, search_k=self.search_k, include_distances=True
+        )
+        ids, scores = np.array(ids), np.array(scores)
+
+        if filter_items is not None:
+            ids, scores = _filter_items_from_results(itemid, ids, scores, filter_items, N)
+
+        return ids, 1 - (scores ** 2) / 2
+
+    def recommend(
+        self,
+        userid,
+        user_items,
+        N=10,
+        filter_already_liked_items=True,
+        filter_items=None,
+        recalculate_user=False,
+        items=None,
+    ):
+        if items is not None and self.approximate_recommend:
+            raise NotImplementedError("using a 'items' list with ANN search isn't supported")
+
+        if not self.approximate_recommend:
+            return self.model.recommend(
+                userid,
+                user_items,
+                N=N,
+                filter_already_liked_items=filter_already_liked_items,
+                filter_items=filter_items,
+                recalculate_user=recalculate_user,
+                items=items,
+            )
+
+        # batch computation isn't supported by annoy, fallback to looping over items
+        if not np.isscalar(userid):
+            return _batch_call(
+                self.recommend,
+                userid,
+                user_items=user_items,
+                N=N,
+                filter_already_liked_items=filter_already_liked_items,
+                filter_items=filter_items,
+                recalculate_user=recalculate_user,
+                items=items,
+            )
+
+        # support recalculate_user if possible (TODO: come back to this since its a bit of a hack)
+        if hasattr(self.model, "+_user_factor"):
+            user = self.model._user_factor(
+                userid, user_items, recalculate_user
+            )  # pylint: disable=protected-access
+        elif recalculate_user:
+            raise NotImplementedError(f"recalculate_user isn't supported with {self.model}")
+        else:
+            user = self.model.user_factors[userid]
+            if implicit.gpu.HAS_CUDA and isinstance(user, implicit.gpu.Matrix):
+                user = user.to_numpy()
+
+        # calculate the top N items, removing the users own liked items from
+        # the results
+        count = N
+        if filter_items:
+            count += len(filter_items)
+            filter_items = np.array(filter_items)
+
+        if filter_already_liked_items:
+            user_likes = user_items[userid].indices
+            filter_items = (
+                np.append(filter_items, user_likes) if filter_items is not None else user_likes
+            )
+            count += len(user_likes)
+
+        query = np.append(user, 0)
+        ids, scores = self.recommend_index.get_nns_by_vector(
+            query, count, include_distances=True, search_k=self.search_k
+        )
+        ids, scores = np.array(ids), np.array(scores)
+
+        if filter_items is not None:
+            ids, scores = _filter_items_from_results(userid, ids, scores, filter_items, N)
+
+        # convert the distances from euclidean to cosine distance,
+        # and then rescale the cosine distance to go back to inner product
+        scaling = self.max_norm * np.linalg.norm(query)
+        scores = scaling * (1 - (scores ** 2) / 2)
+        return ids, scores
+
+    def similar_users(self, userid, N=10, filter_users=None, users=None):
+        raise NotImplementedError(
+            "similar_users isn't implemented with Annoy yet. (note: you can call "
+            " self.model.similar_models to get the same functionality on the inner model class)"
+        )

--- a/implicit/ann/faiss.py
+++ b/implicit/ann/faiss.py
@@ -1,0 +1,276 @@
+import logging
+import warnings
+
+import faiss
+import numpy as np
+
+import implicit.gpu
+from implicit.recommender_base import RecommenderBase
+from implicit.utils import _batch_call, _filter_items_from_results
+
+log = logging.getLogger("implicit")
+
+
+# pylint:  disable=no-value-for-parameter
+
+
+class FaissModel(RecommenderBase):
+    """
+    Speeds up inference calls to MatrixFactorization models by using
+    `Faiss <https://github.com/facebookresearch/faiss>`_ to create approximate nearest neighbours
+    indices of the latent factors.
+
+    Parameters
+    ----------
+    model : MatrixFactorizationBase
+        A matrix factorization model to use for the factors
+    nlist : int, optional
+        The number of cells to use when building the Faiss index.
+    nprobe : int, optional
+        The number of cells to visit to perform a search.
+    use_gpu : bool, optional
+        Whether or not to enable run Faiss on the GPU. Requires faiss to have been
+        built with GPU support.
+    approximate_similar_items : bool, optional
+        whether or not to build an Faiss index for computing similar_items
+    approximate_recommend : bool, optional
+        whether or not to build an Faiss index for the recommend call
+
+    Attributes
+    ----------
+    similar_items_index : faiss.IndexIVFFlat
+        Faiss index for looking up similar items in the cosine space formed by the latent
+        item_factors
+
+    recommend_index : faiss.IndexIVFFlat
+        Faiss index for looking up similar items in the inner product space formed by the latent
+        item_factors
+    """
+
+    def __init__(
+        self,
+        model,
+        approximate_similar_items=True,
+        approximate_recommend=True,
+        nlist=400,
+        nprobe=20,
+        use_gpu=implicit.gpu.HAS_CUDA,
+    ):
+        self.model = model
+        self.similar_items_index = None
+        self.recommend_index = None
+        self.quantizer = None
+        self.gpu_resources = None
+        self.factors = None
+
+        self.approximate_similar_items = approximate_similar_items
+        self.approximate_recommend = approximate_recommend
+
+        # hyper-parameters for FAISS
+        self.nlist = nlist
+        self.nprobe = nprobe
+        self.use_gpu = use_gpu
+        super().__init__()
+
+    def fit(self, Cui, show_progress=True):
+        self.model.fit(Cui, show_progress)
+
+        item_factors = self.model.item_factors
+        if implicit.gpu.HAS_CUDA and isinstance(item_factors, implicit.gpu.Matrix):
+            item_factors = item_factors.to_numpy()
+        item_factors = item_factors.astype("float32")
+
+        self.factors = item_factors.shape[1]
+
+        self.quantizer = faiss.IndexFlat(self.factors)
+
+        if self.use_gpu:
+            self.gpu_resources = faiss.StandardGpuResources()
+
+        if self.approximate_recommend:
+            log.debug("Building faiss recommendation index")
+
+            # build up a inner product index here
+            if self.use_gpu:
+                index = faiss.GpuIndexIVFFlat(
+                    self.gpu_resources, self.factors, self.nlist, faiss.METRIC_INNER_PRODUCT
+                )
+            else:
+                index = faiss.IndexIVFFlat(
+                    self.quantizer, self.factors, self.nlist, faiss.METRIC_INNER_PRODUCT
+                )
+
+            index.train(item_factors)
+            index.add(item_factors)
+            index.nprobe = self.nprobe
+            self.recommend_index = index
+
+        if self.approximate_similar_items:
+            log.debug("Building faiss similar items index")
+
+            # likewise build up cosine index for similar_items, using an inner product
+            # index on normalized vectors`
+            norms = np.linalg.norm(item_factors, axis=1)
+            norms[norms == 0] = 1e-10
+
+            normalized = (item_factors.T / norms).T.astype("float32")
+            if self.use_gpu:
+                index = faiss.GpuIndexIVFFlat(
+                    self.gpu_resources, self.factors, self.nlist, faiss.METRIC_INNER_PRODUCT
+                )
+            else:
+                index = faiss.IndexIVFFlat(
+                    self.quantizer, self.factors, self.nlist, faiss.METRIC_INNER_PRODUCT
+                )
+
+            index.train(normalized)
+            index.add(normalized)
+            index.nprobe = self.nprobe
+            self.similar_items_index = index
+
+    def similar_items(
+        self, itemid, N=10, react_users=None, recalculate_item=False, filter_items=None, items=None
+    ):
+        if items is not None and self.approximate_similar_items:
+            raise NotImplementedError("using an items filter isn't supported with ANN lookup")
+
+        count = N
+        if filter_items is not None:
+            count += len(filter_items)
+
+        if not self.approximate_similar_items or (self.use_gpu and count >= 1024):
+            return self.model.similar_items(
+                itemid,
+                N,
+                react_users=react_users,
+                recalculate_item=recalculate_item,
+                filter_items=filter_items,
+                items=items,
+            )
+
+        # support recalculate_item if possible. TODO: refactor this
+        if hasattr(self.model, "_item_factor"):
+            factors = self.model._item_factor(
+                itemid, react_users, recalculate_item
+            )  # pylint: disable=protected-access
+        elif recalculate_item:
+            raise NotImplementedError(f"recalculate_item isn't supported with {self.model}")
+        else:
+            factors = self.model.item_factors[itemid]
+            if implicit.gpu.HAS_CUDA and isinstance(factors, implicit.gpu.Matrix):
+                factors = factors.to_numpy()
+
+        if np.isscalar(itemid):
+            factors /= np.linalg.norm(factors)
+            factors = factors.reshape(1, -1)
+        else:
+            factors /= np.linalg.norm(factors, axis=1)[:, None]
+
+        scores, ids = self.similar_items_index.search(factors.astype("float32"), count)
+
+        if np.isscalar(itemid):
+            ids, scores = ids[0], scores[0]
+
+        if filter_items is not None:
+            ids, scores = _filter_items_from_results(itemid, ids, scores, filter_items, N)
+
+        return ids, scores
+
+    def recommend(
+        self,
+        userid,
+        user_items,
+        N=10,
+        filter_already_liked_items=True,
+        filter_items=None,
+        recalculate_user=False,
+        items=None,
+    ):
+        if items is not None and self.approximate_recommend:
+            raise NotImplementedError("using a 'items' list with ANN search isn't supported")
+
+        # batch computation is tricky with filter_already_liked_items (requires querying a
+        # different number of rows per user). Instead just fallback to a faiss query per user
+        if filter_already_liked_items and not np.isscalar(userid):
+            return _batch_call(
+                self.recommend,
+                userid,
+                user_items=user_items,
+                N=N,
+                filter_already_liked_items=filter_already_liked_items,
+                filter_items=filter_items,
+                recalculate_user=recalculate_user,
+                items=items,
+            )
+
+        if not self.approximate_recommend:
+            warnings.warning("Calling recommend on a FaissModel with approximate_recommend=False")
+            return self.model.recommend(
+                userid,
+                user_items,
+                N=N,
+                filter_already_liked_items=filter_already_liked_items,
+                filter_items=filter_items,
+                recalculate_user=recalculate_user,
+                items=items,
+            )
+
+        # support recalculate_user if possible (TODO: come back to this since its a bit of a hack)
+        if hasattr(self.model, "+_user_factor"):
+            user = self.model._user_factor(
+                userid, user_items, recalculate_user
+            )  # pylint: disable=protected-access
+        elif recalculate_user:
+            raise NotImplementedError(f"recalculate_user isn't supported with {self.model}")
+        else:
+            user = self.model.user_factors[userid]
+            if implicit.gpu.HAS_CUDA and isinstance(user, implicit.gpu.Matrix):
+                user = user.to_numpy()
+
+        # calculate the top N items, removing the users own liked items from
+        # the results
+        count = N
+        if filter_items:
+            count += len(filter_items)
+            filter_items = np.array(filter_items)
+
+        if filter_already_liked_items:
+            user_likes = user_items[userid].indices
+            filter_items = (
+                np.append(filter_items, user_likes) if filter_items is not None else user_likes
+            )
+            count += len(user_likes)
+
+        # the GPU variant of faiss doesn't support returning more than 1024 results.
+        # fall back to the exact match when this happens
+        if self.use_gpu and count >= 1024:
+            return self.model.recommend(
+                userid,
+                user_items,
+                N=N,
+                filter_already_liked_items=filter_already_liked_items,
+                filter_items=filter_items,
+                recalculate_user=recalculate_user,
+                items=items,
+            )
+
+        if np.isscalar(userid):
+            query = user.reshape(1, -1).astype("float32")
+        else:
+            query = user.astype("float32")
+
+        scores, ids = self.recommend_index.search(query, count)
+
+        if np.isscalar(userid):
+            ids, scores = ids[0], scores[0]
+
+        if filter_items is not None:
+            ids, scores = _filter_items_from_results(userid, ids, scores, filter_items, N)
+
+        return ids, scores
+
+    def similar_users(self, userid, N=10, filter_users=None, users=None):
+        raise NotImplementedError(
+            "similar_users isn't implemented with Faiss yet. (note: you can call "
+            " self.model.similar_models to get the same functionality on the inner model class)"
+        )

--- a/implicit/ann/nmslib.py
+++ b/implicit/ann/nmslib.py
@@ -1,0 +1,235 @@
+import logging
+
+import nmslib
+import numpy as np
+
+import implicit.gpu
+from implicit.recommender_base import RecommenderBase
+from implicit.utils import _batch_call, _filter_items_from_results, augment_inner_product_matrix
+
+log = logging.getLogger("implicit")
+
+
+class NMSLibModel(RecommenderBase):
+
+    """Speeds up inference calls to MatrixFactorization models by using
+    `NMSLib <https://github.com/nmslib/nmslib>`_ to create approximate nearest neighbours
+    indices of the latent factors.
+
+    Parameters
+    ----------
+    model : MatrixFactorizationBase
+        A matrix factorization model to use for the factors
+    method : str, optional
+        The NMSLib method to use
+    index_params: dict, optional
+        Optional params to send to the createIndex call in NMSLib
+    query_params: dict, optional
+        Optional query time params for the NMSLib 'setQueryTimeParams' call
+    approximate_similar_items : bool, optional
+        whether or not to build an NMSLIB index for computing similar_items
+    approximate_recommend : bool, optional
+        whether or not to build an NMSLIB index for the recommend call
+
+    Attributes
+    ----------
+    similar_items_index : nmslib.FloatIndex
+        NMSLib index for looking up similar items in the cosine space formed by the latent
+        item_factors
+
+    recommend_index : nmslib.FloatIndex
+        NMSLib index for looking up similar items in the inner product space formed by the latent
+        item_factors
+    """
+
+    def __init__(
+        self,
+        model,
+        approximate_similar_items=True,
+        approximate_recommend=True,
+        method="hnsw",
+        index_params=None,
+        query_params=None,
+        **kwargs,
+    ):
+        self.model = model
+        if index_params is None:
+            index_params = {"M": 16, "post": 0, "efConstruction": 400}
+        if query_params is None:
+            query_params = {"ef": 90}
+
+        self.similar_items_index = None
+        self.recommend_index = None
+
+        self.approximate_similar_items = approximate_similar_items
+        self.approximate_recommend = approximate_recommend
+        self.method = method
+
+        self.index_params = index_params
+        self.query_params = query_params
+
+        self.max_norm = None
+
+    def fit(self, Cui, show_progress=True):
+        # nmslib can be a little chatty when first imported, disable some of
+        # the logging
+        logging.getLogger("nmslib").setLevel(logging.WARNING)
+
+        # train the model
+        self.model.fit(Cui, show_progress)
+        item_factors = self.model.item_factors
+        if implicit.gpu.HAS_CUDA and isinstance(item_factors, implicit.gpu.Matrix):
+            item_factors = item_factors.to_numpy()
+
+        # create index for similar_items
+        if self.approximate_similar_items:
+            log.debug("Building nmslib similar items index")
+            self.similar_items_index = nmslib.init(method=self.method, space="cosinesimil")
+
+            # there are some numerical instability issues here with
+            # building a cosine index with vectors with 0 norms, hack around this
+            # by just not indexing them
+            norms = np.linalg.norm(item_factors, axis=1)
+            ids = np.arange(item_factors.shape[0])
+
+            # delete zero valued rows from the matrix
+            nonzero_item_factors = np.delete(item_factors, ids[norms == 0], axis=0)
+            ids = ids[norms != 0]
+
+            self.similar_items_index.addDataPointBatch(nonzero_item_factors, ids=ids)
+            self.similar_items_index.createIndex(self.index_params, print_progress=show_progress)
+            self.similar_items_index.setQueryTimeParams(self.query_params)
+
+        # build up a separate index for the inner product (for recommend
+        # methods)
+        if self.approximate_recommend:
+            log.debug("Building nmslib recommendation index")
+            self.max_norm, extra = augment_inner_product_matrix(item_factors)
+            self.recommend_index = nmslib.init(method="hnsw", space="cosinesimil")
+            self.recommend_index.addDataPointBatch(extra)
+            self.recommend_index.createIndex(self.index_params, print_progress=show_progress)
+            self.recommend_index.setQueryTimeParams(self.query_params)
+
+    def similar_items(
+        self, itemid, N=10, react_users=None, recalculate_item=False, filter_items=None, items=None
+    ):
+        if not self.approximate_similar_items:
+            return self.model.similar_items(
+                itemid,
+                N,
+                react_users=react_users,
+                recalculate_item=recalculate_item,
+                filter_items=filter_items,
+                items=items,
+            )
+
+        if items is not None:
+            raise NotImplementedError("using an items filter isn't supported with ANN lookup")
+
+        # support recalculate_item if possible. TODO: refactor this
+        if hasattr(self.model, "_item_factor"):
+            factors = self.model._item_factor(
+                itemid, react_users, recalculate_item
+            )  # pylint: disable=protected-access
+        elif recalculate_item:
+            raise NotImplementedError(f"recalculate_item isn't supported with {self.model}")
+        else:
+            factors = self.model.item_factors[itemid]
+            if implicit.gpu.HAS_CUDA and isinstance(factors, implicit.gpu.Matrix):
+                factors = factors.to_numpy()
+
+        count = N
+        if filter_items is not None:
+            count += len(filter_items)
+
+        if np.isscalar(itemid):
+            ids, scores = self.similar_items_index.knnQuery(factors, count)
+        else:
+            results = self.similar_items_index.knnQueryBatch(factors, count)
+            ids = np.stack([result[0] for result in results])
+            scores = np.stack([result[1] for result in results])
+
+        scores = 1.0 - scores
+        if filter_items is not None:
+            ids, scores = _filter_items_from_results(itemid, ids, scores, filter_items, N)
+
+        return ids, scores
+
+    def recommend(
+        self,
+        userid,
+        user_items,
+        N=10,
+        filter_already_liked_items=True,
+        filter_items=None,
+        recalculate_user=False,
+        items=None,
+    ):
+        if items is not None and self.approximate_recommend:
+            raise NotImplementedError("using a 'items' list with ANN search isn't supported")
+
+        if not self.approximate_recommend:
+            return self.model.recommend(
+                userid,
+                user_items,
+                N=N,
+                filter_already_liked_items=filter_already_liked_items,
+                filter_items=filter_items,
+                recalculate_user=recalculate_user,
+                items=items,
+            )
+
+        # batch computation is hard here, fallback to looping over items
+        if not np.isscalar(userid):
+            return _batch_call(
+                self.recommend,
+                userid,
+                user_items=user_items,
+                N=N,
+                filter_already_liked_items=filter_already_liked_items,
+                filter_items=filter_items,
+                recalculate_user=recalculate_user,
+                items=items,
+            )
+
+        # support recalculate_user if possible (TODO: come back to this since its a bit of a hack)
+        if hasattr(self.model, "+_user_factor"):
+            user = self.model._user_factor(
+                userid, user_items, recalculate_user
+            )  # pylint: disable=protected-access
+        elif recalculate_user:
+            raise NotImplementedError(f"recalculate_user isn't supported with {self.model}")
+        else:
+            user = self.model.user_factors[userid]
+            if implicit.gpu.HAS_CUDA and isinstance(user, implicit.gpu.Matrix):
+                user = user.to_numpy()
+
+        # calculate the top N items, removing the users own liked items from
+        # the results
+        count = N
+        if filter_items:
+            count += len(filter_items)
+            filter_items = np.array(filter_items)
+
+        if filter_already_liked_items:
+            user_likes = user_items[userid].indices
+            filter_items = (
+                np.append(filter_items, user_likes) if filter_items is not None else user_likes
+            )
+            count += len(user_likes)
+
+        query = np.append(user, 0)
+        ids, scores = self.recommend_index.knnQuery(query, count)
+        scaling = self.max_norm * np.linalg.norm(query)
+        scores = scaling * (1.0 - (scores))
+
+        if filter_items is not None:
+            ids, scores = _filter_items_from_results(userid, ids, scores, filter_items, N)
+
+        return ids, scores
+
+    def similar_users(self, userid, N=10, filter_users=None, users=None):
+        raise NotImplementedError(
+            "similar_users isn't implemented with NMSLib yet. (note: you can call "
+            " self.model.similar_models to get the same functionality on the inner model class)"
+        )

--- a/implicit/approximate_als.py
+++ b/implicit/approximate_als.py
@@ -3,676 +3,74 @@ generate recommendations and lists of similar items.
 
 See http://www.benfrederickson.com/approximate-nearest-neighbours-for-recommender-systems/
 """
-import logging
-
-import numpy as np
-
 import implicit.gpu
-from implicit.cpu.als import AlternatingLeastSquares
 
-from .utils import _batch_call
 
-log = logging.getLogger("implicit")
-
-
-def augment_inner_product_matrix(factors):
-    """This function transforms a factor matrix such that an angular nearest neighbours search
-    will return top related items of the inner product.
-
-    This involves transforming each row by adding one extra dimension as suggested in the paper:
-    "Speeding Up the Xbox Recommender System Using a Euclidean Transformation for Inner-Product
-    Spaces" https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/XboxInnerProduct.pdf
-
-    Basically this involves transforming each feature vector so that they have the same norm, which
-    means the cosine of this transformed vector is proportional to the dot product (if the other
-    vector in the cosine has a 0 in the extra dimension)."""
-    norms = np.linalg.norm(factors, axis=1)
-    max_norm = norms.max()
-
-    # add an extra dimension so that the norm of each row is the same
-    # (max_norm)
-    extra_dimension = np.sqrt(max_norm ** 2 - norms ** 2)
-    return max_norm, np.append(factors, extra_dimension.reshape(norms.shape[0], 1), axis=1)
-
-
-class NMSLibAlternatingLeastSquares(AlternatingLeastSquares):
-
-    """Speeds up the base :class:`~implicit.als.AlternatingLeastSquares` model by using
-    `NMSLib <https://github.com/searchivarius/nmslib>`_ to create approximate nearest neighbours
-    indices of the latent factors.
-
-    Parameters
-    ----------
-    method : str, optional
-        The NMSLib method to use
-    index_params: dict, optional
-        Optional params to send to the createIndex call in NMSLib
-    query_params: dict, optional
-        Optional query time params for the NMSLib 'setQueryTimeParams' call
-    approximate_similar_items : bool, optional
-        whether or not to build an NMSLIB index for computing similar_items
-    approximate_recommend : bool, optional
-        whether or not to build an NMSLIB index for the recommend call
-    random_state : int, RandomState or None, optional
-        The random state for seeding the initial item and user factors.
-        Default is None.
-
-    Attributes
-    ----------
-    similar_items_index : nmslib.FloatIndex
-        NMSLib index for looking up similar items in the cosine space formed by the latent
-        item_factors
-
-    recommend_index : nmslib.FloatIndex
-        NMSLib index for looking up similar items in the inner product space formed by the latent
-        item_factors
-    """
-
-    def __init__(
-        self,
-        *args,
-        approximate_similar_items=True,
-        approximate_recommend=True,
-        method="hnsw",
-        index_params=None,
-        query_params=None,
-        random_state=None,
-        **kwargs
-    ):
-        if index_params is None:
-            index_params = {"M": 16, "post": 0, "efConstruction": 400}
-        if query_params is None:
-            query_params = {"ef": 90}
-
-        self.similar_items_index = None
-        self.recommend_index = None
-
-        self.approximate_similar_items = approximate_similar_items
-        self.approximate_recommend = approximate_recommend
-        self.method = method
-
-        self.index_params = index_params
-        self.query_params = query_params
-
-        self.max_norm = None
-
-        super().__init__(*args, random_state=random_state, **kwargs)
-
-    def fit(self, Cui, show_progress=True):
-        # nmslib can be a little chatty when first imported, disable some of
-        # the logging
-        logging.getLogger("nmslib").setLevel(logging.WARNING)
-        import nmslib
-
-        # train the model
-        super().fit(Cui, show_progress)
-
-        # create index for similar_items
-        if self.approximate_similar_items:
-            log.debug("Building nmslib similar items index")
-            self.similar_items_index = nmslib.init(method=self.method, space="cosinesimil")
-
-            # there are some numerical instability issues here with
-            # building a cosine index with vectors with 0 norms, hack around this
-            # by just not indexing them
-            norms = np.linalg.norm(self.item_factors, axis=1)
-            ids = np.arange(self.item_factors.shape[0])
-
-            # delete zero valued rows from the matrix
-            item_factors = np.delete(self.item_factors, ids[norms == 0], axis=0)
-            ids = ids[norms != 0]
-
-            self.similar_items_index.addDataPointBatch(item_factors, ids=ids)
-            self.similar_items_index.createIndex(self.index_params, print_progress=show_progress)
-            self.similar_items_index.setQueryTimeParams(self.query_params)
-
-        # build up a separate index for the inner product (for recommend
-        # methods)
-        if self.approximate_recommend:
-            log.debug("Building nmslib recommendation index")
-            self.max_norm, extra = augment_inner_product_matrix(self.item_factors)
-            self.recommend_index = nmslib.init(method="hnsw", space="cosinesimil")
-            self.recommend_index.addDataPointBatch(extra)
-            self.recommend_index.createIndex(self.index_params, print_progress=show_progress)
-            self.recommend_index.setQueryTimeParams(self.query_params)
-
-    def similar_items(
-        self, itemid, N=10, react_users=None, recalculate_item=False, filter_items=None, items=None
-    ):
-        if not self.approximate_similar_items:
-            return super().similar_items(
-                itemid,
-                N,
-                react_users=react_users,
-                recalculate_item=recalculate_item,
-                filter_items=filter_items,
-                items=items,
-            )
-
-        if items is not None:
-            raise NotImplementedError("using an items filter isn't supported with ANN lookup")
-
-        factors = self._item_factor(itemid, react_users, recalculate_item)
-        count = N
-        if filter_items is not None:
-            count += len(filter_items)
-
-        if np.isscalar(itemid):
-            ids, scores = self.similar_items_index.knnQuery(factors, count)
-        else:
-            results = self.similar_items_index.knnQueryBatch(factors, count)
-            ids = np.stack([result[0] for result in results])
-            scores = np.stack([result[1] for result in results])
-
-        scores = 1.0 - scores
-        if filter_items is not None:
-            ids, scores = _filter_items_from_results(itemid, ids, scores, filter_items, N)
-
-        return ids, scores
-
-    def recommend(
-        self,
-        userid,
-        user_items,
-        N=10,
-        filter_already_liked_items=True,
-        filter_items=None,
-        recalculate_user=False,
-        items=None,
-    ):
-        if items and self.approximate_recommend:
-            raise NotImplementedError("using a 'items' list with ANN search isn't supported")
-
-        if not self.approximate_recommend:
-            return super().recommend(
-                userid,
-                user_items,
-                N=N,
-                filter_already_liked_items=filter_already_liked_items,
-                filter_items=filter_items,
-                recalculate_user=recalculate_user,
-                items=items,
-            )
-
-        # batch computation is hard here, fallback to looping over items
-        if not np.isscalar(userid):
-            return _batch_call(
-                self.recommend,
-                userid,
-                user_items=user_items,
-                N=N,
-                filter_already_liked_items=filter_already_liked_items,
-                filter_items=filter_items,
-                recalculate_user=recalculate_user,
-                items=items,
-            )
-
-        user = self._user_factor(userid, user_items, recalculate_user)
-
-        # calculate the top N items, removing the users own liked items from
-        # the results
-        count = N
-        if filter_items:
-            count += len(filter_items)
-            filter_items = np.array(filter_items)
-
-        if filter_already_liked_items:
-            user_likes = user_items[userid].indices
-            filter_items = (
-                np.append(filter_items, user_likes) if filter_items is not None else user_likes
-            )
-            count += len(user_likes)
-
-        query = np.append(user, 0)
-        ids, scores = self.recommend_index.knnQuery(query, count)
-        scaling = self.max_norm * np.linalg.norm(query)
-        scores = scaling * (1.0 - (scores))
-
-        if filter_items is not None:
-            ids, scores = _filter_items_from_results(userid, ids, scores, filter_items, N)
-
-        return ids, scores
-
-
-class AnnoyAlternatingLeastSquares(AlternatingLeastSquares):
-
-    """A version of the :class:`~implicit.als.AlternatingLeastSquares` model that uses an
-    `Annoy <https://github.com/spotify/annoy>`_ index to calculate similar items and
-    recommend items.
-
-    Parameters
-    ----------
-    n_trees : int, optional
-        The number of trees to use when building the Annoy index. More trees gives higher precision
-        when querying.
-    search_k : int, optional
-        Provides a way to search more trees at runtime, giving the ability to have more accurate
-        results at the cost of taking more time.
-    approximate_similar_items : bool, optional
-        whether or not to build an Annoy index for computing similar_items
-    approximate_recommend : bool, optional
-        whether or not to build an Annoy index for the recommend call
-    random_state : int, RandomState or None, optional
-        The random state for seeding the initial item and user factors.
-        Default is None.
-
-    Attributes
-    ----------
-    similar_items_index : annoy.AnnoyIndex
-        Annoy index for looking up similar items in the cosine space formed by the latent
-        item_factors
-
-    recommend_index : annoy.AnnoyIndex
-        Annoy index for looking up similar items in the inner product space formed by the latent
-        item_factors
-    """
-
-    def __init__(
-        self,
-        *args,
-        approximate_similar_items=True,
-        approximate_recommend=True,
-        n_trees=50,
-        search_k=-1,
-        random_state=None,
-        **kwargs
-    ):
-
-        super().__init__(*args, random_state=random_state, **kwargs)
-
-        self.similar_items_index = None
-        self.recommend_index = None
-        self.max_norm = None
-
-        self.approximate_similar_items = approximate_similar_items
-        self.approximate_recommend = approximate_recommend
-
-        self.n_trees = n_trees
-        self.search_k = search_k
-
-    def fit(self, Cui, show_progress=True):
-        # delay loading the annoy library in case its not installed here
-        import annoy
-
-        # train the model
-        super().fit(Cui, show_progress)
-
-        # build up an Annoy Index with all the item_factors (for calculating
-        # similar items)
-        if self.approximate_similar_items:
-            log.debug("Building annoy similar items index")
-
-            self.similar_items_index = annoy.AnnoyIndex(self.item_factors.shape[1], "angular")
-            for i, row in enumerate(self.item_factors):
-                self.similar_items_index.add_item(i, row)
-            self.similar_items_index.build(self.n_trees)
-
-        # build up a separate index for the inner product (for recommend
-        # methods)
-        if self.approximate_recommend:
-            log.debug("Building annoy recommendation index")
-            self.max_norm, extra = augment_inner_product_matrix(self.item_factors)
-            self.recommend_index = annoy.AnnoyIndex(extra.shape[1], "angular")
-            for i, row in enumerate(extra):
-                self.recommend_index.add_item(i, row)
-            self.recommend_index.build(self.n_trees)
-
-    def similar_items(
-        self, itemid, N=10, react_users=None, recalculate_item=False, filter_items=None, items=None
-    ):
-        if items is not None and self.approximate_similar_items:
-            raise NotImplementedError("using an items filter isn't supported with ANN lookup")
-
-        count = N
-        if filter_items is not None:
-            count += len(filter_items)
-
-        if not self.approximate_similar_items:
-            return super().similar_items(
-                itemid,
-                N,
-                react_users=react_users,
-                recalculate_item=recalculate_item,
-                filter_items=filter_items,
-                items=items,
-            )
-
-        # annoy doesn't have a batch mode we can use
-        if not np.isscalar(itemid):
-            return _batch_call(
-                self.similar_items,
-                itemid,
-                N=N,
-                react_users=react_users,
-                recalculate_item=recalculate_item,
-                filter_items=filter_items,
-            )
-
-        factor = self._item_factor(itemid, react_users, recalculate_item)
-
-        ids, scores = self.similar_items_index.get_nns_by_vector(
-            factor, N, search_k=self.search_k, include_distances=True
-        )
-        ids, scores = np.array(ids), np.array(scores)
-
-        if filter_items is not None:
-            ids, scores = _filter_items_from_results(itemid, ids, scores, filter_items, N)
-
-        return ids, 1 - (scores ** 2) / 2
-
-    def recommend(
-        self,
-        userid,
-        user_items,
-        N=10,
-        filter_already_liked_items=True,
-        filter_items=None,
-        recalculate_user=False,
-        items=None,
-    ):
-        if items and self.approximate_recommend:
-            raise NotImplementedError("using a 'items' list with ANN search isn't supported")
-
-        if not self.approximate_recommend:
-            return super().recommend(
-                userid,
-                user_items,
-                N=N,
-                filter_already_liked_items=filter_already_liked_items,
-                filter_items=filter_items,
-                recalculate_user=recalculate_user,
-                items=items,
-            )
-
-        # batch computation isn't supported by annoy, fallback to looping over items
-        if not np.isscalar(userid):
-            return _batch_call(
-                self.recommend,
-                userid,
-                user_items=user_items,
-                N=N,
-                filter_already_liked_items=filter_already_liked_items,
-                filter_items=filter_items,
-                recalculate_user=recalculate_user,
-                items=items,
-            )
-        user = self._user_factor(userid, user_items, recalculate_user)
-
-        # calculate the top N items, removing the users own liked items from
-        # the results
-        count = N
-        if filter_items:
-            count += len(filter_items)
-            filter_items = np.array(filter_items)
-
-        if filter_already_liked_items:
-            user_likes = user_items[userid].indices
-            filter_items = (
-                np.append(filter_items, user_likes) if filter_items is not None else user_likes
-            )
-            count += len(user_likes)
-
-        query = np.append(user, 0)
-        ids, scores = self.recommend_index.get_nns_by_vector(
-            query, count, include_distances=True, search_k=self.search_k
-        )
-        ids, scores = np.array(ids), np.array(scores)
-
-        if filter_items is not None:
-            ids, scores = _filter_items_from_results(userid, ids, scores, filter_items, N)
-
-        # convert the distances from euclidean to cosine distance,
-        # and then rescale the cosine distance to go back to inner product
-        scaling = self.max_norm * np.linalg.norm(query)
-        scores = scaling * (1 - (scores ** 2) / 2)
-        return ids, scores
-
-
-class FaissAlternatingLeastSquares(AlternatingLeastSquares):
-
-    """Speeds up the base :class:`~implicit.als.AlternatingLeastSquares` model by using
-    `Faiss <https://github.com/facebookresearch/faiss>`_ to create approximate nearest neighbours
-    indices of the latent factors.
-
-
-    Parameters
-    ----------
-    nlist : int, optional
-        The number of cells to use when building the Faiss index.
-    nprobe : int, optional
-        The number of cells to visit to perform a search.
-    use_gpu : bool, optional
-        Whether or not to enable run Faiss on the GPU. Requires faiss to have been
-        built with GPU support.
-    approximate_similar_items : bool, optional
-        whether or not to build an Faiss index for computing similar_items
-    approximate_recommend : bool, optional
-        whether or not to build an Faiss index for the recommend call
-    random_state : int, RandomState or None, optional
-        The random state for seeding the initial item and user factors.
-        Default is None.
-
-    Attributes
-    ----------
-    similar_items_index : faiss.IndexIVFFlat
-        Faiss index for looking up similar items in the cosine space formed by the latent
-        item_factors
-
-    recommend_index : faiss.IndexIVFFlat
-        Faiss index for looking up similar items in the inner product space formed by the latent
-        item_factors
-    """
-
-    def __init__(
-        self,
-        *args,
-        approximate_similar_items=True,
-        approximate_recommend=True,
-        nlist=400,
-        nprobe=20,
-        use_gpu=implicit.gpu.HAS_CUDA,
-        random_state=None,
-        **kwargs
-    ):
-
-        self.similar_items_index = None
-        self.recommend_index = None
-        self.quantizer = None
-        self.gpu_resources = None
-
-        self.approximate_similar_items = approximate_similar_items
-        self.approximate_recommend = approximate_recommend
-
-        # hyper-parameters for FAISS
-        self.nlist = nlist
-        self.nprobe = nprobe
-        self.use_gpu = use_gpu
-        super().__init__(*args, random_state=random_state, **kwargs)
-
-    def fit(self, Cui, show_progress=True):
-        import faiss
-
-        # train the model
-        super().fit(Cui, show_progress)
-
-        self.quantizer = faiss.IndexFlat(self.factors)
-
-        if self.use_gpu:
-            self.gpu_resources = faiss.StandardGpuResources()
-
-        item_factors = self.item_factors.astype("float32")
-
-        if self.approximate_recommend:
-            log.debug("Building faiss recommendation index")
-
-            # build up a inner product index here
-            if self.use_gpu:
-                index = faiss.GpuIndexIVFFlat(
-                    self.gpu_resources, self.factors, self.nlist, faiss.METRIC_INNER_PRODUCT
-                )
-            else:
-                index = faiss.IndexIVFFlat(
-                    self.quantizer, self.factors, self.nlist, faiss.METRIC_INNER_PRODUCT
-                )
-
-            index.train(item_factors)
-            index.add(item_factors)
-            index.nprobe = self.nprobe
-            self.recommend_index = index
-
-        if self.approximate_similar_items:
-            log.debug("Building faiss similar items index")
-
-            # likewise build up cosine index for similar_items, using an inner product
-            # index on normalized vectors`
-            norms = np.linalg.norm(item_factors, axis=1)
-            norms[norms == 0] = 1e-10
-
-            normalized = (item_factors.T / norms).T.astype("float32")
-            if self.use_gpu:
-                index = faiss.GpuIndexIVFFlat(
-                    self.gpu_resources, self.factors, self.nlist, faiss.METRIC_INNER_PRODUCT
-                )
-            else:
-                index = faiss.IndexIVFFlat(
-                    self.quantizer, self.factors, self.nlist, faiss.METRIC_INNER_PRODUCT
-                )
-
-            index.train(normalized)
-            index.add(normalized)
-            index.nprobe = self.nprobe
-            self.similar_items_index = index
-
-    def similar_items(
-        self, itemid, N=10, react_users=None, recalculate_item=False, filter_items=None, items=None
-    ):
-        if items is not None and self.approximate_similar_items:
-            raise NotImplementedError("using an items filter isn't supported with ANN lookup")
-
-        count = N
-        if filter_items is not None:
-            count += len(filter_items)
-
-        if not self.approximate_similar_items or (self.use_gpu and count >= 1024):
-            return super().similar_items(
-                itemid,
-                N,
-                react_users=react_users,
-                recalculate_item=recalculate_item,
-                filter_items=filter_items,
-                items=items,
-            )
-
-        factors = self._item_factor(itemid, react_users, recalculate_item)
-
-        if np.isscalar(itemid):
-            factors /= np.linalg.norm(factors)
-            factors = factors.reshape(1, -1)
-        else:
-            factors /= np.linalg.norm(factors, axis=1)[:, None]
-
-        scores, ids = self.similar_items_index.search(factors.astype("float32"), count)
-
-        if np.isscalar(itemid):
-            ids, scores = ids[0], scores[0]
-
-        if filter_items is not None:
-            ids, scores = _filter_items_from_results(itemid, ids, scores, filter_items, N)
-
-        return ids, scores
-
-    def recommend(
-        self,
-        userid,
-        user_items,
-        N=10,
-        filter_already_liked_items=True,
-        filter_items=None,
-        recalculate_user=False,
-        items=None,
-    ):
-        if items and self.approximate_recommend:
-            raise NotImplementedError("using a 'items' list with ANN search isn't supported")
-
-        if not self.approximate_recommend:
-            return super().recommend(
-                userid,
-                user_items,
-                N=N,
-                filter_already_liked_items=filter_already_liked_items,
-                filter_items=filter_items,
-                recalculate_user=recalculate_user,
-                items=items,
-            )
-
-        # batch computation is tricky with filter_already_liked_items (requires querying a
-        # different number of rows per user). Instead just fallback to a faiss query per user
-        if filter_already_liked_items and not np.isscalar(userid):
-            return _batch_call(
-                self.recommend,
-                userid,
-                user_items=user_items,
-                N=N,
-                filter_already_liked_items=filter_already_liked_items,
-                filter_items=filter_items,
-                recalculate_user=recalculate_user,
-                items=items,
-            )
-
-        user = self._user_factor(userid, user_items, recalculate_user)
-
-        # calculate the top N items, removing the users own liked items from
-        # the results
-        count = N
-        if filter_items:
-            count += len(filter_items)
-            filter_items = np.array(filter_items)
-
-        if filter_already_liked_items:
-            user_likes = user_items[userid].indices
-            filter_items = (
-                np.append(filter_items, user_likes) if filter_items is not None else user_likes
-            )
-            count += len(user_likes)
-
-        # the GPU variant of faiss doesn't support returning more than 1024 results.
-        # fall back to the exact match when this happens
-        if self.use_gpu and count >= 1024:
-            return super().recommend(
-                userid,
-                user_items,
-                N=N,
-                filter_items=filter_items,
-                recalculate_user=recalculate_user,
-            )
-
-        if np.isscalar(userid):
-            query = user.reshape(1, -1).astype("float32")
-        else:
-            query = user.astype("float32")
-
-        scores, ids = self.recommend_index.search(query, count)
-
-        if np.isscalar(userid):
-            ids, scores = ids[0], scores[0]
-
-        if filter_items is not None:
-            ids, scores = _filter_items_from_results(userid, ids, scores, filter_items, N)
-
-        return ids, scores
-
-
-def _filter_items_from_results(queryid, ids, scores, filter_items, N):
-    if np.isscalar(queryid):
-        mask = np.in1d(ids, filter_items, invert=True)
-        ids, scores = ids[mask][:N], scores[mask][:N]
-    else:
-        rows = len(queryid)
-        filtered_scores = np.zeros((rows, N), dtype=scores.dtype)
-        filtered_ids = np.zeros((rows, N), dtype=ids.dtype)
-        for row in range(rows):
-            mask = np.in1d(ids[row], filter_items, invert=True)
-            filtered_ids[row] = ids[row][mask][:N]
-            filtered_scores[row] = scores[row][mask][:N]
-        ids, scores = filtered_ids, filtered_scores
-    return ids, scores
+def NMSLibAlternatingLeastSquares(
+    *args,
+    approximate_similar_items=True,
+    approximate_recommend=True,
+    method="hnsw",
+    index_params=None,
+    query_params=None,
+    use_gpu=implicit.gpu.HAS_CUDA,
+    **kwargs
+):
+    # delay importing here in case nmslib isn't installed
+    from implicit.ann.nmslib import NMSLibModel
+
+    # note that we're using the factory function here to instantiate a CPU/GPU model as appropriate
+    als_model = implicit.als.AlternatingLeastSquares(*args, use_gpu=use_gpu, **kwargs)
+    return NMSLibModel(
+        als_model,
+        approximate_similar_items=approximate_similar_items,
+        approximate_recommend=approximate_recommend,
+        method=method,
+        index_params=index_params,
+        query_params=query_params,
+    )
+
+
+def AnnoyAlternatingLeastSquares(
+    *args,
+    approximate_similar_items=True,
+    approximate_recommend=True,
+    n_trees=50,
+    search_k=-1,
+    use_gpu=implicit.gpu.HAS_CUDA,
+    **kwargs
+):
+    als_model = implicit.als.AlternatingLeastSquares(*args, use_gpu=use_gpu, **kwargs)
+    from implicit.ann.annoy import AnnoyModel
+
+    return AnnoyModel(
+        als_model,
+        approximate_similar_items=approximate_similar_items,
+        approximate_recommend=approximate_recommend,
+        n_trees=n_trees,
+        search_k=search_k,
+    )
+
+
+def FaissAlternatingLeastSquares(
+    *args,
+    approximate_similar_items=True,
+    approximate_recommend=True,
+    nlist=400,
+    nprobe=20,
+    use_gpu=implicit.gpu.HAS_CUDA,
+    **kwargs
+):
+    # note that we're using the factory function here to instantiate a CPU/GPU model as appropriate
+    als_model = implicit.als.AlternatingLeastSquares(*args, use_gpu=use_gpu, **kwargs)
+
+    from implicit.ann.faiss import FaissModel
+
+    return FaissModel(
+        als_model,
+        approximate_similar_items=approximate_similar_items,
+        approximate_recommend=approximate_recommend,
+        nlist=nlist,
+        nprobe=nprobe,
+        use_gpu=use_gpu,
+    )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import platform
 import sys
 
 try:
-    import numpy.distutils
+    import numpy.distutils  # noqa
 except ImportError:
     pass
 

--- a/tests/approximate_als_test.py
+++ b/tests/approximate_als_test.py
@@ -17,17 +17,25 @@ try:
 
     class AnnoyALSTest(unittest.TestCase, RecommenderBaseTestMixin):
         def _get_model(self):
-            return AnnoyAlternatingLeastSquares(factors=32, regularization=0, random_state=23)
+            return AnnoyAlternatingLeastSquares(
+                factors=32, regularization=0, random_state=23, use_gpu=False
+            )
 
         def test_pickle(self):
             # pickle isn't supported on annoy indices
             pass
 
-        def test_rank_items(self):
-            pass
+    if HAS_CUDA:
 
-        def test_rank_items_batch(self):
-            pass
+        class AnnoyALSGPUTest(unittest.TestCase, RecommenderBaseTestMixin):
+            def _get_model(self):
+                return AnnoyAlternatingLeastSquares(
+                    factors=32, regularization=0, random_state=23, use_gpu=True
+                )
+
+            def test_pickle(self):
+                # pickle isn't supported on annoy indices
+                pass
 
 except ImportError:
     pass
@@ -38,18 +46,33 @@ try:
     class NMSLibALSTest(unittest.TestCase, RecommenderBaseTestMixin):
         def _get_model(self):
             return NMSLibAlternatingLeastSquares(
-                factors=32, regularization=0, index_params={"post": 2}, random_state=23
+                factors=32,
+                regularization=0,
+                index_params={"post": 2},
+                random_state=23,
+                use_gpu=False,
             )
 
         def test_pickle(self):
             # pickle isn't supported on nmslib indices
             pass
 
-        def test_rank_items(self):
-            pass
+    if HAS_CUDA:
+        # nmslib doesn't support querying on the gpu, but we should be able to still use a GPU als
+        # model with the nmslib index
+        class NMSLibALSGPUTest(unittest.TestCase, RecommenderBaseTestMixin):
+            def _get_model(self):
+                return NMSLibAlternatingLeastSquares(
+                    factors=32,
+                    regularization=0,
+                    index_params={"post": 2},
+                    random_state=23,
+                    use_gpu=True,
+                )
 
-        def test_rank_items_batch(self):
-            pass
+            def test_pickle(self):
+                # pickle isn't supported on nmslib indices
+                pass
 
 except ImportError:
     pass
@@ -65,12 +88,6 @@ try:
 
         def test_pickle(self):
             # pickle isn't supported on faiss indices
-            pass
-
-        def test_rank_items(self):
-            pass
-
-        def test_rank_items_batch(self):
             pass
 
     if HAS_CUDA:
@@ -114,12 +131,6 @@ try:
 
             def test_pickle(self):
                 # pickle isn't supported on faiss indices
-                pass
-
-            def test_rank_items(self):
-                pass
-
-            def test_rank_items_batch(self):
                 pass
 
 except ImportError:

--- a/tests/recommender_base_test.py
+++ b/tests/recommender_base_test.py
@@ -151,23 +151,26 @@ class RecommenderBaseTestMixin:
 
     def test_similar_users(self):
         model = self._get_model()
-        # calculating similar users in nearest-neighbours is not implemented yet
-        if isinstance(model, ItemItemRecommender):
-            return
         model.fit(get_checker_board(50), show_progress=False)
-        for userid in range(50):
-            ids, _ = model.similar_users(userid, N=10)
-            for r in ids:
-                self.assertEqual(r % 2, userid % 2)
+
+        try:
+            for userid in range(50):
+                ids, _ = model.similar_users(userid, N=10)
+                for r in ids:
+                    self.assertEqual(r % 2, userid % 2)
+        except NotImplementedError:
+            pass
 
     def test_similar_users_batch(self):
         model = self._get_model()
-        # calculating similar users in nearest-neighbours is not implemented yet
-        if isinstance(model, ItemItemRecommender):
-            return
         model.fit(get_checker_board(256), show_progress=False)
         userids = np.arange(50)
-        ids, scores = model.similar_users(userids, N=10)
+
+        try:
+            ids, scores = model.similar_users(userids, N=10)
+        except NotImplementedError:
+            # similar users isn't implemented for many models (ItemItemRecommeder/ ANN models)
+            return
 
         self.assertEqual(ids.shape, (50, 10))
 
@@ -189,7 +192,11 @@ class RecommenderBaseTestMixin:
         model.fit(get_checker_board(256), show_progress=False)
         userids = np.arange(50)
 
-        ids, _ = model.similar_users(userids, N=10, filter_users=np.arange(52) * 5)
+        try:
+            ids, _ = model.similar_users(userids, N=10, filter_users=np.arange(52) * 5)
+        except NotImplementedError:
+            return
+
         for userid in userids:
             for r in ids[userid]:
                 self.assertTrue(r % 5 != 0)
@@ -292,9 +299,12 @@ class RecommenderBaseTestMixin:
         for userid in range(50):
             selected_items = random.sample(range(50), 10)
 
-            ids, _ = model.recommend(
-                userid, user_items, items=selected_items, filter_already_liked_items=False
-            )
+            try:
+                ids, _ = model.recommend(
+                    userid, user_items, items=selected_items, filter_already_liked_items=False
+                )
+            except NotImplementedError:
+                return
 
             # ranked list should have same items
             self.assertEqual(set(ids), set(selected_items))
@@ -318,7 +328,10 @@ class RecommenderBaseTestMixin:
         model.fit(item_users, show_progress=False)
 
         selected_items = np.arange(10) * 3
-        ids, _ = model.recommend(np.arange(50), user_items, items=selected_items)
+        try:
+            ids, _ = model.recommend(np.arange(50), user_items, items=selected_items)
+        except NotImplementedError:
+            return
 
         for userid in range(50):
             current_ids = ids[userid]


### PR DESCRIPTION
Approximate nearest neighbours used to only work for the ALS mode on the CPU.

This change makes it so that we can compose ANN methods with any matrix factorization
model (including BPR/LMF) and also use the GPU MF models as well.

Currently this provides the same api in implicit/approximate_als.py for backwards
compatability - but this may be removed at a future date.

Closes #487