### PR TITLE
Disable building GPU extension if IMPLICIT_DISABLE_CUDA env var is set

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
         - id: isort
           additional_dependencies: [toml]
       - repo: https://github.com/python/black
-        rev: 21.12b0
+        rev: 22.3.0
         hooks:
         - id: black
       - repo: https://github.com/pycqa/flake8

--- a/implicit/ann/annoy.py
+++ b/implicit/ann/annoy.py
@@ -146,7 +146,7 @@ class AnnoyModel(RecommenderBase):
         if filter_items is not None:
             ids, scores = _filter_items_from_results(itemid, ids, scores, filter_items, N)
 
-        return ids, 1 - (scores ** 2) / 2
+        return ids, 1 - (scores**2) / 2
 
     def recommend(
         self,
@@ -228,7 +228,7 @@ class AnnoyModel(RecommenderBase):
         # convert the distances from euclidean to cosine distance,
         # and then rescale the cosine distance to go back to inner product
         scaling = self.max_norm * np.linalg.norm(query)
-        scores = scaling * (1 - (scores ** 2) / 2)
+        scores = scaling * (1 - (scores**2) / 2)
         return ids, scores
 
     def similar_users(self, userid, N=10, filter_users=None, users=None):

--- a/implicit/gpu/CMakeLists.txt
+++ b/implicit/gpu/CMakeLists.txt
@@ -4,6 +4,11 @@ find_package(CUDAToolkit)
 if(CUDAToolkit_FOUND)
 if (${CUDAToolkit_VERSION} VERSION_LESS "11.0.0")
     message("implicit requires CUDA 11.0 or greater for GPU acceleration - found CUDA ${CUDAToolkit_VERSION}")
+
+elseif(DEFINED ENV{IMPLICIT_DISABLE_CUDA})
+    # disable building the CUDA extension if the IMPLICIT_DISABLE_CUDA environment variable is set
+    message("Disabling building the GPU extension since IMPLICIT_DISABLE_CUDA env var is set")
+
 else()
     enable_language(CUDA)
     add_cython_target(_cuda CXX)

--- a/implicit/gpu/bpr.py
+++ b/implicit/gpu/bpr.py
@@ -137,7 +137,7 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
                     Y,
                     self.learning_rate,
                     self.regularization,
-                    rs.randint(2 ** 31),
+                    rs.randint(2**31),
                     self.verify_negative_samples,
                 )
                 progress.update(1)

--- a/implicit/gpu/matrix_factorization_base.py
+++ b/implicit/gpu/matrix_factorization_base.py
@@ -239,7 +239,7 @@ def check_random_state(random_state):
     """
     if isinstance(random_state, np.random.RandomState):
         # we need to convert from numpy random state our internal random state
-        return implicit.gpu.RandomState(random_state.randint(2 ** 31))
+        return implicit.gpu.RandomState(random_state.randint(2**31))
 
     # otherwise try to initialize a new one, and let it fail through
     # on the numpy side if it doesn't work

--- a/implicit/nearest_neighbours.py
+++ b/implicit/nearest_neighbours.py
@@ -220,7 +220,7 @@ def normalize(X):
     """equivalent to scipy.preprocessing.normalize on sparse matrices
     , but lets avoid another dependency just for a small utility function"""
     X = coo_matrix(X)
-    X.data = X.data / sqrt(bincount(X.row, X.data ** 2))[X.row]
+    X.data = X.data / sqrt(bincount(X.row, X.data**2))[X.row]
     return X
 
 

--- a/implicit/utils.py
+++ b/implicit/utils.py
@@ -71,7 +71,7 @@ def augment_inner_product_matrix(factors):
 
     # add an extra dimension so that the norm of each row is the same
     # (max_norm)
-    extra_dimension = np.sqrt(max_norm ** 2 - norms ** 2)
+    extra_dimension = np.sqrt(max_norm**2 - norms**2)
     return max_norm, np.append(factors, extra_dimension.reshape(norms.shape[0], 1), axis=1)
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 
 scikit-build>=0.13.1
 pytest
-black==21.12b0
+black==22.3.0
 flake8
 isort
 codespell


### PR DESCRIPTION
Add an option to build implicit without the GPU extension, if the IMPLICIT_DISABLE_CUDA environment variable
is set. Closes https://github.com/benfred/implicit/issues/446