### PR TITLE
docs: Fix a few typos

### DIFF
--- a/ci/rename_wheels.py
+++ b/ci/rename_wheels.py
@@ -5,7 +5,7 @@ import shutil
 
 if __name__ == "__main__":
     # auditwheel will try to vendor cublas/cudart/curand etc - which makes the
-    # packagae unacceptably large. instead of running auditwheel lets just rename
+    # package unacceptably large. instead of running auditwheel lets just rename
     # to be manylinux
     wheelhouse = os.path.join(
         os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "wheelhouse"

--- a/examples/lastfm.py
+++ b/examples/lastfm.py
@@ -2,7 +2,7 @@
 from the last.fm dataset. More details can be found
 at http://www.benfrederickson.com/matrix-factorization/
 
-This code will automically download a HDF5 version of the dataset from
+This code will automatically download a HDF5 version of the dataset from
 GitHub when it is first run. The original dataset can also be found at
 http://ocelma.net/MusicRecommendationDataset/lastfm-360K.html
 """


### PR DESCRIPTION
There are small typos in:
- ci/rename_wheels.py
- examples/lastfm.py

Fixes:
- Should read `package` rather than `packagae`.
- Should read `automatically` rather than `automically`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md