### PR TITLE
Require cmake v3.17+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.17.0)
 
 project(implicit)
 

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,10 @@ except ImportError:
 # Add CMake as a build requirement if cmake is not installed or is too low a version
 setup_requires = []
 try:
-    if LegacyVersion(get_cmake_version()) < LegacyVersion("3.5"):
-        setup_requires.append("cmake")
+    if LegacyVersion(get_cmake_version()) < LegacyVersion("3.17"):
+        setup_requires.append("cmake>=3.17")
 except SKBuildError:
-    setup_requires.append("cmake")
+    setup_requires.append("cmake>=3.17")
 
 
 def read(file_name):


### PR DESCRIPTION
The FindCUDAToolkit module was introduced in cmake v3.17 - add that
as a minimum cmake version