### PR TITLE
Don't require empty rows in user_items and item_users

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ model = implicit.als.AlternatingLeastSquares(factors=50)
 model.fit(user_item_data)
 
 # recommend items for a user
-recommendations = model.recommend(userid, user_item_data)
+recommendations = model.recommend(userid, user_item_data[userid])
 
 # find related items
 related = model.similar_items(itemid)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,7 +37,7 @@ Basic Usage
     model.fit(user_item_data)
 
     # recommend items for a user
-    recommendations = model.recommend(userid, user_item_data)
+    recommendations = model.recommend(userid, user_item_data[userid])
 
     # find related items
     related = model.similar_items(itemid)

--- a/implicit/_nearest_neighbours.pyx
+++ b/implicit/_nearest_neighbours.pyx
@@ -61,7 +61,7 @@ cdef class NearestNeighboursScorer(object):
         try:
             with self.lock:
                 with nogil:
-                    for index1 in range(user_indptr[u], user_indptr[u+1]):
+                    for index1 in range(user_indptr[0], user_indptr[1]):
                         i = user_indices[index1]
                         weight = user_data[index1]
 
@@ -71,7 +71,7 @@ cdef class NearestNeighboursScorer(object):
 
                     if remove_own_likes:
                         # set the score to 0 for things already liked
-                        for index1 in range(user_indptr[u], user_indptr[u+1]):
+                        for index1 in range(user_indptr[0], user_indptr[1]):
                             i = user_indices[index1]
                             self.neighbours.sums[i] = 0
 

--- a/implicit/ann/annoy.py
+++ b/implicit/ann/annoy.py
@@ -210,7 +210,7 @@ class AnnoyModel(RecommenderBase):
             filter_items = np.array(filter_items)
 
         if filter_already_liked_items:
-            user_likes = user_items[userid].indices
+            user_likes = user_items[0].indices
             filter_items = (
                 np.append(filter_items, user_likes) if filter_items is not None else user_likes
             )

--- a/implicit/ann/faiss.py
+++ b/implicit/ann/faiss.py
@@ -241,7 +241,7 @@ class FaissModel(RecommenderBase):
             filter_items = np.array(filter_items)
 
         if filter_already_liked_items:
-            user_likes = user_items[userid].indices
+            user_likes = user_items[0].indices
             filter_items = (
                 np.append(filter_items, user_likes) if filter_items is not None else user_likes
             )

--- a/implicit/ann/nmslib.py
+++ b/implicit/ann/nmslib.py
@@ -218,7 +218,7 @@ class NMSLibModel(RecommenderBase):
             filter_items = np.array(filter_items)
 
         if filter_already_liked_items:
-            user_likes = user_items[userid].indices
+            user_likes = user_items[0].indices
             filter_items = (
                 np.append(filter_items, user_likes) if filter_items is not None else user_likes
             )

--- a/implicit/cpu/matrix_factorization_base.py
+++ b/implicit/cpu/matrix_factorization_base.py
@@ -37,10 +37,12 @@ class MatrixFactorizationBase(RecommenderBase):
         recalculate_user=False,
         items=None,
     ):
-        if (filter_already_liked_items or recalculate_user) and not isinstance(
-            user_items, csr_matrix
-        ):
-            raise ValueError("user_items needs to be a CSR sparse matrix")
+        if filter_already_liked_items or recalculate_user:
+            if not isinstance(user_items, csr_matrix):
+                raise ValueError("user_items needs to be a CSR sparse matrix")
+            user_count = 1 if np.isscalar(userid) else len(userid)
+            if user_items.shape[0] != user_count:
+                raise ValueError("user_items must contain 1 row for every user in userids")
 
         user = self._user_factor(userid, user_items, recalculate_user)
 
@@ -64,7 +66,7 @@ class MatrixFactorizationBase(RecommenderBase):
         # get a CSR matrix of items to filter per-user
         filter_query_items = None
         if filter_already_liked_items:
-            filter_query_items = user_items[userid]
+            filter_query_items = user_items
 
             # if we've been given a list of explicit itemids to rank, we need to filter down
             if items is not None:

