### PR TITLE
Dynamically detect CUDA availability

### DIFF
--- a/examples/lastfm.py
+++ b/examples/lastfm.py
@@ -52,7 +52,7 @@ def get_model(model_name):
 
     # some default params
     if model_name.endswith("als"):
-        params = {"factors": 128, "dtype": np.float32}
+        params = {"factors": 64, "dtype": np.float32}
     elif model_name == "bm25":
         params = {"K1": 100, "B": 0.5}
     elif model_name == "bpr":
@@ -106,7 +106,9 @@ def calculate_similar_artists(output_filename, model_name="als"):
             batch_size = 1000
             for startidx in range(0, len(to_generate), batch_size):
                 batch = to_generate[startidx : startidx + batch_size]
-                ids, scores = model.similar_items(batch, 11)
+                ids, scores = model.similar_items(
+                    batch, 11, react_users=plays, recalculate_item=True
+                )
                 for i, artistid in enumerate(batch):
                     artist = artists[artistid]
                     for other, score in zip(ids[i], scores[i]):
@@ -151,7 +153,9 @@ def calculate_recommendations(output_filename, model_name="als"):
             to_generate = np.arange(len(users))
             for startidx in range(0, len(to_generate), batch_size):
                 batch = to_generate[startidx : startidx + batch_size]
-                ids, scores = model.recommend(batch, user_plays, filter_already_liked_items=True)
+                ids, scores = model.recommend(
+                    batch, user_plays, filter_already_liked_items=True, recalculate_user=True
+                )
                 for i, userid in enumerate(batch):
                     username = users[userid]
                     for other, score in zip(ids[i], scores[i]):

