### PR TITLE
Rename react_users to item_users

### DIFF
--- a/implicit/ann/annoy.py
+++ b/implicit/ann/annoy.py
@@ -93,7 +93,7 @@ class AnnoyModel(RecommenderBase):
             self.recommend_index.build(self.n_trees)
 
     def similar_items(
-        self, itemid, N=10, react_users=None, recalculate_item=False, filter_items=None, items=None
+        self, itemid, N=10, recalculate_item=False, item_users=None, filter_items=None, items=None
     ):
         if items is not None and self.approximate_similar_items:
             raise NotImplementedError("using an items filter isn't supported with ANN lookup")
@@ -106,8 +106,8 @@ class AnnoyModel(RecommenderBase):
             return self.model.similar_items(
                 itemid,
                 N,
-                react_users=react_users,
                 recalculate_item=recalculate_item,
+                item_users=item_users,
                 filter_items=filter_items,
                 items=items,
             )
@@ -118,15 +118,15 @@ class AnnoyModel(RecommenderBase):
                 self.similar_items,
                 itemid,
                 N=N,
-                react_users=react_users,
                 recalculate_item=recalculate_item,
+                item_users=item_users,
                 filter_items=filter_items,
             )
 
         # support recalculate_item if possible. TODO: refactor this
         if hasattr(self.model, "_item_factor"):
             factor = self.model._item_factor(
-                itemid, react_users, recalculate_item
+                itemid, item_users, recalculate_item
             )  # pylint: disable=protected-access
         elif recalculate_item:
             raise NotImplementedError(f"recalculate_item isn't supported with {self.model}")

--- a/implicit/ann/faiss.py
+++ b/implicit/ann/faiss.py
@@ -130,7 +130,7 @@ class FaissModel(RecommenderBase):
             self.similar_items_index = index
 
     def similar_items(
-        self, itemid, N=10, react_users=None, recalculate_item=False, filter_items=None, items=None
+        self, itemid, N=10, recalculate_item=False, item_users=None, filter_items=None, items=None
     ):
         if items is not None and self.approximate_similar_items:
             raise NotImplementedError("using an items filter isn't supported with ANN lookup")
@@ -143,8 +143,8 @@ class FaissModel(RecommenderBase):
             return self.model.similar_items(
                 itemid,
                 N,
-                react_users=react_users,
                 recalculate_item=recalculate_item,
+                item_users=item_users,
                 filter_items=filter_items,
                 items=items,
             )
@@ -152,7 +152,7 @@ class FaissModel(RecommenderBase):
         # support recalculate_item if possible. TODO: refactor this
         if hasattr(self.model, "_item_factor"):
             factors = self.model._item_factor(
-                itemid, react_users, recalculate_item
+                itemid, item_users, recalculate_item
             )  # pylint: disable=protected-access
         elif recalculate_item:
             raise NotImplementedError(f"recalculate_item isn't supported with {self.model}")

--- a/implicit/ann/nmslib.py
+++ b/implicit/ann/nmslib.py
@@ -112,13 +112,13 @@ class NMSLibModel(RecommenderBase):
             self.recommend_index.setQueryTimeParams(self.query_params)
 
     def similar_items(
-        self, itemid, N=10, react_users=None, recalculate_item=False, filter_items=None, items=None
+        self, itemid, N=10, recalculate_item=False, item_users=None, filter_items=None, items=None
     ):
         if not self.approximate_similar_items:
             return self.model.similar_items(
                 itemid,
                 N,
-                react_users=react_users,
+                item_users=item_users,
                 recalculate_item=recalculate_item,
                 filter_items=filter_items,
                 items=items,
@@ -130,7 +130,7 @@ class NMSLibModel(RecommenderBase):
         # support recalculate_item if possible. TODO: refactor this
         if hasattr(self.model, "_item_factor"):
             factors = self.model._item_factor(
-                itemid, react_users, recalculate_item
+                itemid, item_users, recalculate_item
             )  # pylint: disable=protected-access
         elif recalculate_item:
             raise NotImplementedError(f"recalculate_item isn't supported with {self.model}")

--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -213,10 +213,10 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         )
         return user_factors[0] if np.isscalar(userid) else user_factors
 
