### PR TITLE
Minor GPU fixes

### DIFF
--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -199,8 +199,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
     def recalculate_user(self, userid, user_items):
         # we're using the cholesky solver here on purpose, since for a full recompute
         users = 1 if np.isscalar(userid) else len(userid)
-        random_state = check_random_state(self.random_state)
-        user_factors = random_state.rand(users, self.factors).astype(self.dtype) * 0.01
+        user_factors = np.zeros((users, self.factors), dtype=self.dtype)
         Cui = user_items[userid]
         _als._least_squares(
             self.YtY,
@@ -216,10 +215,8 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
 
     def recalculate_item(self, itemid, react_users):
         items = 1 if np.isscalar(itemid) else len(itemid)
-        random_state = check_random_state(self.random_state)
-        item_factors = random_state.rand(items, self.factors).astype(self.dtype) * 0.01
+        item_factors = np.zeros((items, self.factors), dtype=self.dtype)
         Ciu = react_users[itemid]
-
         _als._least_squares(
             self.XtX,
             Ciu.indptr,

--- a/implicit/gpu/_cuda.pyx
+++ b/implicit/gpu/_cuda.pyx
@@ -42,7 +42,7 @@ cdef class RandomState(object):
 cdef class KnnQuery(object):
     cdef CppKnnQuery * c_knn
 
-    def __cinit__(self, size_t max_temp_memory=500_000_000):
+    def __cinit__(self, size_t max_temp_memory=0):
         self.c_knn = new CppKnnQuery(max_temp_memory)
 
     def __dealloc__(self):

--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -169,10 +169,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
 
     def recalculate_user(self, userid, user_items):
         users = 1 if np.isscalar(userid) else len(userid)
-        random_state = check_random_state(self.random_state)
-        user_factors = random_state.uniform(
-            users, self.factors, low=-0.5 / self.factors, high=0.5 / self.factors
-        )
+        user_factors = implicit.gpu.Matrix.zeros(users, self.factors)
         Cui = implicit.gpu.CSRMatrix(user_items[userid])
 
         self.solver.least_squares(
@@ -182,10 +179,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
 
     def recalculate_item(self, itemid, react_users):
         items = 1 if np.isscalar(itemid) else len(itemid)
-        random_state = check_random_state(self.random_state)
-        item_factors = random_state.uniform(
-            items, self.factors, low=-0.5 / self.factors, high=0.5 / self.factors
-        )
+        item_factors = implicit.gpu.Matrix.zeros(items, self.factors)
         Ciu = implicit.gpu.CSRMatrix(react_users[itemid])
         self.solver.least_squares(
             Ciu, item_factors, self.XtX, self.user_factors, cg_steps=self.factors

--- a/implicit/gpu/knn.cu
+++ b/implicit/gpu/knn.cu
@@ -278,10 +278,8 @@ void KnnQuery::argpartition(const Matrix &items, int k, int *indices,
     int cols_tile = cols / TILE_GROUPS;
 
     rmm::cuda_stream_view stream;
-    rmm::device_uvector<int> temp_indices(items.rows * items.cols, stream,
-                                          mr.get());
-    rmm::device_uvector<float> temp_distances(items.rows * items.cols, stream,
-                                              mr.get());
+    rmm::device_uvector<int> temp_indices(rows_tile * k, stream, mr.get());
+    rmm::device_uvector<float> temp_distances(rows_tile * k, stream, mr.get());
 
     faiss::gpu::DeviceTensor<float, 2, true> items_tensor(
         const_cast<float *>(items.data), {rows_tile, cols_tile});


### PR DESCRIPTION
* Fix OOM that could happen on the GPU topk when tiling rows
* Don't bother randomly initializing factors in recalculate_users/items
* Rather than only use 500MB for GPU temp memory, have it dynamic based off free mem