### PR TITLE
Fix ItemItemRecommender to use float32, and handle int matrices

### DIFF
--- a/implicit/nearest_neighbours.py
+++ b/implicit/nearest_neighbours.py
@@ -4,7 +4,7 @@ from scipy.sparse import coo_matrix, csr_matrix
 
 from ._nearest_neighbours import NearestNeighboursScorer, all_pairs_knn
 from .recommender_base import RecommenderBase
-from .utils import _batch_call
+from .utils import _batch_call, check_csr, check_float_dtype
 
 
 class ItemItemRecommender(RecommenderBase):
@@ -29,6 +29,9 @@ class ItemItemRecommender(RecommenderBase):
 
     def fit(self, weighted, show_progress=True):
         """Computes and stores the similarity matrix"""
+        weighted = check_csr(weighted)
+        weighted = check_float_dtype(weighted)
+
         self.similarity = all_pairs_knn(
             weighted, self.K, show_progress=show_progress, num_threads=self.num_threads
         ).tocsr()
@@ -44,6 +47,7 @@ class ItemItemRecommender(RecommenderBase):
         recalculate_user=False,
         items=None,
     ):
+        user_items = check_float_dtype(user_items)
         if not isinstance(user_items, csr_matrix):
             raise ValueError("user_items needs to be a CSR sparse matrix")
 

--- a/implicit/utils.py
+++ b/implicit/utils.py
@@ -141,3 +141,9 @@ def check_csr(user_items):
             ParameterWarning,
         )
     return user_items
+
+
+def check_float_dtype(user_items):
+    if not np.issubdtype(user_items.dtype, np.float32):
+        return user_items.astype(np.float32)
+    return user_items


### PR DESCRIPTION
```python
ii_model = BM25Recommender(K=25, K1=1.5, B=1.)
ii_model.fit(tr)
ranking_metrics_at_k(ii_model, tr, te, K=100)
```
where tr has integral dtype.
```
----> 2 ranking_metrics_at_k(ii_model, tr.astype(np.int32), te, K=100)

File evaluation.pyx:436, in implicit.evaluation.ranking_metrics_at_k()

File ~/miniforge3/lib/python3.9/site-packages/implicit/nearest_neighbours.py:54, in ItemItemRecommender.recommend(self, userid, user_items, N, filter_already_liked_items, filter_items, recalculate_user, items)
     51     if user_items.shape[0] != len(userid):
     52         raise ValueError("user_items must contain 1 row for every user in userids")
---> 54     return _batch_call(
     55         self.recommend,
     56         userid,
     57         user_items=user_items,
     58         N=N,
     59         filter_already_liked_items=filter_already_liked_items,
     60         filter_items=filter_items,
     61         recalculate_user=recalculate_user,
     62         items=items,
     63     )
     65 if filter_items is not None and items is not None:
     66     raise ValueError("Can't specify both filter_items and items")

File ~/miniforge3/lib/python3.9/site-packages/implicit/utils.py:97, in _batch_call(func, ids, N, *args, **kwargs)
     94 elif item_users is not None:
     95     current_kwargs = dict(item_users=item_users[i], **kwargs)
---> 97 batch_ids, batch_scores = func(idx, *args, N=N, **current_kwargs)
     99 # pad out to N items if we're returned fewer
    100 missing_items = N - len(batch_ids)

File ~/miniforge3/lib/python3.9/site-packages/implicit/nearest_neighbours.py:77, in ItemItemRecommender.recommend(self, userid, user_items, N, filter_already_liked_items, filter_items, recalculate_user, items)
     74     if items.max() >= N or items.min() < 0:
     75         raise IndexError("Some of selected itemids are not in the model")
---> 77 ids, scores = self.scorer.recommend(
     78     userid,
     79     user_items.indptr,
     80     user_items.indices,
     81     user_items.data,
     82     K=N,
     83     remove_own_likes=filter_already_liked_items,
     84 )
     86 if filter_items is not None:
     87     mask = np.in1d(ids, filter_items, invert=True)

File _nearest_neighbours.pyx:52, in implicit._nearest_neighbours.NearestNeighboursScorer.__pyx_fused_cpdef()

TypeError: No matching signature found

```
if integer csr user_item matrix is given, ItemItemRecommenders raise Error which is not human-readable.
change integer matrices to float matrix solves it, but I think it's hard to find.