--- a/examples/movielens.py
+++ b/examples/movielens.py
@@ -49,7 +49,7 @@ def calculate_similar_movies(output_filename, model_name="als", min_rating=4.0, 
 
     # generate a recommender model based off the input params
     if model_name == "als":
-        model = AlternatingLeastSquares()
+        model = AlternatingLeastSquares(use_gpu=False)
 
         # lets weight these models by bm25weight.
         log.debug("weighting matrix by bm25_weight")

--- a/implicit/gpu/__init__.py
+++ b/implicit/gpu/__init__.py
@@ -1,8 +1,17 @@
 from __future__ import absolute_import
 
+HAS_CUDA = False
 try:
     from ._cuda import *  # noqa
 
+    get_device_count()  # noqa pylint: disable=undefined-variable
     HAS_CUDA = True
+
+except RuntimeError as e:
+    import warnings
+
+    warnings.warn(
+        f"CUDA extension is built, but disabling GPU support because of '{e}'",
+    )
 except ImportError:
-    HAS_CUDA = False
+    pass

--- a/implicit/gpu/_cuda.pyx
+++ b/implicit/gpu/_cuda.pyx
@@ -17,6 +17,7 @@ from .matrix cimport Matrix as CppMatrix
 from .matrix cimport Vector as CppVector
 from .matrix cimport calculate_norms as cpp_calculate_norms
 from .random cimport RandomState as CppRandomState
+from .utils cimport get_device_count as cpp_get_device_count
 
 
 cdef class RandomState(object):
@@ -231,6 +232,10 @@ def calculate_norms(Matrix items):
     ret = Matrix(None)
     ret.c_matrix = new CppMatrix(cpp_calculate_norms(dereference(items.c_matrix)))
     return ret
+
+
+def get_device_count():
+    return cpp_get_device_count()
 
 
 def bpr_update(IntVector userids, IntVector itemids, IntVector indptr,

--- a/implicit/gpu/als.cu
+++ b/implicit/gpu/als.cu
@@ -5,7 +5,8 @@
 #include <cuda_runtime.h>
 
 #include "implicit/gpu/als.h"
-#include "implicit/gpu/utils.cuh"
+#include "implicit/gpu/dot.cuh"
+#include "implicit/gpu/utils.h"
 
 namespace implicit {
 namespace gpu {

--- a/implicit/gpu/bpr.cu
+++ b/implicit/gpu/bpr.cu
@@ -6,7 +6,8 @@
 #include <curand.h>
 
 #include "implicit/gpu/als.h"
-#include "implicit/gpu/utils.cuh"
+#include "implicit/gpu/dot.cuh"
+#include "implicit/gpu/utils.h"
 
 namespace implicit {
 namespace gpu {

--- a/implicit/gpu/dot.cuh
+++ b/implicit/gpu/dot.cuh
@@ -1,0 +1,62 @@
+#ifndef IMPLICIT_GPU_DOT_CUH_
+#define IMPLICIT_GPU_DOT_CUH_
+
+namespace implicit {
+namespace gpu {
+#define WARP_SIZE 32
+
+// https://devblogs.nvidia.com/parallelforall/faster-parallel-reductions-kepler/
+__inline__ __device__ float warp_reduce_sum(float val) {
+
+#if __CUDACC_VER_MAJOR__ >= 9
+  // __shfl_down is deprecated with cuda 9+. use newer variants
+  unsigned int active = __activemask();
+#pragma unroll
+  for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+    val += __shfl_down_sync(active, val, offset);
+  }
+#else
+#pragma unroll
+  for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+    val += __shfl_down(val, offset);
+  }
+#endif
+  return val;
+}
+
+__inline__ __device__ float dot(float a, float b, float *shared) {
+  // figure out the warp/ position inside the warp
+  int warp = threadIdx.x / WARP_SIZE;
+  int lane = threadIdx.x % WARP_SIZE;
+
+  // partially reduce the dot product inside each warp using a shuffle
+  float val = a * b;
+  val = warp_reduce_sum(val);
+
+  // write out the partial reduction to shared memory if appropriate
+  if (lane == 0) {
+    shared[warp] = val;
+  }
+  __syncthreads();
+
+  // if we we don't have multiple warps, we're done
+  if (blockDim.x <= WARP_SIZE) {
+    return shared[0];
+  }
+
+  // otherwise reduce again in the first warp
+  if (warp == 0) {
+    int num_warps = (blockDim.x + WARP_SIZE - 1) / WARP_SIZE;
+    val = (lane < num_warps) ? shared[lane] : 0;
+    val = warp_reduce_sum(val);
+    // broadcast back to shared memory
+    if (threadIdx.x == 0) {
+      shared[0] = val;
+    }
+  }
+  __syncthreads();
+  return shared[0];
+}
+} // namespace gpu
+} // namespace implicit
+#endif // IMPLICIT_GPU_DOT_CUH_

--- a/implicit/gpu/knn.cu
+++ b/implicit/gpu/knn.cu
@@ -18,7 +18,7 @@
 #include <thrust/transform.h>
 
 #include "implicit/gpu/knn.h"
-#include "implicit/gpu/utils.cuh"
+#include "implicit/gpu/utils.h"
 
 namespace implicit {
 namespace gpu {

--- a/implicit/gpu/matrix.cu
+++ b/implicit/gpu/matrix.cu
@@ -3,8 +3,9 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
 
+#include "implicit/gpu/dot.cuh"
 #include "implicit/gpu/matrix.h"
-#include "implicit/gpu/utils.cuh"
+#include "implicit/gpu/utils.h"
 
 namespace implicit {
 namespace gpu {

--- a/implicit/gpu/random.cu
+++ b/implicit/gpu/random.cu
@@ -6,7 +6,7 @@
 #include <thrust/transform.h>
 
 #include "implicit/gpu/random.h"
-#include "implicit/gpu/utils.cuh"
+#include "implicit/gpu/utils.h"
 
 namespace implicit {
 namespace gpu {

--- a/implicit/gpu/utils.h
+++ b/implicit/gpu/utils.h
@@ -66,59 +66,10 @@ inline void checkCurand(curandStatus_t code, const char *file, int line) {
   }
 }
 
-#define WARP_SIZE 32
-
-// https://devblogs.nvidia.com/parallelforall/faster-parallel-reductions-kepler/
-__inline__ __device__ float warp_reduce_sum(float val) {
-
-#if __CUDACC_VER_MAJOR__ >= 9
-  // __shfl_down is deprecated with cuda 9+. use newer variants
-  unsigned int active = __activemask();
-#pragma unroll
-  for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
-    val += __shfl_down_sync(active, val, offset);
-  }
-#else
-#pragma unroll
-  for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
-    val += __shfl_down(val, offset);
-  }
-#endif
-  return val;
-}
-
-__inline__ __device__ float dot(float a, float b, float *shared) {
-  // figure out the warp/ position inside the warp
-  int warp = threadIdx.x / WARP_SIZE;
-  int lane = threadIdx.x % WARP_SIZE;
-
-  // partially reduce the dot product inside each warp using a shuffle
-  float val = a * b;
-  val = warp_reduce_sum(val);
-
-  // write out the partial reduction to shared memory if appropriate
-  if (lane == 0) {
-    shared[warp] = val;
-  }
-  __syncthreads();
-
-  // if we we don't have multiple warps, we're done
-  if (blockDim.x <= WARP_SIZE) {
-    return shared[0];
-  }
-
-  // otherwise reduce again in the first warp
-  if (warp == 0) {
-    int num_warps = (blockDim.x + WARP_SIZE - 1) / WARP_SIZE;
-    val = (lane < num_warps) ? shared[lane] : 0;
-    val = warp_reduce_sum(val);
-    // broadcast back to shared memory
-    if (threadIdx.x == 0) {
-      shared[0] = val;
-    }
-  }
-  __syncthreads();
-  return shared[0];
+inline int get_device_count() {
+  int count;
+  CHECK_CUDA(cudaGetDeviceCount(&count));
+  return count;
 }
 } // namespace gpu
 } // namespace implicit

--- a/implicit/gpu/utils.pxd
+++ b/implicit/gpu/utils.pxd
@@ -1,0 +1,2 @@
+cdef extern from "implicit/gpu/utils.h" namespace "implicit::gpu" nogil:
+    int get_device_count() except +


### PR DESCRIPTION
Rather than just relying on the _cuda extension being built, also
check to see if we have valid GPU devices. If there aren't
GPU devices available, a warning saying:

``` 
UserWarning: CUDA extension is built, but disabling GPU support because of 'Cuda Error:
no CUDA-capable device is detected
```

will be logged, and GPU compatability disabled.