### PR TITLE
Multithreaded speedups for CPU models.

### DIFF
--- a/implicit/_nearest_neighbours.pyx
+++ b/implicit/_nearest_neighbours.pyx
@@ -129,7 +129,7 @@ def all_pairs_knn(users, unsigned int K=100, int num_threads=0, show_progress=Tr
         topk = new TopK[int, double](K)
 
         try:
-            for i in prange(item_count, schedule='guided'):
+            for i in prange(item_count, schedule='dynamic', chunksize=8):
                 for index1 in range(item_indptr[i], item_indptr[i+1]):
                     u = item_indices[index1]
                     w1 = item_data[index1]

--- a/implicit/cpu/_als.pyx
+++ b/implicit/cpu/_als.pyx
@@ -82,7 +82,7 @@ def _least_squares(YtY, integral[:] indptr, integral[:] indices, float[:] data,
         A = <floating *> malloc(sizeof(floating) * factors * factors)
         b = <floating *> malloc(sizeof(floating) * factors)
         try:
-            for u in prange(users, schedule='guided'):
+            for u in prange(users, schedule='dynamic', chunksize=8):
                 # if we have no items for this user, skip and set to zero
                 if indptr[u] == indptr[u+1]:
                     memset(&X[u, 0], 0, sizeof(floating) * factors)
@@ -161,7 +161,7 @@ def _least_squares_cg(integral[:] indptr, integral[:] indices, float[:] data,
         p = <floating *> malloc(sizeof(floating) * N)
         r = <floating *> malloc(sizeof(floating) * N)
         try:
-            for u in prange(users, schedule='guided'):
+            for u in prange(users, schedule='dynamic', chunksize=8):
                 # start from previous iteration
                 x = &X[u, 0]
 
@@ -260,7 +260,7 @@ def _calculate_loss(Cui, integral[:] indptr, integral[:] indices, float[:] data,
     with nogil, parallel(num_threads=num_threads):
         r = <floating *> malloc(sizeof(floating) * N)
         try:
-            for u in prange(users, schedule='guided'):
+            for u in prange(users, schedule='dynamic', chunksize=8):
                 # calculates (A.dot(Xu) - 2 * b).dot(Xu), without calculating A
                 temp = 1.0
                 symv(b"U", &N, &temp, &YtY[0, 0], &N, &X[u, 0], &one, &zero, r, &one)
@@ -284,7 +284,7 @@ def _calculate_loss(Cui, integral[:] indptr, integral[:] indices, float[:] data,
                 loss += dot(&N, r, &one, &X[u, 0], &one)
                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)
 
-            for i in prange(items, schedule='guided'):
+            for u in prange(users, schedule='dynamic', chunksize=8):
                 item_norm += dot(&N, &Y[i, 0], &one, &Y[i, 0], &one)
 
         finally:

--- a/implicit/evaluation.pyx
+++ b/implicit/evaluation.pyx
@@ -427,7 +427,7 @@ def ranking_metrics_at_k(model, train_user_items, test_user_items, int K=10,
         ids = <int * > malloc(sizeof(int) * K)
         likes = new unordered_set[int]()
         try:
-            for u in prange(users, schedule='guided'):
+            for u in prange(users, schedule='dynamic', chunksize=8):
                 # if we don't have any test items, skip this user
                 if test_indptr[u] == test_indptr[u+1]:
                     with gil:


### PR DESCRIPTION
On the CPU, we were not achieving full thread utilization. The problem seems to be that
using the 'guided' schedule in openmp assigns a large range of ids to a single thread,
and its pretty common to have ids sorted by frequency. This caused 1 thread to process
all the high activity users/items - and left the others starved for work as they finished
early.

Fix by switching to a dynamic openmp schedule. For the ALS model on cpu, this change is 3.8x
faster on training movielens-20m, and 2.2x faster training the Github Stars dataset -
while being neutral  on lastfm. For the cosine model, this change is 2.2x training movielens20m.

* 'schedule=dynamic' times:
    * ALS model:
	  * GitHub 60.96 s/it
	  * Movielens: 1.05 it/s
	  * LastFM 2.19 s/it
    * Cosine model:
	  * Movielens: 49603.48 it/s
* 'schedule=guided' openmp times (before this change):
    * ALS model:
	  * Github: 133 s/it
	  * Movielens: 3.62 s/it
	  * Lastfm: 2.19 s/it
    * Cosine model:
	  * Movielens 22804.29 it/s
