### PR TITLE
Fix partial_fit_items bug with only growing by a single item

### DIFF
--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -315,7 +315,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         # ensure that we have enough storage for any new items
         items, factors = self.item_factors.shape
         max_itemid = max(itemids)
-        if max_itemid > items:
+        if max_itemid >= items:
             self.item_factors = np.concatenate(
                 [self.item_factors, np.zeros((max_itemid - items + 1, factors), dtype=self.dtype)]
             )

--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -242,7 +242,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         # ensure that we have enough storage for any new items
         items, factors = self.item_factors.shape
         max_itemid = max(itemids)
-        if max_itemid > items:
+        if max_itemid >= items:
             # TODO: grow exponentially ?
             self.item_factors.resize(max_itemid + 1, factors)
 

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -255,3 +255,9 @@ def test_incremental_retrain(use_gpu):
     model.partial_fit_items([100], likes[1])
     ids, _ = model.recommend(1, likes[1], N=2)
     assert set(ids) == {1, 100}
+
+    # check to make sure we can index only a single extra item/user
+    model.partial_fit_users([101], likes[1])
+    model.partial_fit_items([101], likes[1])
+    ids, _ = model.recommend(101, likes[1], N=3)
+    assert set(ids) == {1, 100, 101}


### PR DESCRIPTION
When trying to update with exactly 1 new item, partial_fit_items would
throw an exception since we had an off-by-one error in allocating
factor storage. Fix and add a unittest that would catch this.

Closes #556