### PR TITLE
Use rapids-cmake for including FAISS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "thirdparty/faiss"]
-	path = thirdparty/faiss
-	url = https://github.com/facebookresearch/faiss.git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,14 +1,6 @@
-recursive-include implicit *.h *.cu *.cuh *.pyx *.py *.cpp *.pxd
+recursive-include implicit *.h *.cu *.cuh *.pyx *.py *.pxd *.txt
 include README.md
+include CMakeLists.txt
 include requirements.txt
 include LICENSE
 include tox.ini
-
-recursive-include thirdparty/faiss/faiss/gpu/utils/ *.cu *.cuh *.h
-include thirdparty/faiss/faiss/gpu/GpuResources.cpp
-include thirdparty/faiss/faiss/gpu/GpuResources.h
-include thirdparty/faiss/faiss/gpu/GpuFaissAssert.h
-include thirdparty/faiss/faiss/impl/FaissAssert.h
-include thirdparty/faiss/faiss/impl/FaissException.h
-include thirdparty/faiss/faiss/impl/platform_macros.h
-include thirdparty/faiss/faiss/MetricType.h

--- a/implicit/gpu/CMakeLists.txt
+++ b/implicit/gpu/CMakeLists.txt
@@ -28,7 +28,7 @@ if(CUDAToolkit_FOUND)
     FILE(GLOB FAISS_BLOCK_SELECT ${FAISS_SOURCE_DIR}/faiss/gpu/utils/blockselect/*.cu)
     include_directories(${FAISS_SOURCE_DIR})
 
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --extended-lambda -Wno-deprecated-gpu-targets")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --extended-lambda -Wno-deprecated-gpu-targets -Xfatbin=-compress-all")
 
     add_library(_cuda MODULE ${_cuda}
         als.cu

--- a/implicit/gpu/CMakeLists.txt
+++ b/implicit/gpu/CMakeLists.txt
@@ -2,16 +2,34 @@ add_cython_target(_cuda CXX)
 
 find_package(CUDAToolkit)
 
+
 if(CUDAToolkit_FOUND)
     enable_language(CUDA)
     
-    include_directories(../../thirdparty/faiss)
+    # use rapids-cmake to install dependencies
+    file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.02/RAPIDS.cmake
+        ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+    include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+    include(rapids-cmake)
+    include(rapids-cpm)
+    include(rapids-cuda)
+    include(rapids-export)
+    include(rapids-find)
+    rapids_cpm_init()
+    rapids_cmake_build_type(Release)
 
-    FILE(GLOB faiss_block_select ../../thirdparty/faiss/faiss/gpu/utils/blockselect/*.cu)
+    # get faiss from git
+    rapids_cpm_find(FAISS 1.7.2
+        CPM_ARGS
+          GIT_REPOSITORY  https://github.com/facebookresearch/faiss.git
+          VERSION         1.7.2
+          DOWNLOAD_ONLY   YES
+    )
+    FILE(GLOB FAISS_BLOCK_SELECT ${FAISS_SOURCE_DIR}/faiss/gpu/utils/blockselect/*.cu)
+    include_directories(${FAISS_SOURCE_DIR})
 
-    # TODO: faiss targets?
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --extended-lambda -Wno-deprecated-gpu-targets")
-        
+
     add_library(_cuda MODULE ${_cuda}
         als.cu
         bpr.cu
@@ -19,13 +37,14 @@ if(CUDAToolkit_FOUND)
         device_buffer.cu
         random.cu
         knn.cu
-        ${faiss_block_select}
-        ../../thirdparty/faiss/faiss/gpu/utils/BlockSelectFloat.cu
-        ../../thirdparty/faiss/faiss/gpu/utils/DeviceUtils.cu
-        ../../thirdparty/faiss/faiss/gpu/GpuResources.cpp
+        # we need a limited subset of faiss for the blockselect code. rather than compile all of
+        # faiss, just include the minimal subset here
+        ${FAISS_BLOCK_SELECT}
+        ${FAISS_SOURCE_DIR}/faiss/gpu/utils/BlockSelectFloat.cu
+        ${FAISS_SOURCE_DIR}/faiss/gpu/utils/DeviceUtils.cu
+        ${FAISS_SOURCE_DIR}/faiss/gpu/GpuResources.cpp
     )
-    
-    # TODO: add cudart/cublas/curand variables
+
     python_extension_module(_cuda)
 
     set_target_properties(_cuda PROPERTIES CUDA_ARCHITECTURES "37;50;70;60;80;86")


### PR DESCRIPTION
Use rapids-cmake for including FAISS, rather than checout w/ a git submodule.
Using rapids-cmake will also make including RMM/Raft (in a future pr) much easier.