### PR TITLE
Warn on non-csr input passed to model.fit

### DIFF
--- a/implicit/_nearest_neighbours.pyx
+++ b/implicit/_nearest_neighbours.pyx
@@ -1,11 +1,11 @@
-import cython
-
-from cython cimport floating, integral
-
 import threading
+import time
+import warnings
 
+import cython
 import numpy as np
 import scipy.sparse
+from cython cimport floating, integral
 from cython.operator import dereference
 from cython.parallel import parallel, prange
 
@@ -14,6 +14,8 @@ from libcpp.utility cimport pair
 from libcpp.vector cimport vector
 
 from tqdm.auto import tqdm
+
+from implicit.utils import check_csr
 
 
 cdef extern from "implicit/nearest_neighbours.h" namespace "implicit" nogil:
@@ -100,7 +102,7 @@ cdef class NearestNeighboursScorer(object):
 def all_pairs_knn(users, unsigned int K=100, int num_threads=0, show_progress=True):
     """ Returns the top K nearest neighbours for each row in the matrix.
     """
-    users = users.tocsr()
+    users = check_csr(users)
     items = users.T.tocsr()
 
     cdef int item_count = items.shape[0]

--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -9,7 +9,7 @@ import scipy
 import scipy.sparse
 from tqdm.auto import tqdm
 
-from ..utils import check_blas_config, check_random_state, nonzeros
+from ..utils import check_blas_config, check_csr, check_random_state, nonzeros
 from . import _als
 from .matrix_factorization_base import MatrixFactorizationBase
 
@@ -118,13 +118,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         # initialize the random state
         random_state = check_random_state(self.random_state)
 
-        Cui = user_items
-        if not isinstance(Cui, scipy.sparse.csr_matrix):
-            s = time.time()
-            log.debug("Converting input to CSR format")
-            Cui = Cui.tocsr()
-            log.debug("Converted input to CSR in %.3fs", time.time() - s)
-
+        Cui = check_csr(user_items)
         if Cui.dtype != np.float32:
             Cui = Cui.astype(np.float32)
 

--- a/implicit/cpu/bpr.pyx
+++ b/implicit/cpu/bpr.pyx
@@ -23,7 +23,7 @@ import scipy.sparse
 
 from libcpp.vector cimport vector
 
-from ..utils import check_random_state
+from ..utils import check_csr, check_random_state
 from .matrix_factorization_base import MatrixFactorizationBase
 
 log = logging.getLogger("implicit")
@@ -141,6 +141,7 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
         if user_items.dtype != np.float32:
             user_items = user_items.astype(np.float32)
 
+        user_items = check_csr(user_items)
         users, items = user_items.shape
 
         # We need efficient user lookup for case of removing own likes

--- a/implicit/cpu/lmf.pyx
+++ b/implicit/cpu/lmf.pyx
@@ -25,7 +25,7 @@ import scipy.sparse
 
 from libcpp.vector cimport vector
 
-from ..utils import check_random_state
+from ..utils import check_csr, check_random_state
 from .matrix_factorization_base import MatrixFactorizationBase
 
 log = logging.getLogger("implicit")
@@ -134,7 +134,7 @@ class LogisticMatrixFactorization(MatrixFactorizationBase):
 
         users, items = user_items.shape
 
-        user_items = user_items.tocsr()
+        user_items = check_csr(user_items)
         item_users = user_items.T.tocsr()
 
         if not item_users.has_sorted_indices:

--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -2,13 +2,11 @@ import logging
 import time
 
 import numpy as np
-import scipy
-import scipy.sparse
 from tqdm.auto import tqdm
 
 import implicit.gpu
-
-from .matrix_factorization_base import MatrixFactorizationBase, check_random_state
+from implicit.gpu.matrix_factorization_base import MatrixFactorizationBase, check_random_state
+from implicit.utils import check_csr
 
 log = logging.getLogger("implicit")
 
