### PR TITLE
Handle more than 2**31 parameters on GPU models

### DIFF
--- a/implicit/gpu/_cuda.pyx
+++ b/implicit/gpu/_cuda.pyx
@@ -54,7 +54,7 @@ cdef class KnnQuery(object):
         cdef CppMatrix * queries = m.c_matrix
         cdef CppCOOMatrix * c_query_filter = NULL
         cdef CppVector[int] * c_item_filter = NULL
-        cdef int rows = queries.rows
+        cdef size_t rows = queries.rows
         cdef int[:, :] x
         cdef float[:, :] y
 
@@ -154,7 +154,7 @@ cdef class Matrix(object):
         rows = IntVector(np.array(rowids).astype("int32"))
         self.c_matrix.assign_rows(dereference(rows.c_vector), dereference(other.c_matrix))
 
-    def resize(self, int rows, int cols):
+    def resize(self, size_t rows, size_t cols):
         self.c_matrix.resize(rows, cols)
 
     def to_numpy(self):

--- a/implicit/gpu/bpr.cu
+++ b/implicit/gpu/bpr.cu
@@ -16,7 +16,7 @@ namespace gpu {
 
 __global__ void bpr_update_kernel(int samples, unsigned int *random_likes,
                                   unsigned int *random_dislikes, int *itemids,
-                                  int *userids, int *indptr, int factors,
+                                  int *userids, int *indptr, size_t factors,
                                   float *X, float *Y, float learning_rate,
                                   float reg, bool verify_negative_samples,
                                   int *stats) {

--- a/implicit/gpu/knn.cu
+++ b/implicit/gpu/knn.cu
@@ -153,7 +153,7 @@ void KnnQuery::topk(const Matrix &items, const Matrix &query, int k,
     batch_size *= 0.15;
   }
 
-  batch_size = std::min(batch_size, static_cast<size_t>(query.rows));
+  batch_size = std::min(batch_size, query.rows);
   batch_size = std::max(batch_size, static_cast<size_t>(1));
 
   rmm::device_uvector<float> temp_mem(batch_size * temp_distances_cols, stream,
@@ -170,7 +170,7 @@ void KnnQuery::topk(const Matrix &items, const Matrix &query, int k,
   }
 
   for (int start = 0; start < query.rows; start += batch_size) {
-    auto end = std::min(query.rows, start + static_cast<int>(batch_size));
+    auto end = std::min(query.rows, start + batch_size);
 
     Matrix batch(query, start, end);
     temp_distances.rows = batch.rows;
@@ -249,7 +249,7 @@ void KnnQuery::topk(const Matrix &items, const Matrix &query, int k,
 
 void KnnQuery::argpartition(const Matrix &items, int k, int *indices,
                             float *distances, bool allow_tiling) {
-  k = std::min(k, items.cols);
+  k = std::min(k, static_cast<int>(items.cols));
 
   if (k >= GPU_MAX_SELECTION_K) {
     rmm::cuda_stream_view stream;

--- a/implicit/gpu/matrix.h
+++ b/implicit/gpu/matrix.h
@@ -8,11 +8,11 @@ namespace implicit {
 namespace gpu {
 // Thin wrappers of CUDA memory: copies to from host, frees in destructor etc
 template <typename T> struct Vector {
-  Vector(int size, const T *data = NULL);
+  Vector(size_t size, const T *data = NULL);
   void to_host(T *output) const;
 
   std::shared_ptr<rmm::device_uvector<T>> storage;
-  int size;
+  size_t size;
   T *data;
 };
 
@@ -21,20 +21,20 @@ struct Matrix {
   // device (if allocate=True and data != null). If allocate=false, this assumes
   // the data is preallocated on the gpu (cupy etc) and doesn't allocate any new
   // storage
-  Matrix(int rows, int cols, float *data = NULL, bool allocate = true);
+  Matrix(size_t rows, size_t cols, float *data = NULL, bool allocate = true);
 
   // Create a new Matrix by slicing a single row from an existing one. The
   // underlying storage buffer is shared in this case.
-  Matrix(const Matrix &other, int rowid);
+  Matrix(const Matrix &other, size_t rowid);
 
   // Slice a contiguous series of rows from this Matrix. The underlying storge
   // buffer is shared here.
-  Matrix(const Matrix &other, int start_rowid, int end_rowid);
+  Matrix(const Matrix &other, size_t start_rowid, size_t end_rowid);
 
   // select a bunch of rows from this matrix. this creates a copy
   Matrix(const Matrix &other, const Vector<int> &rowids);
 
-  void resize(int rows, int cols);
+  void resize(size_t rows, size_t cols);
   void assign_rows(const Vector<int> &rowids, const Matrix &other);
 
   Matrix() : rows(0), cols(0), data(NULL) {}
@@ -42,7 +42,7 @@ struct Matrix {
   // Copy the Matrix to host memory.
   void to_host(float *output) const;
 
-  int rows, cols;
+  size_t rows, cols;
   float *data;
 
   std::shared_ptr<rmm::device_uvector<float>> storage;

--- a/implicit/gpu/matrix.pxd
+++ b/implicit/gpu/matrix.pxd
@@ -11,21 +11,21 @@ cdef extern from "implicit/gpu/matrix.h" namespace "implicit::gpu" nogil:
                   const int * row, const int * col, const float * data) except +
 
     cdef cppclass Vector[T]:
-        Vector(int size, T * data) except +
+        Vector(size_t size, T * data) except +
         void to_host(T * output) except +
         T * data
-        int size
+        size_t size
 
     cdef cppclass Matrix:
-        Matrix(int rows, int cols, float * data, bool host) except +
-        Matrix(const Matrix & other, int rowid) except +
-        Matrix(const Matrix & other, int start, int end) except +
+        Matrix(size_t rows, size_t cols, float * data, bool host) except +
+        Matrix(const Matrix & other, size_t rowid) except +
+        Matrix(const Matrix & other, size_t start, size_t end) except +
         Matrix(const Matrix & other, const Vector[int] & rowids) except +
         Matrix(Matrix && other) except +
         void to_host(float * output) except +
-        void resize(int rows, int cols) except +
+        void resize(size_t rows, size_t cols) except +
         void assign_rows(const Vector[int] & rowids, const Matrix & other) except +
-        int rows, cols
+        size_t rows, cols
         float * data
 
     Matrix calculate_norms(const Matrix & items) except +

--- a/implicit/gpu/random.cu
+++ b/implicit/gpu/random.cu
@@ -16,7 +16,7 @@ RandomState::RandomState(long seed) {
   CHECK_CURAND(curandSetPseudoRandomGeneratorSeed(rng, seed));
 }
 
-Matrix RandomState::uniform(int rows, int cols, float low, float high) {
+Matrix RandomState::uniform(size_t rows, size_t cols, float low, float high) {
   Matrix ret(rows, cols, NULL);
   CHECK_CURAND(curandGenerateUniform(rng, ret.data, rows * cols));
 
@@ -30,7 +30,7 @@ Matrix RandomState::uniform(int rows, int cols, float low, float high) {
   return ret;
 }
 
-Matrix RandomState::randn(int rows, int cols, float mean, float stddev) {
+Matrix RandomState::randn(size_t rows, size_t cols, float mean, float stddev) {
   Matrix ret(rows, cols, NULL);
   CHECK_CURAND(curandGenerateNormal(rng, ret.data, rows * cols, mean, stddev));
   return ret;

--- a/implicit/gpu/random.h
+++ b/implicit/gpu/random.h
@@ -11,8 +11,8 @@ struct RandomState {
   RandomState(long seed);
   ~RandomState();
 
-  Matrix uniform(int rows, int cols, float low = 0.0, float high = 1.0);
-  Matrix randn(int rows, int cols, float mean = 0, float stddev = 1);
+  Matrix uniform(size_t rows, size_t cols, float low = 0.0, float high = 1.0);
+  Matrix randn(size_t rows, size_t cols, float mean = 0, float stddev = 1);
 
   RandomState(const RandomState &) = delete;
   RandomState &operator=(const RandomState &) = delete;

--- a/implicit/gpu/random.pxd
+++ b/implicit/gpu/random.pxd
@@ -4,5 +4,5 @@ from .matrix cimport Matrix
 cdef extern from "implicit/gpu/random.h" namespace "implicit::gpu" nogil:
     cdef cppclass RandomState:
         RandomState(long rows) except +
-        Matrix uniform(int rows, int cols, float low, float high) except +
-        Matrix randn(int rows, int cols, float mean, float stdev) except +
+        Matrix uniform(size_t rows, size_t cols, float low, float high) except +
+        Matrix randn(size_t rows, size_t cols, float mean, float stdev) except +


### PR DESCRIPTION
We had some issues that prevented us from learning models with more than
2**31 parameters in one of the matrices (so ~8GB of total space). This
was because we were using int32 to represent the rows/cols - and
when multiplying together we'd overflow.

Fix by using size_t. Have manually verified I can train a model with
over 25M users and 128 factors with this change (both bpr & als).