### PR TITLE
Add incremental retraining support for ALS models

### DIFF
--- a/implicit/gpu/_cuda.pyx
+++ b/implicit/gpu/_cuda.pyx
@@ -148,6 +148,14 @@ cdef class Matrix(object):
 
         return ret
 
+    def assign_rows(self, rowids, Matrix other):
+        cdef IntVector rows
+        rows = IntVector(np.array(rowids).astype("int32"))
+        self.c_matrix.assign_rows(dereference(rows.c_vector), dereference(other.c_matrix))
+
+    def resize(self, int rows, int cols):
+        self.c_matrix.resize(rows, cols)
+
     def to_numpy(self):
         ret = np.zeros((self.c_matrix.rows, self.c_matrix.cols), dtype="float32")
         cdef float[:, :] temp = ret

--- a/implicit/gpu/als.cu
+++ b/implicit/gpu/als.cu
@@ -140,10 +140,10 @@ void LeastSquaresSolver::least_squares(const CSRMatrix &Cui, Matrix *X,
     throw invalid_argument("X and Y should have the same number of columns");
   if (X->cols != YtY.cols)
     throw invalid_argument("Columns of X don't match number of factors");
-  if (Cui.rows != X->rows)
-    throw invalid_argument("Dimensionality mismatch between Cui and X");
-  if (Cui.cols != Y.rows)
-    throw invalid_argument("Dimensionality mismatch between Cui and Y");
+  if (Cui.rows > X->rows)
+    throw invalid_argument("Dimensionality mismatch between rows of Cui and X");
+  if (Cui.cols > Y.rows)
+    throw invalid_argument("Dimensionality mismatch between cols of Cui and Y");
 
   // TODO: multi-gpu support
   int devId;

--- a/implicit/gpu/matrix.h
+++ b/implicit/gpu/matrix.h
@@ -34,6 +34,9 @@ struct Matrix {
   // select a bunch of rows from this matrix. this creates a copy
   Matrix(const Matrix &other, const Vector<int> &rowids);
 
+  void resize(int rows, int cols);
+  void assign_rows(const Vector<int> &rowids, const Matrix &other);
+
   Matrix() : rows(0), cols(0), data(NULL) {}
 
   // Copy the Matrix to host memory.

--- a/implicit/gpu/matrix.pxd
+++ b/implicit/gpu/matrix.pxd
@@ -23,6 +23,8 @@ cdef extern from "implicit/gpu/matrix.h" namespace "implicit::gpu" nogil:
         Matrix(const Matrix & other, const Vector[int] & rowids) except +
         Matrix(Matrix && other) except +
         void to_host(float * output) except +
+        void resize(int rows, int cols) except +
+        void assign_rows(const Vector[int] & rowids, const Matrix & other) except +
         int rows, cols
         float * data
 

--- a/tests/approximate_als_test.py
+++ b/tests/approximate_als_test.py
@@ -124,7 +124,7 @@ try:
                 recs = model.similar_items(0, N=1050)
                 self.assertEqual(recs[0][0], 0)
 
-                recs = model.recommend(0, plays.T.tocsr(), N=1050)
+                recs = model.recommend(0, plays.T.tocsr()[0], N=1050)
                 self.assertEqual(recs[0][0], 0)
 
             def test_pickle(self):


### PR DESCRIPTION
This change adds a 'partial_fit_users' and a 'partial_fit_items' methods to the ALS
models, that lets you incrementally retrain the model. This both lets you add
new items and users to the model without fully retraining, as well as recalculate
existing item/users with new interactions.