### PR TITLE
Use num_threads for batch recommendations in MF models

### DIFF
--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -41,9 +41,8 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
     calculate_training_loss : bool, optional
         Whether to log out the training loss at each iteration
     num_threads : int, optional
-        The number of threads to use for fitting the model. This only
-        applies for the native extensions. Specifying 0 means to default
-        to the number of cores on the machine.
+        The number of threads to use for fitting the model and batch recommend calls.
+        Specifying 0 means to default to the number of cores on the machine.
     random_state : int, numpy.random.RandomState or None, optional
         The random state for seeding the initial item and user factors.
         Default is None.
@@ -68,8 +67,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         num_threads=0,
         random_state=None,
     ):
-
-        super().__init__()
+        super().__init__(num_threads=num_threads)
 
         # parameters on how to factorize
         self.factors = factors
@@ -81,7 +79,6 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         self.use_cg = use_cg
         self.iterations = iterations
         self.calculate_training_loss = calculate_training_loss
-        self.num_threads = num_threads
         self.fit_callback = None
         self.cg_steps = 3
         self.random_state = random_state

--- a/implicit/cpu/bpr.pyx
+++ b/implicit/cpu/bpr.pyx
@@ -94,9 +94,8 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
         been liked by the user. This check increases the time needed to train but usually leads
         to better predictions.
     num_threads : int, optional
-        The number of threads to use for fitting the model. This only
-        applies for the native extensions. Specifying 0 means to default
-        to the number of cores on the machine.
+        The number of threads to use for fitting the model and batch recommend calls.
+        Specifying 0 means to default to the number of cores on the machine.
     random_state : int, RandomState or None, optional
         The random state for seeding the initial item and user factors.
         Default is None.
@@ -111,14 +110,13 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
     def __init__(self, factors=100, learning_rate=0.01, regularization=0.01, dtype=np.float32,
                  iterations=100, num_threads=0,
                  verify_negative_samples=True, random_state=None):
-        super(BayesianPersonalizedRanking, self).__init__()
+        super(BayesianPersonalizedRanking, self).__init__(num_threads=num_threads)
 
         self.factors = factors
         self.learning_rate = learning_rate
         self.iterations = iterations
         self.regularization = regularization
         self.dtype = np.dtype(dtype)
-        self.num_threads = num_threads
         self.verify_negative_samples = verify_negative_samples
         self.random_state = random_state
 

--- a/implicit/cpu/lmf.pyx
+++ b/implicit/cpu/lmf.pyx
@@ -83,9 +83,8 @@ class LogisticMatrixFactorization(MatrixFactorizationBase):
         The proportion of negative samples. i.e.) "neg_prop = 30" means if user have seen 5 items,
         then 5 * 30 = 150 negative samples are used for training.
     num_threads : int, optional
-        The number of threads to use for fitting the model. This only
-        applies for the native extensions. Specifying 0 means to default
-        to the number of cores on the machine.
+        The number of threads to use for fitting the model and batch recommendation calls.
+        Specifying 0 means to default to the number of cores on the machine.
     random_state : int, RandomState or None, optional
         The random state for seeding the initial item and user factors.
         Default is None.
@@ -101,14 +100,13 @@ class LogisticMatrixFactorization(MatrixFactorizationBase):
     def __init__(self, factors=30, learning_rate=1.00, regularization=0.6, dtype=np.float32,
                  iterations=30, neg_prop=30, num_threads=0,
                  random_state=None):
-        super(LogisticMatrixFactorization, self).__init__()
+        super(LogisticMatrixFactorization, self).__init__(num_threads=num_threads)
 
         self.factors = factors
         self.learning_rate = learning_rate
         self.iterations = iterations
         self.regularization = regularization
         self.dtype = np.dtype(dtype)
-        self.num_threads = num_threads
         self.neg_prop = neg_prop
         self.random_state = random_state
 


### PR DESCRIPTION
For the MF models on the CPU, there didn't use to be a way to
control how many threads were used during batch .recommend calls.
Re-use the num_threads parameter for this, to allow using only
a limited number of threads for calculating batch recommendation
calls.

Closes #554