### PR TITLE
Add an `alpha` parameter for the ALS models

### DIFF
--- a/examples/tutorial_lastfm.ipynb
+++ b/examples/tutorial_lastfm.ipynb
@@ -125,8 +125,8 @@
    "source": [
     "from implicit.als import AlternatingLeastSquares\n",
     "\n",
-    "model = AlternatingLeastSquares(factors=64, regularization=0.05)\n",
-    "model.fit(2 * user_plays)"
+    "model = AlternatingLeastSquares(factors=64, regularization=0.05, alpha=2.0)\n",
+    "model.fit(user_plays)"
    ]
   },
   {

--- a/implicit/als.py
+++ b/implicit/als.py
@@ -7,6 +7,7 @@ import implicit.gpu.als
 def AlternatingLeastSquares(
     factors=100,
     regularization=0.01,
+    alpha=1.0,
     dtype=np.float32,
     use_native=True,
     use_cg=True,
@@ -33,6 +34,8 @@ def AlternatingLeastSquares(
         The number of latent factors to compute
     regularization : float, optional
         The regularization factor to use
+    alpha : float, optional
+        The weight to give to positive examples.
     dtype : data-type, optional
         Specifies whether to generate 64 bit or 32 bit floating point factors
     use_native : bool, optional
@@ -57,6 +60,7 @@ def AlternatingLeastSquares(
         return implicit.gpu.als.AlternatingLeastSquares(
             factors,
             regularization,
+            alpha,
             iterations=iterations,
             calculate_training_loss=calculate_training_loss,
             random_state=random_state,
@@ -64,6 +68,7 @@ def AlternatingLeastSquares(
     return implicit.cpu.als.AlternatingLeastSquares(
         factors,
         regularization,
+        alpha,
         dtype,
         use_native,
         use_cg,

--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -128,7 +128,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
 
         # Give the positive examples more weight if asked for
         if self.alpha != 1.0:
-            Cui *= self.alpha
+            Cui = self.alpha * Cui
 
         s = time.time()
         Ciu = Cui.T.tocsr()
@@ -360,9 +360,13 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
             A factorized representation of the user. Passing this in to
             future 'explain' calls will lead to noticeable speedups
         """
+
+        user_items = check_csr(user_items)
+        if self.alpha != 1.0:
+            user_items = self.alpha * user_items
+
         # user_weights = Cholesky decomposition of Wu^-1
         # from section 5 of the paper CF for Implicit Feedback Datasets
-        user_items = user_items.tocsr()
         if user_weights is None:
             A, _ = user_linear_equation(
                 self.item_factors, self.YtY, user_items, userid, self.regularization, self.factors

--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -217,6 +217,9 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         if user_items.shape[0] != users:
             raise ValueError("user_items should have one row for every item in user")
 
+        if self.alpha != 1.0:
+            user_items = self.alpha * user_items
+
         user_factors = np.zeros((users, self.factors), dtype=self.dtype)
         _als._least_squares(
             self.YtY,
@@ -244,6 +247,10 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
             Sparse matrix of (items, users) that contain the users that liked
             each item
         """
+
+        if self.alpha != 1.0:
+            item_users = self.alpha * item_users
+
         items = 1 if np.isscalar(itemid) else len(itemid)
         item_factors = np.zeros((items, self.factors), dtype=self.dtype)
         _als._least_squares(

--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -30,6 +30,8 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         The number of latent factors to compute
     regularization : float, optional
         The regularization factor to use
+    alpha : float, optional
+        The weight to give to positive examples.
     dtype : data-type, optional
         Specifies whether to generate 64 bit or 32 bit floating point factors
     use_native : bool, optional
@@ -59,6 +61,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         self,
         factors=100,
         regularization=0.01,
+        alpha=1.0,
         dtype=np.float32,
         use_native=True,
         use_cg=True,
@@ -72,6 +75,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         # parameters on how to factorize
         self.factors = factors
         self.regularization = regularization
+        self.alpha = alpha
 
         # options on how to fit the model
         self.dtype = np.dtype(dtype)
@@ -121,6 +125,10 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         Cui = check_csr(user_items)
         if Cui.dtype != np.float32:
             Cui = Cui.astype(np.float32)
+
+        # Give the positive examples more weight if asked for
+        if self.alpha != 1.0:
+            Cui *= self.alpha
 
         s = time.time()
         Ciu = Cui.T.tocsr()
@@ -408,6 +416,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         ret = implicit.gpu.als.AlternatingLeastSquares(
             factors=self.factors,
             regularization=self.regularization,
+            alpha=self.alpha,
             iterations=self.iterations,
             calculate_training_loss=self.calculate_training_loss,
             random_state=self.random_state,
@@ -432,6 +441,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
             calculate_training_loss=self.calculate_training_loss,
             dtype=self.dtype.name,
             random_state=self.random_state,
+            alpha=self.alpha,
         )
         # filter out 'None' valued args, since we can't go np.load on
         # them without using pickle

--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -165,6 +165,9 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
             log.info("Final training loss %.4f", loss)
 
     def recalculate_user(self, userid, user_items):
+        if self.alpha != 1.0:
+            user_items = self.alpha * user_items
+
         users = 1 if np.isscalar(userid) else len(userid)
         user_factors = implicit.gpu.Matrix.zeros(users, self.factors)
         Cui = implicit.gpu.CSRMatrix(user_items)
@@ -175,6 +178,9 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         return user_factors[0] if np.isscalar(userid) else user_factors
 
     def recalculate_item(self, itemid, item_users):
+        if self.alpha != 1.0:
+            item_users = self.alpha * item_users
+
         items = 1 if np.isscalar(itemid) else len(itemid)
         item_factors = implicit.gpu.Matrix.zeros(items, self.factors)
         Ciu = implicit.gpu.CSRMatrix(item_users)

--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -25,6 +25,8 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         The number of latent factors to compute
     regularization : float, optional
         The regularization factor to use
+    alpha : float, optional
+        The weight to give to positive examples.
     iterations : int, optional
         The number of ALS iterations to use when fitting data
     calculate_training_loss : bool, optional
@@ -45,6 +47,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         self,
         factors=64,
         regularization=0.01,
+        alpha=1.0,
         iterations=15,
         calculate_training_loss=False,
         random_state=None,
@@ -57,6 +60,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         # parameters on how to factorize
         self.factors = factors
         self.regularization = regularization
+        self.alpha = alpha
 
         # options on how to fit the model
         self.iterations = iterations
@@ -267,6 +271,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         ret = implicit.cpu.als.AlternatingLeastSquares(
             factors=self.factors,
             regularization=self.regularization,
+            alpha=self.alpha,
             iterations=self.iterations,
             calculate_training_loss=self.calculate_training_loss,
             random_state=self.random_state,

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -121,18 +121,18 @@ def test_factorize(use_native, use_gpu, use_cg, dtype):
         ],
         dtype=np.float64,
     )
-    user_items = counts * 2
 
     model = AlternatingLeastSquares(
         factors=6,
         regularization=0,
+        alpha=2.0,
         dtype=dtype,
         use_native=use_native,
         use_cg=use_cg,
         use_gpu=use_gpu,
         random_state=42,
     )
-    model.fit(user_items, show_progress=False)
+    model.fit(counts, show_progress=False)
     rows, cols = model.user_factors, model.item_factors
 
     if use_gpu:
@@ -161,12 +161,12 @@ def test_explain():
         ],
         dtype=np.float32,
     )
-    item_users = counts * 2
-    user_items = item_users.T.tocsr()
+    user_items = counts.T.tocsr()
 
     model = AlternatingLeastSquares(
         factors=4,
         regularization=20,
+        alpha=2.0,
         use_native=False,
         use_cg=False,
         use_gpu=False,


### PR DESCRIPTION
This adds an alpha parameter to the ALS models - which is the weight each
positive example is multiplied by. While we could previously achieve the
same result before by passsing a sparse matrix to model.fit where the weight
was already multiplied in, having as an explicit parameter makes it easier
to work with hyper parameter tuning frameworks - letting you treat the same
as things like regularization/epochs etc