### PR TITLE
Fix `recalculate_user` / `recalculate_user` on the GPU

### DIFF
--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -261,14 +261,14 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
     @property
     def YtY(self):
         if self._YtY is None:
-            self._YtY = implicit.gpu.Matrix(self.factors, self.factors)
+            self._YtY = implicit.gpu.Matrix.zeros(self.factors, self.factors)
             self.solver.calculate_yty(self.item_factors, self._YtY, self.regularization)
         return self._YtY
 
     @property
     def XtX(self):
         if self._XtX is None:
-            self._XtX = implicit.gpu.Matrix(self.factors, self.factors)
+            self._XtX = implicit.gpu.Matrix.zeros(self.factors, self.factors)
             self.solver.calculate_yty(self.user_factors, self._XtX, self.regularization)
         return self._XtX
 

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 from recommender_base_test import RecommenderBaseTestMixin, get_checker_board
 from scipy.sparse import coo_matrix, csr_matrix, random
 
@@ -31,6 +32,21 @@ def test_zero_iterations_with_loss(use_gpu):
         factors=128, use_gpu=use_gpu, iterations=0, calculate_training_loss=True
     )
     model.fit(csr_matrix(np.ones((10, 10))))
+
+
+@pytest.mark.skipif(not HAS_CUDA, reason="test requires gpu")
+def test_recalculate_after_cpu_conversion():
+    # test out issue reported in https://github.com/benfred/implicit/issues/597
+    user_items = get_checker_board(50)
+
+    model = AlternatingLeastSquares(factors=2, use_gpu=True)
+    model.fit(user_items)
+    original_ids, _ = model.recommend(0, user_items=user_items[0], recalculate_user=True)
+
+    model = model.to_cpu().to_gpu()
+    ids, _ = model.recommend(0, user_items=user_items[0], recalculate_user=True)
+
+    assert_array_equal(ids, original_ids)
 
 
 @pytest.mark.parametrize("use_native", [True, False])


### PR DESCRIPTION
The recalculate_user or recalculate_item functionality didn't work on the GPU
AlternatingLeastSquares model, if the model was created from a saved version
of converted from a CPU model. Fix and add a unittest that would have caught this

Fixes #597