### PR TITLE
Fix for recommend with 'items' filter

### DIFF
--- a/implicit/cpu/matrix_factorization_base.py
+++ b/implicit/cpu/matrix_factorization_base.py
@@ -49,6 +49,7 @@ class MatrixFactorizationBase(RecommenderBase):
         # if we have an item list to restrict down to, we need to filter the item_factors
         # and filter_query_items
         if items is not None:
+            N = min(N, len(items))
             if filter_items:
                 raise ValueError("Can't set both items and filter_items in recommend call")
 
@@ -249,7 +250,7 @@ def _filter_items_from_sparse_matrix(items, query_items):
     positions = np.searchsorted(items, filter_query_items.col)
     positions = np.clip(positions, 0, len(items) - 1)
 
-    filter_query_items.col = positions
     filter_query_items.data[items[positions] != filter_query_items.col] = 0
+    filter_query_items.col = positions
     filter_query_items.eliminate_zeros()
     return filter_query_items.tocsr()

--- a/implicit/gpu/matrix_factorization_base.py
+++ b/implicit/gpu/matrix_factorization_base.py
@@ -51,6 +51,7 @@ class MatrixFactorizationBase(RecommenderBase):
 
         item_factors = self.item_factors
         if items is not None:
+            N = min(N, len(items))
             if filter_items:
                 raise ValueError("Can't set both items and filter_items in recommend call")
 

--- a/tests/recommender_base_test.py
+++ b/tests/recommender_base_test.py
@@ -296,16 +296,30 @@ class RecommenderBaseTestMixin:
         model = self._get_model()
         model.fit(item_users, show_progress=False)
 
+        try:
+            selected_items = np.array([1, 2, 3, 4, 5, 6])
+            ids, _ = model.recommend(0, user_items, items=selected_items, N=20)
+
+            self.assertEqual(len(ids), len(selected_items))
+
+            # ranked list should have same items
+            self.assertEqual(set(ids), set(selected_items))
+
+            if not isinstance(model, ItemItemRecommender):
+                # items 2,4,6 are in the 'filter_alread_liked_items' set
+                # and should be in the last 3 positions (except with itemitemrecommenders
+                # where its a little more complicated since the sparse results)
+                self.assertEqual(set(ids[3:]), set([2, 4, 6]))
+
+        except NotImplementedError:
+            return
+
         for userid in range(50):
             selected_items = random.sample(range(50), 10)
 
-            try:
-                ids, _ = model.recommend(
-                    userid, user_items, items=selected_items, filter_already_liked_items=False
-                )
-            except NotImplementedError:
-                return
-
+            ids, _ = model.recommend(
+                userid, user_items, items=selected_items, filter_already_liked_items=False
+            )
             # ranked list should have same items
             self.assertEqual(set(ids), set(selected_items))
 


### PR DESCRIPTION
When using the 'items' filter on the recommend calls, we had two
different bugs in the latest code. One was that if you specified
a 'N' value greater than the size of the items you were ranking,
the results contained invalid values. The other was that we weren't
properly handling the 'filter_already_liked' option when the 'items'
option was set for MF models. Fix and add a unittest that would have
caught this