--- a/implicit/evaluation.pyx
+++ b/implicit/evaluation.pyx
@@ -433,7 +433,7 @@ def ranking_metrics_at_k(model, train_user_items, test_user_items, int K=10,
 
     while start_idx < len(to_generate):
         batch = to_generate[start_idx: start_idx + batch_size]
-        ids, _ = model.recommend(batch, train_user_items, N=K)
+        ids, _ = model.recommend(batch, train_user_items[batch], N=K)
         start_idx += batch_size
 
         with nogil:

--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -170,7 +170,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
     def recalculate_user(self, userid, user_items):
         users = 1 if np.isscalar(userid) else len(userid)
         user_factors = implicit.gpu.Matrix.zeros(users, self.factors)
-        Cui = implicit.gpu.CSRMatrix(user_items[userid])
+        Cui = implicit.gpu.CSRMatrix(user_items)
 
         self.solver.least_squares(
             Cui, user_factors, self.YtY, self.item_factors, cg_steps=self.factors
@@ -180,7 +180,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
     def recalculate_item(self, itemid, item_users):
         items = 1 if np.isscalar(itemid) else len(itemid)
         item_factors = implicit.gpu.Matrix.zeros(items, self.factors)
-        Ciu = implicit.gpu.CSRMatrix(item_users[itemid])
+        Ciu = implicit.gpu.CSRMatrix(item_users)
         self.solver.least_squares(
             Ciu, item_factors, self.XtX, self.user_factors, cg_steps=self.factors
         )

--- a/implicit/gpu/matrix_factorization_base.py
+++ b/implicit/gpu/matrix_factorization_base.py
@@ -41,10 +41,12 @@ class MatrixFactorizationBase(RecommenderBase):
         recalculate_user=False,
         items=None,
     ):
-        if (filter_already_liked_items or recalculate_user) and not isinstance(
-            user_items, csr_matrix
-        ):
-            raise ValueError("user_items needs to be a CSR sparse matrix")
+        if filter_already_liked_items or recalculate_user:
+            if not isinstance(user_items, csr_matrix):
+                raise ValueError("user_items needs to be a CSR sparse matrix")
+            user_count = 1 if np.isscalar(userid) else len(userid)
+            if user_items.shape[0] != user_count:
+                raise ValueError("user_items must contain 1 row for every user in userids")
 
         if recalculate_user:
             user_factors = self.recalculate_user(userid, user_items)
@@ -70,7 +72,7 @@ class MatrixFactorizationBase(RecommenderBase):
 
         query_filter = None
         if filter_already_liked_items:
-            query_filter = user_items[userid]
+            query_filter = user_items
 
             # if we've been given a list of explicit itemids to rank, we need to filter down
             if items is not None:

--- a/implicit/nearest_neighbours.py
+++ b/implicit/nearest_neighbours.py
@@ -44,7 +44,13 @@ class ItemItemRecommender(RecommenderBase):
         recalculate_user=False,
         items=None,
     ):
+        if not isinstance(user_items, csr_matrix):
+            raise ValueError("user_items needs to be a CSR sparse matrix")
+
         if not np.isscalar(userid):
+            if user_items.shape[0] != len(userid):
+                raise ValueError("user_items must contain 1 row for every user in userids")
+
             return _batch_call(
                 self.recommend,
                 userid,
@@ -55,14 +61,6 @@ class ItemItemRecommender(RecommenderBase):
                 recalculate_user=recalculate_user,
                 items=items,
             )
-
-        if (filter_already_liked_items or recalculate_user) and not isinstance(
-            user_items, csr_matrix
-        ):
-            raise ValueError("user_items needs to be a CSR sparse matrix")
-
-        if userid >= user_items.shape[0]:
-            raise ValueError("userid is out of bounds of the user_items matrix")
 
         if filter_items is not None and items is not None:
             raise ValueError("Can't specify both filter_items and items")

--- a/implicit/recommender_base.py
+++ b/implicit/recommender_base.py
@@ -55,20 +55,23 @@ class RecommenderBase:
         Example usage::
 
             # calculate the top recommendations for a single user
-            ids, scores = model.recommend(0, user_items)
+            ids, scores = model.recommend(0, user_items[0])
 
             # calculate the top recommendations for a batch of users
-            ids, scores = model.recommend(np.arange(10), user_items)
+            userids = np.arange(10)
+            ids, scores = model.recommend(userids, user_items[userids])
 
         Parameters
         ----------
         userid : Union[int, array_like]
             The userid or array of userids to calculate recommendations for
         user_items : csr_matrix