-    def recalculate_item(self, itemid, react_users):
+    def recalculate_item(self, itemid, item_users):
         items = 1 if np.isscalar(itemid) else len(itemid)
         item_factors = np.zeros((items, self.factors), dtype=self.dtype)
-        Ciu = react_users[itemid]
+        Ciu = item_users[itemid]
         _als._least_squares(
             self.XtX,
             Ciu.indptr,

--- a/implicit/cpu/matrix_factorization_base.py
+++ b/implicit/cpu/matrix_factorization_base.py
@@ -127,15 +127,15 @@ class MatrixFactorizationBase(RecommenderBase):
             return self.recalculate_user(userid, user_items)
         return self.user_factors[userid]
 
-    def _item_factor(self, itemid, react_users, recalculate_item=False):
+    def _item_factor(self, itemid, item_users, recalculate_item=False):
         if recalculate_item:
-            return self.recalculate_item(itemid, react_users)
+            return self.recalculate_item(itemid, item_users)
         return self.item_factors[itemid]
 
     def recalculate_user(self, userid, user_items):
         raise NotImplementedError("recalculate_user is not supported with this model")
 
-    def recalculate_item(self, itemid, react_users):
+    def recalculate_item(self, itemid, item_users):
         raise NotImplementedError("recalculate_item is not supported with this model")
 
     def similar_users(self, userid, N=10, filter_users=None, users=None):
@@ -168,9 +168,9 @@ class MatrixFactorizationBase(RecommenderBase):
     similar_users.__doc__ = RecommenderBase.similar_users.__doc__
 
     def similar_items(
-        self, itemid, N=10, react_users=None, recalculate_item=False, filter_items=None, items=None
+        self, itemid, N=10, recalculate_item=False, item_users=None, filter_items=None, items=None
     ):
-        factor = self._item_factor(itemid, react_users, recalculate_item)
+        factor = self._item_factor(itemid, item_users, recalculate_item)
         factors = self.item_factors
         norms = self.item_norms
 

--- a/implicit/datasets/lastfm.py
+++ b/implicit/datasets/lastfm.py
@@ -28,7 +28,7 @@ def get_lastfm():
     with h5py.File(filename, "r") as f:
         m = f.get("artist_user_plays")
         plays = csr_matrix((m.get("data"), m.get("indices"), m.get("indptr")))
-        return np.array(f["artist"]), np.array(f["user"]), plays
+        return np.array(f["artist"].asstr()[:]), np.array(f["user"].asstr()[:]), plays
 
 
 def generate_dataset(filename, outputfilename):
@@ -74,7 +74,7 @@ def _hfd5_from_dataframe(data, outputfilename):
     plays = coo_matrix(
         (
             data["plays"].astype(np.float32),
-            (data["artist"].cat.codes.copy(), data["user"].cat.codes.copy()),
+            (data["user"].cat.codes.copy(), data["artist"].cat.codes.copy()),
         )
     ).tocsr()
 

--- a/implicit/datasets/movielens.py
+++ b/implicit/datasets/movielens.py
@@ -42,7 +42,7 @@ def get_movielens(variant="20m"):
     with h5py.File(path, "r") as f:
         m = f.get("movie_user_ratings")
         plays = csr_matrix((m.get("data"), m.get("indices"), m.get("indptr")))
-        return np.array(f["movie"]), plays
+        return np.array(f["movie"].asstr()[:]), plays
 
 
 def generate_dataset(path, variant="20m", outputpath="."):

--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -177,10 +177,10 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         )
         return user_factors[0] if np.isscalar(userid) else user_factors
 
-    def recalculate_item(self, itemid, react_users):
+    def recalculate_item(self, itemid, item_users):
         items = 1 if np.isscalar(itemid) else len(itemid)
         item_factors = implicit.gpu.Matrix.zeros(items, self.factors)
-        Ciu = implicit.gpu.CSRMatrix(react_users[itemid])
+        Ciu = implicit.gpu.CSRMatrix(item_users[itemid])
         self.solver.least_squares(
             Ciu, item_factors, self.XtX, self.user_factors, cg_steps=self.factors
         )

