### PR TITLE
Allow GPU models to train on sparse matrices that exceed the size of available GPU memory

### DIFF
--- a/implicit/gpu/matrix.cu
+++ b/implicit/gpu/matrix.cu
@@ -169,17 +169,23 @@ CSRMatrix::CSRMatrix(int rows, int cols, int nonzeros, const int *indptr_,
                      const int *indices_, const float *data_)
     : rows(rows), cols(cols), nonzeros(nonzeros) {
 
-  CHECK_CUDA(cudaMalloc(&indptr, (rows + 1) * sizeof(int)));
+  CHECK_CUDA(cudaMallocManaged(&indptr, (rows + 1) * sizeof(int)));
   CHECK_CUDA(cudaMemcpy(indptr, indptr_, (rows + 1) * sizeof(int),
                         cudaMemcpyHostToDevice));
+  CHECK_CUDA(cudaMemAdvise(indptr, (rows + 1) * sizeof(int),
+                           cudaMemAdviseSetReadMostly, 0));
 
-  CHECK_CUDA(cudaMalloc(&indices, nonzeros * sizeof(int)));
+  CHECK_CUDA(cudaMallocManaged(&indices, nonzeros * sizeof(int)));
   CHECK_CUDA(cudaMemcpy(indices, indices_, nonzeros * sizeof(int),
                         cudaMemcpyHostToDevice));
+  CHECK_CUDA(cudaMemAdvise(indices, nonzeros * sizeof(int),
+                           cudaMemAdviseSetReadMostly, 0));
 
-  CHECK_CUDA(cudaMalloc(&data, nonzeros * sizeof(float)));
-  CHECK_CUDA(
-      cudaMemcpy(data, data_, nonzeros * sizeof(int), cudaMemcpyHostToDevice));
+  CHECK_CUDA(cudaMallocManaged(&data, nonzeros * sizeof(float)));
+  CHECK_CUDA(cudaMemcpy(data, data_, nonzeros * sizeof(float),
+                        cudaMemcpyHostToDevice));
+  CHECK_CUDA(cudaMemAdvise(data, nonzeros * sizeof(float),
+                           cudaMemAdviseSetReadMostly, 0));
 }
 
 CSRMatrix::~CSRMatrix() {
@@ -192,15 +198,15 @@ COOMatrix::COOMatrix(int rows, int cols, int nonzeros, const int *row_,
                      const int *col_, const float *data_)
     : rows(rows), cols(cols), nonzeros(nonzeros) {
 
-  CHECK_CUDA(cudaMalloc(&row, nonzeros * sizeof(int)));
+  CHECK_CUDA(cudaMallocManaged(&row, nonzeros * sizeof(int)));
   CHECK_CUDA(
       cudaMemcpy(row, row_, nonzeros * sizeof(int), cudaMemcpyHostToDevice));
 
-  CHECK_CUDA(cudaMalloc(&col, nonzeros * sizeof(int)));
+  CHECK_CUDA(cudaMallocManaged(&col, nonzeros * sizeof(int)));
   CHECK_CUDA(
       cudaMemcpy(col, col_, nonzeros * sizeof(int), cudaMemcpyHostToDevice));
 
-  CHECK_CUDA(cudaMalloc(&data, nonzeros * sizeof(float)));
+  CHECK_CUDA(cudaMallocManaged(&data, nonzeros * sizeof(float)));
   CHECK_CUDA(
       cudaMemcpy(data, data_, nonzeros * sizeof(int), cudaMemcpyHostToDevice));
 }


### PR DESCRIPTION
Use CUDA Unified Virtual Memory for sparse matrices on the GPU. This allows GPU models to train on
input sparse matrices that exceed the size of GPU memory, by letting cuda page data to/from host memory using UVM.

This has been tested on a ALS model with around 2B entries in the spare matrix, on a GPU with 16GB of memory. Previously this OOM'ed since we need around 32GB of GPU memory to store the sparse matrix and its transpose, but with this change training succeeded - and was around 20x faster on the GPU than on the CPU.