-            A sparse matrix of shape (number_users, number_items). This lets us look
+            A sparse matrix of shape (users, number_items). This lets us look
             up the liked items and their weights for the user. This is used to filter out
             items that have already been liked from the output, and to also potentially
-            recalculate the user representation.
+            recalculate the user representation. Each row in this sparse matrix corresponds
+            to a row in the userid parameter: that is the first row in this matrix contains
+            the liked items for the first user in the userid array.
         N : int, optional
             The number of results to return
         filter_already_liked_items: bool, optional
@@ -132,9 +135,11 @@ class RecommenderBase:
             When true, don't rely on stored item state and instead recalculate from the
             passed in item_users
         item_users : csr_matrix, optional
-            A sparse matrix of shape (number_items, number_users). This lets us look
+            A sparse matrix of shape (itemid, number_users). This lets us look
             up the users for each item. This is only needs to be set when setting
-            recalculate_item=True
+            recalculate_item=True. This should have the same number of rows as
+            the itemid parameter, with the first row of the sparse matrix corresponding
+            to the first item in the itemid array.
         filter_items: array_like, optional
             An array of item ids to filter out from the results being returned
         items: array_like, optional

--- a/implicit/utils.py
+++ b/implicit/utils.py
@@ -81,8 +81,18 @@ def _batch_call(func, ids, *args, N=10, **kwargs):
     output_ids = np.zeros((len(ids), N), dtype=np.int32)
     output_scores = np.zeros((len(ids), N), dtype=np.float32)
 
+    user_items = kwargs.pop("user_items") if "user_items" in kwargs else None
+    item_users = kwargs.pop("item_users") if "item_users" in kwargs else None
+
+    # pylint: disable=unsubscriptable-object
     for i, idx in enumerate(ids):
-        batch_ids, batch_scores = func(idx, *args, N=N, **kwargs)
+        current_kwargs = kwargs
+        if user_items is not None:
+            current_kwargs = dict(user_items=user_items[i], **kwargs)
+        elif item_users is not None:
+            current_kwargs = dict(item_users=item_users[i], **kwargs)
+
+        batch_ids, batch_scores = func(idx, *args, N=N, **current_kwargs)
 
         # pad out to N items if we're returned fewer
         missing_items = N - len(batch_ids)

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -182,9 +182,9 @@ def test_explain():
     # TODO: this doesn't quite work with N=10 (because we returns items that should have been
     # filtered with large negative score?) also seems like the dtype is different between
     # recalculate and not
-    ids, scores = model.recommend(userid, user_items, N=3)
+    ids, scores = model.recommend(userid, user_items[userid], N=3)
     recalculated_ids, recalculated_scores = model.recommend(
-        userid, user_items, N=3, recalculate_user=True
+        userid, user_items[userid], N=3, recalculate_user=True
     )
     for item1, score1, item2, score2 in zip(ids, scores, recalculated_ids, recalculated_scores):
         assert item1 == item2

--- a/tests/gpu_test.py
+++ b/tests/gpu_test.py
@@ -71,11 +71,13 @@ def test_calculate_norms():
 )
 @pytest.mark.parametrize("from_gpu", [True, False])
 def test_cpu_gpu_conversion(model_class, from_gpu):
-    print("model_class!", model_class, from_gpu)
     model = model_class(use_gpu=from_gpu, factors=32)
     user_plays = get_checker_board(50)
     model.fit(user_plays)
     converted = model.to_cpu() if from_gpu else model.to_gpu()
     assert_allclose(
-        model.recommend(0, user_plays), converted.recommend(0, user_plays), rtol=1e-3, atol=1e-3
+        model.recommend(0, user_plays[0]),
+        converted.recommend(0, user_plays[0]),
+        rtol=1e-3,
+        atol=1e-3,
     )


### PR DESCRIPTION
In the recommend call, user_items required empty rows to be passed for users that
weren't being recommended - and likewise the similar_items had a item_users param
with the same restriction. When generating recommendations for a single user,
if the userid is large - we'd have to generate a vector with an entry for each smaller userid.

Change this to use the passed in 'userid' array, and just have the rows in the user_items
sparse matrix match those in the userid array.