### PR TITLE
Check user_items is a CSR matrix in recommend

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -44,6 +44,6 @@ disable=fixme,
     protected-access,
 
 [SIMILARITIES]
-min-similarity-lines=50
+min-similarity-lines=64
 ignore-docstrings=yes
 ignore-imports=yes

--- a/implicit/ann/annoy.py
+++ b/implicit/ann/annoy.py
@@ -2,6 +2,7 @@ import logging
 
 import annoy
 import numpy as np
+from scipy.sparse import csr_matrix
 
 import implicit.gpu
 from implicit.recommender_base import RecommenderBase
@@ -157,6 +158,11 @@ class AnnoyModel(RecommenderBase):
         recalculate_user=False,
         items=None,
     ):
+        if (filter_already_liked_items or recalculate_user) and not isinstance(
+            user_items, csr_matrix
+        ):
+            raise ValueError("user_items needs to be a CSR sparse matrix")
+
         if items is not None and self.approximate_recommend:
             raise NotImplementedError("using a 'items' list with ANN search isn't supported")
 

--- a/implicit/ann/faiss.py
+++ b/implicit/ann/faiss.py
@@ -3,6 +3,7 @@ import warnings
 
 import faiss
 import numpy as np
+from scipy.sparse import csr_matrix
 
 import implicit.gpu
 from implicit.recommender_base import RecommenderBase
@@ -186,6 +187,11 @@ class FaissModel(RecommenderBase):
         recalculate_user=False,
         items=None,
     ):
+        if (filter_already_liked_items or recalculate_user) and not isinstance(
+            user_items, csr_matrix
+        ):
+            raise ValueError("user_items needs to be a CSR sparse matrix")
+
         if items is not None and self.approximate_recommend:
             raise NotImplementedError("using a 'items' list with ANN search isn't supported")
 

--- a/implicit/ann/nmslib.py
+++ b/implicit/ann/nmslib.py
@@ -2,6 +2,7 @@ import logging
 
 import nmslib
 import numpy as np
+from scipy.sparse import csr_matrix
 
 import implicit.gpu
 from implicit.recommender_base import RecommenderBase
@@ -165,6 +166,11 @@ class NMSLibModel(RecommenderBase):
         recalculate_user=False,
         items=None,
     ):
+        if (filter_already_liked_items or recalculate_user) and not isinstance(
+            user_items, csr_matrix
+        ):
+            raise ValueError("user_items needs to be a CSR sparse matrix")
+
         if items is not None and self.approximate_recommend:
             raise NotImplementedError("using a 'items' list with ANN search isn't supported")
 

--- a/implicit/cpu/matrix_factorization_base.py
+++ b/implicit/cpu/matrix_factorization_base.py
@@ -2,7 +2,7 @@
 import warnings
 
 import numpy as np
-from scipy.sparse import lil_matrix
+from scipy.sparse import csr_matrix, lil_matrix
 
 from ..recommender_base import ModelFitError, RecommenderBase
 from .topk import topk
@@ -37,6 +37,11 @@ class MatrixFactorizationBase(RecommenderBase):
         recalculate_user=False,
         items=None,
     ):
+        if (filter_already_liked_items or recalculate_user) and not isinstance(
+            user_items, csr_matrix
+        ):
+            raise ValueError("user_items needs to be a CSR sparse matrix")
+
         user = self._user_factor(userid, user_items, recalculate_user)
 
         item_factors = self.item_factors

--- a/implicit/gpu/matrix_factorization_base.py
+++ b/implicit/gpu/matrix_factorization_base.py
@@ -1,6 +1,7 @@
 import time
 
 import numpy as np
+from scipy.sparse import csr_matrix
 
 import implicit.gpu
 
@@ -40,6 +41,11 @@ class MatrixFactorizationBase(RecommenderBase):
         recalculate_user=False,
         items=None,
     ):
+        if (filter_already_liked_items or recalculate_user) and not isinstance(
+            user_items, csr_matrix
+        ):
+            raise ValueError("user_items needs to be a CSR sparse matrix")
+
         if recalculate_user:
             raise NotImplementedError("recalculate_user isn't support on GPU yet")
 

--- a/implicit/nearest_neighbours.py
+++ b/implicit/nearest_neighbours.py
@@ -57,6 +57,11 @@ class ItemItemRecommender(RecommenderBase):
                 items=items,
             )
 
+        if (filter_already_liked_items or recalculate_user) and not isinstance(
+            user_items, csr_matrix
+        ):
+            raise ValueError("user_items needs to be a CSR sparse matrix")
+
         if userid >= user_items.shape[0]:
             raise ValueError("userid is out of bounds of the user_items matrix")
 

--- a/tests/recommender_base_test.py
+++ b/tests/recommender_base_test.py
@@ -345,6 +345,18 @@ class RecommenderBaseTestMixin:
         pickled = pickle.dumps(model)
         pickle.loads(pickled)
 
+    def test_invalid_user_items(self):
+
+        user_items = get_checker_board(50)
+        model = self._get_model()
+        model.fit(user_items, show_progress=False)
+
+        with self.assertRaises(ValueError):
+            model.recommend(0, user_items=user_items.tocsc())
+
+        with self.assertRaises(ValueError):
+            model.recommend(0, user_items=user_items.tocoo())
+
     def get_checker_board(self, X):
         """Returns a 'checkerboard' matrix: where every even userid has liked
         every even itemid and every odd userid has liked every odd itemid.


### PR DESCRIPTION
If user_items isn't a CSR matrix in the recommend call then wrong results will get returned with
filter_already_liked_items or recalculate_user options.

Closes #365