### PR TITLE
Add methods for converting MF models to/from gpu

### DIFF
--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -313,6 +313,20 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
             self._XtX = X.T.dot(X)
         return self._XtX
 
+    def to_gpu(self):
+        """Converts this model to an equivalent version running on the gpu"""
+        import implicit.gpu.als
+
+        ret = implicit.gpu.als.AlternatingLeastSquares(
+            factors=self.factors,
+            regularization=self.regularization,
+            iterations=self.iterations,
+            calculate_training_loss=self.calculate_training_loss,
+        )
+        ret.user_factors = implicit.gpu.Matrix(self.user_factors)
+        ret.item_factors = implicit.gpu.Matrix(self.item_factors)
+        return ret
+
 
 def least_squares(Cui, X, Y, regularization, num_threads=0):
     """For each user in Cui, calculate factors Xu for them

--- a/implicit/cpu/bpr.pyx
+++ b/implicit/cpu/bpr.pyx
@@ -201,6 +201,21 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
 
         self._check_fit_errors()
 
+    def to_gpu(self):
+        """Converts this model to an equivalent version running on the gpu"""
+        import implicit.gpu.bpr
+
+        ret = implicit.gpu.bpr.BayesianPersonalizedRanking(
+            factors=self.factors,
+            learning_rate=self.learning_rate,
+            regularization=self.regularization,
+            iterations=self.iterations,
+            verify_negative_samples=self.verify_negative_samples,
+        )
+        ret.user_factors = implicit.gpu.Matrix(self.user_factors)
+        ret.item_factors = implicit.gpu.Matrix(self.item_factors)
+        return ret
+
 
 @cython.cdivision(True)
 @cython.boundscheck(False)

--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -205,3 +205,15 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
             self._XtX = implicit.gpu.Matrix(self.factors, self.factors)
             self.solver.calculate_yty(self.user_factors, self._XtX, self.regularization)
         return self._XtX
+
+    def to_cpu(self):
+        """Converts this model to an equivalent version running on the CPU"""
+        ret = implicit.cpu.als.AlternatingLeastSquares(
+            factors=self.factors,
+            regularization=self.regularization,
+            iterations=self.iterations,
+            calculate_training_loss=self.calculate_training_loss,
+        )
+        ret.user_factors = self.user_factors.to_numpy()
+        ret.item_factors = self.item_factors.to_numpy()
+        return ret

--- a/implicit/gpu/bpr.py
+++ b/implicit/gpu/bpr.py
@@ -149,3 +149,16 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
                             "skipped": f"{100.0 * skipped / total:0.2f}%",
                         }
                     )
+
+    def to_cpu(self):
+        """Converts this model to an equivalent version running on the cpu"""
+        ret = implicit.cpu.bpr.BayesianPersonalizedRanking(
+            factors=self.factors,
+            learning_rate=self.learning_rate,
+            regularization=self.regularization,
+            iterations=self.iterations,
+            verify_negative_samples=self.verify_negative_samples,
+        )
+        ret.user_factors = self.user_factors.to_numpy()
+        ret.item_factors = self.item_factors.to_numpy()
+        return ret


### PR DESCRIPTION
Adds some simple methods to convert BPR and ALS models from a CPU version
to a GPU version. This is useful for when you want to train on the CPU
and evaluate on the GPU (or vice versa).