--- a/implicit/gpu/matrix_factorization_base.py
+++ b/implicit/gpu/matrix_factorization_base.py
@@ -158,7 +158,7 @@ class MatrixFactorizationBase(RecommenderBase):
     similar_users.__doc__ = RecommenderBase.similar_users.__doc__
 
     def similar_items(
-        self, itemid, N=10, react_users=None, recalculate_item=False, filter_items=None, items=None
+        self, itemid, N=10, recalculate_item=False, item_users=None, filter_items=None, items=None
     ):
         item_factors = self.item_factors
         norms = self.item_norms
@@ -177,7 +177,7 @@ class MatrixFactorizationBase(RecommenderBase):
                 raise IndexError("Some itemids are not in the model")
 
         if recalculate_item:
-            query_factors = self.recalculate_item(itemid, react_users)
+            query_factors = self.recalculate_item(itemid, item_users)
         else:
             query_factors = self.item_factors[itemid]
 
@@ -202,7 +202,7 @@ class MatrixFactorizationBase(RecommenderBase):
     def recalculate_user(self, userid, user_items):
         raise NotImplementedError("recalculate_user is not supported with this model")
 
-    def recalculate_item(self, itemid, react_users):
+    def recalculate_item(self, itemid, item_users):
         raise NotImplementedError("recalculate_item is not supported with this model")
 
     def __getstate__(self):

--- a/implicit/nearest_neighbours.py
+++ b/implicit/nearest_neighbours.py
@@ -106,7 +106,7 @@ class ItemItemRecommender(RecommenderBase):
         raise NotImplementedError("similar_users isn't implemented for item-item recommenders")
 
     def similar_items(
-        self, itemid, N=10, react_users=None, recalculate_item=False, filter_items=None, items=None
+        self, itemid, N=10, recalculate_item=False, item_users=None, filter_items=None, items=None
     ):
         """Returns a list of the most similar other items"""
         if recalculate_item:

--- a/implicit/recommender_base.py
+++ b/implicit/recommender_base.py
@@ -98,7 +98,7 @@ class RecommenderBase:
 
     @abstractmethod
     def similar_items(
-        self, itemid, N=10, react_users=None, recalculate_item=False, filter_items=None, items=None
+        self, itemid, N=10, recalculate_item=False, item_users=None, filter_items=None, items=None
     ):
         """
         Calculates a list of similar items
@@ -109,12 +109,13 @@ class RecommenderBase:
             The item id or an array of item ids to retrieve similar items for
         N : int, optional
             The number of similar items to return
-        react_users : csr_matrix, optional
-            A sparse matrix of shape (number_items, number_users). This lets us look
-            up the reacted users and their weights for the item.
         recalculate_item : bool, optional
             When true, don't rely on stored item state and instead recalculate from the
-            passed in react_users
+            passed in item_users
+        item_users : csr_matrix, optional
+            A sparse matrix of shape (number_items, number_users). This lets us look
+            up the users for each item. This is only needs to be set when setting
+            recalculate_item=True
         filter_items: array_like, optional
             An array of item ids to filter out from the results being returned
         items: array_like, optional

--- a/tests/recommender_base_test.py
+++ b/tests/recommender_base_test.py
@@ -216,7 +216,7 @@ class RecommenderBaseTestMixin:
 
             try:
                 recalculated_ids, recalculated_scores = model.similar_items(
-                    itemid, N=10, react_users=item_users
+                    itemid, N=10, item_users=item_users
                 )
                 assert np.allclose(ids, recalculated_ids)
                 assert np.allclose(scores, recalculated_scores)
@@ -243,7 +243,7 @@ class RecommenderBaseTestMixin:
         check_results(ids)
         try:
             ids, _ = model.similar_items(
-                itemids, N=10, recalculate_item=True, react_users=user_items.T.tocsr()
+                itemids, N=10, recalculate_item=True, item_users=user_items.T.tocsr()
             )
             check_results(ids)
         except NotImplementedError:


### PR DESCRIPTION
On the model.recommend we pass 'user_items' sparse matrix, but on the
model.similar_items call we had a 'react_users' sparse matrix. Rename
this parameter to 'item_users' to be consistent