### PR TITLE
Use scikit-build>=0.13.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,7 @@ line-length = 100
 requires = [
     "setuptools>=42",
     "wheel",
-    # scikit-build 0.12 doesn't support Cython docstrings, get the latest code
-    # until a new release is pushed
-    # https://github.com/scikit-build/scikit-build/issues/518
-    "scikit-build@git+https://github.com/scikit-build/scikit-build.git",
+    "scikit-build>=0.13.1",
     "Cython>=0.24",
     "scipy>=0.16"
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-git+https:///github.com/scikit-build/scikit-build.git
+scikit-build>=0.13.1
 pytest
 black==21.12b0
 flake8


### PR DESCRIPTION
We were using the latest git version of scikit-build, since the
0.12 release didn't have support for docstrings in cython.

Now that scikit-build 0.13 is out, this is no longer necessary. switch
to using the stable release version.