### PR TITLE
Add support for recalculate_users/items on the GPU

### DIFF
--- a/implicit/cpu/_als.pyx
+++ b/implicit/cpu/_als.pyx
@@ -56,12 +56,13 @@ cdef inline void gesv(int * n, int * nrhs, floating * a, int * lda, int * piv, f
 
 
 def least_squares(Cui, X, Y, regularization, num_threads=0):
-    _least_squares(Cui.indptr, Cui.indices, Cui.data.astype('float32'),
+    YtY = np.dot(np.transpose(Y), Y)
+    _least_squares(YtY, Cui.indptr, Cui.indices, Cui.data.astype('float32'),
                    X, Y, regularization, num_threads)
 
 
 @cython.boundscheck(False)
-def _least_squares(integral[:] indptr, integral[:] indices, float[:] data,
+def _least_squares(YtY, integral[:] indptr, integral[:] indices, float[:] data,
                    floating[:, :] X, floating[:, :] Y, double regularization,
                    int num_threads=0):
     dtype = np.float64 if floating is double else np.float32
@@ -69,8 +70,6 @@ def _least_squares(integral[:] indptr, integral[:] indices, float[:] data,
     cdef integral users = X.shape[0], u, i, j, index
     cdef int one = 1, factors = X.shape[1], err
     cdef floating confidence, temp
-
-    YtY = np.dot(np.transpose(Y), Y)
 
     cdef floating[:, :] initialA = YtY + regularization * np.eye(factors, dtype=dtype)
     cdef floating[:] initialB = np.zeros(factors, dtype=dtype)

--- a/implicit/cpu/matrix_factorization_base.py
+++ b/implicit/cpu/matrix_factorization_base.py
@@ -124,16 +124,12 @@ class MatrixFactorizationBase(RecommenderBase):
 
     def _user_factor(self, userid, user_items, recalculate_user=False):
         if recalculate_user:
-            if np.isscalar(userid):
-                return self.recalculate_user(userid, user_items)
-            return np.stack([self.recalculate_user(i, user_items) for i in userid])
+            return self.recalculate_user(userid, user_items)
         return self.user_factors[userid]
 
     def _item_factor(self, itemid, react_users, recalculate_item=False):
         if recalculate_item:
-            if np.isscalar(itemid):
-                return self.recalculate_item(itemid, react_users)
-            return np.stack([self.recalculate_item(i, react_users) for i in itemid])
+            return self.recalculate_item(itemid, react_users)
         return self.item_factors[itemid]
 
     def recalculate_user(self, userid, user_items):

--- a/implicit/gpu/als.h
+++ b/implicit/gpu/als.h
@@ -9,16 +9,17 @@ namespace implicit {
 namespace gpu {
 
 struct LeastSquaresSolver {
-  explicit LeastSquaresSolver(int factors);
+  explicit LeastSquaresSolver();
   ~LeastSquaresSolver();
 
-  void least_squares(const CSRMatrix &Cui, Matrix *X, const Matrix &Y,
-                     float regularization, int cg_steps) const;
+  void least_squares(const CSRMatrix &Cui, Matrix *X, const Matrix &YtY,
+                     const Matrix &Y, int cg_steps) const;
+
+  void calculate_yty(const Matrix &Y, Matrix *YtY, float regularization);
 
   float calculate_loss(const CSRMatrix &Cui, const Matrix &X, const Matrix &Y,
                        float regularization);
 
-  Matrix YtY;
   cublasContext *blas_handle;
 };
 } // namespace gpu

--- a/implicit/gpu/als.pxd
+++ b/implicit/gpu/als.pxd
@@ -3,9 +3,13 @@ from .matrix cimport CSRMatrix, Matrix
 
 cdef extern from "implicit/gpu/als.h" namespace "implicit::gpu" nogil:
     cdef cppclass LeastSquaresSolver:
-        LeastSquaresSolver(int factors) except +
+        LeastSquaresSolver() except +
+
+        void calculate_yty(const Matrix & Y, Matrix * YtY, float regularization) except *
+
         void least_squares(const CSRMatrix & Cui, Matrix * X,
-                           const Matrix & Y, float regularization, int cg_steps) except +
+                           const Matrix & YtY, const Matrix & Y,
+                           int cg_steps) except +
 
         float calculate_loss(const CSRMatrix & Cui, const Matrix & X,
                              const Matrix & Y, float regularization) except +


### PR DESCRIPTION
Add GPU support for recalculating items and users factors at inference time.
Also speed up the CPU versions by using the native solver rather than the
python version.