### PR TITLE
Only call sort_indices when verifying negative samples

### DIFF
--- a/implicit/cpu/bpr.pyx
+++ b/implicit/cpu/bpr.pyx
@@ -145,7 +145,7 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
         users, items = user_items.shape
 
         # We need efficient user lookup for case of removing own likes
-        if not user_items.has_sorted_indices:
+        if self.verify_negative_samples and not user_items.has_sorted_indices:
             user_items.sort_indices()
 
         # this basically calculates the 'row' attribute of a COO matrix

--- a/implicit/gpu/bpr.py
+++ b/implicit/gpu/bpr.py
@@ -88,7 +88,7 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
         users, items = user_items.shape
 
         # We need efficient user lookup for case of removing own likes
-        if not user_items.has_sorted_indices:
+        if self.verify_negative_samples and not user_items.has_sorted_indices:
             user_items.sort_indices()
 
         # this basically calculates the 'row' attribute of a COO matrix


### PR DESCRIPTION
In the BPR model, we only need sorted indices in the CSR matrix input
to verify negative samples. Change to not sort the indices when we're
not verifying negative samples.