### PR TITLE
Fix save/load for models that haven't been fit

### DIFF
--- a/implicit/cpu/lmf.pyx
+++ b/implicit/cpu/lmf.pyx
@@ -196,9 +196,8 @@ class LogisticMatrixFactorization(MatrixFactorizationBase):
 
         self._check_fit_errors()
 
-    def save(self, file):
-        np.savez(
-            file,
+    def save(self, fileobj_or_path):
+        args = dict(
             user_factors=self.user_factors,
             item_factors=self.item_factors,
             regularization=self.regularization,
@@ -208,20 +207,12 @@ class LogisticMatrixFactorization(MatrixFactorizationBase):
             num_threads=self.num_threads,
             iterations=self.iterations,
             dtype=self.dtype.name,
-        )
+            random_state=self.random_state)
 
-    @classmethod
-    def load(cls, file):
-        if isinstance(file, str) and not file.endswith(".npz"):
-            file = file + ".npz"
-        with np.load(file, allow_pickle=False) as data:
-            ret = cls()
-            for k, v in data.items():
-                if k == "dtype":
-                    ret.dtype = np.dtype(str(v))
-                else:
-                    setattr(ret, k, v)
-            return ret
+        # filter out 'None' valued args, since we can't go np.load on
+        # them without using pickle
+        args = {k:v for k,v in args.items() if v is not None}
+        np.savez(fileobj_or_path, **args)
 
 
 @cython.cdivision(True)

--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -276,6 +276,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
             regularization=self.regularization,
             iterations=self.iterations,
             calculate_training_loss=self.calculate_training_loss,
+            random_state=self.random_state,
         )
         ret.user_factors = self.user_factors.to_numpy() if self.user_factors is not None else None
         ret.item_factors = self.item_factors.to_numpy() if self.item_factors is not None else None

--- a/implicit/gpu/bpr.py
+++ b/implicit/gpu/bpr.py
@@ -158,6 +158,7 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
             regularization=self.regularization,
             iterations=self.iterations,
             verify_negative_samples=self.verify_negative_samples,
+            random_state=self.random_state,
         )
         ret.user_factors = self.user_factors.to_numpy() if self.user_factors is not None else None
         ret.item_factors = self.item_factors.to_numpy() if self.item_factors is not None else None

--- a/tests/recommender_base_test.py
+++ b/tests/recommender_base_test.py
@@ -408,3 +408,11 @@ class RecommenderBaseTestMixin:
                 reloaded = model.load(f)
                 assert_array_equal(model.similar_items(1)[0], reloaded.similar_items(1)[0])
                 assert_array_equal(model.similar_items(1)[1], reloaded.similar_items(1)[1])
+
+    def test_serialization_without_fit(self):
+        model = self._get_model()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filename = os.path.join(tmpdir, "model.npz")
+            model.save(filename)
+            reloaded = model.load(filename)
+            assert model.__dict__ == reloaded.__dict__


### PR DESCRIPTION
We were seeing errors calling the .save and .load methods
on models that hadn't been fit yet. The problem was that the
factors were None values - and couldn't be loaded back in without
using pickle (which we disable). Fix and add a unittest