@@ -101,12 +99,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         random_state = check_random_state(self.random_state)
 
         # TODO: allow passing in cupy arrays on gpu
-        Cui = user_items
-        if not isinstance(Cui, scipy.sparse.csr_matrix):
-            s = time.time()
-            log.debug("Converting input to CSR format")
-            Cui = Cui.tocsr()
-            log.debug("Converted input to CSR in %.3fs", time.time() - s)
+        Cui = check_csr(user_items)
 
         if Cui.dtype != np.float32:
             Cui = Cui.astype(np.float32)

--- a/implicit/gpu/bpr.py
+++ b/implicit/gpu/bpr.py
@@ -5,7 +5,7 @@ from tqdm.auto import tqdm
 
 import implicit.gpu
 
-from ..utils import check_random_state
+from ..utils import check_csr, check_random_state
 from .matrix_factorization_base import MatrixFactorizationBase
 
 log = logging.getLogger("implicit")
@@ -79,6 +79,7 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
             Whether to show a progress bar
         """
         rs = check_random_state(self.random_state)
+        user_items = check_csr(user_items)
 
         # for now, all we handle is float 32 values
         if user_items.dtype != np.float32:

--- a/implicit/utils.py
+++ b/implicit/utils.py
@@ -1,7 +1,9 @@
 import os
+import time
 import warnings
 
 import numpy as np
+import scipy.sparse
 
 
 def nonzeros(m, row):
@@ -122,3 +124,20 @@ def _filter_items_from_results(queryid, ids, scores, filter_items, N):
             filtered_scores[row] = scores[row][mask][:N]
         ids, scores = filtered_ids, filtered_scores
     return ids, scores
+
+
+class ParameterWarning(Warning):
+    pass
+
+
+def check_csr(user_items):
+    if not isinstance(user_items, scipy.sparse.csr_matrix):
+        class_name = user_items.__class__.__name__
+        start = time.time()
+        user_items = user_items.tocsr()
+        warnings.warn(
+            f"Method expects CSR input, and was passed {class_name} instead. "
+            f"Converting to CSR took {time.time() - start} seconds",
+            ParameterWarning,
+        )
+    return user_items

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,8 @@ CUDACXX = "/usr/local/cuda/bin/nvcc"
 # wheel cannot be tested in this configuration.
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "universal2", "arm64"]
+
+
+
+[tool.pytest.ini_options]
+filterwarnings = ['ignore::implicit.utils.ParameterWarning']

--- a/tests/recommender_base_test.py
+++ b/tests/recommender_base_test.py
@@ -5,11 +5,13 @@ import random
 import tempfile
 
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
 from scipy.sparse import csr_matrix
 
 from implicit.evaluation import precision_at_k
 from implicit.nearest_neighbours import ItemItemRecommender
+from implicit.utils import ParameterWarning
 
 
 def get_checker_board(X):
@@ -294,6 +296,19 @@ class RecommenderBaseTestMixin:
         for itemid in range(40):
             ids, _ = model.similar_items(itemid, 10)
             self.assertTrue(42 not in ids)
+
+    def test_fit_non_csr_matrix(self):
+        # models should be able to fit user_items that are passed as a COO or LiL matrix
+        # but should warn on input
+        user_items = get_checker_board(50)
+        model = self._get_model()
+
+        with pytest.warns(ParameterWarning):
+            model.fit(user_items.tocoo(), show_progress=False)
+
+        model = self._get_model()
+        with pytest.warns(ParameterWarning):
+            model.fit(user_items.tolil(), show_progress=False)
 
     def test_dtype(self):
         # models should be able to accept input of either float32 or float64


### PR DESCRIPTION
Previously we allowed non-csr inputs to the ALS models, but would fail
if a non-csr matrix was passed to the BPR model.fit. Change to be consistent
in allowing, but warn if we are based a COO or LIL matrix instead of the CSR
matrix we expect.