### PR TITLE
Tweak callback API

### DIFF
--- a/implicit/ann/annoy.py
+++ b/implicit/ann/annoy.py
@@ -63,9 +63,9 @@ class AnnoyModel(RecommenderBase):
         self.n_trees = n_trees
         self.search_k = search_k
 
-    def fit(self, Cui, show_progress=True):
+    def fit(self, Cui, show_progress=True, callback=None):
         # train the model
-        self.model.fit(Cui, show_progress)
+        self.model.fit(Cui, show_progress, callback)
 
         item_factors = self.model.item_factors
         if implicit.gpu.HAS_CUDA and isinstance(item_factors, implicit.gpu.Matrix):

--- a/implicit/ann/faiss.py
+++ b/implicit/ann/faiss.py
@@ -73,8 +73,8 @@ class FaissModel(RecommenderBase):
         self.use_gpu = use_gpu
         super().__init__()
 
-    def fit(self, Cui, show_progress=True):
-        self.model.fit(Cui, show_progress)
+    def fit(self, Cui, show_progress=True, callback=None):
+        self.model.fit(Cui, show_progress, callback=callback)
 
         item_factors = self.model.item_factors
         if implicit.gpu.HAS_CUDA and isinstance(item_factors, implicit.gpu.Matrix):

--- a/implicit/ann/nmslib.py
+++ b/implicit/ann/nmslib.py
@@ -71,13 +71,13 @@ class NMSLibModel(RecommenderBase):
 
         self.max_norm = None
 
-    def fit(self, Cui, show_progress=True):
+    def fit(self, Cui, show_progress=True, callback=None):
         # nmslib can be a little chatty when first imported, disable some of
         # the logging
         logging.getLogger("nmslib").setLevel(logging.WARNING)
 
         # train the model
-        self.model.fit(Cui, show_progress)
+        self.model.fit(Cui, show_progress, callback=callback)
         item_factors = self.model.item_factors
         if implicit.gpu.HAS_CUDA and isinstance(item_factors, implicit.gpu.Matrix):
             item_factors = item_factors.to_numpy()

--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -94,7 +94,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
 
         check_blas_config()
 
-    def fit(self, user_items, show_progress=True, fit_callback=None):
+    def fit(self, user_items, show_progress=True, callback=None):
         """Factorizes the user_items matrix.
 
         After calling this method, the members 'user_factors' and 'item_factors' will be
@@ -118,7 +118,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
             and the value is the confidence that the user liked the item.
         show_progress : bool, optional
             Whether to show a progress bar during fitting
-        fit_callback: Callable, optional
+        callback: Callable, optional
             Callable function on each epoch with such arguments as epoch, elapsed time and progress
         """
         # initialize the random state
@@ -190,10 +190,10 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
                         log.info("loss %.4f", loss)
 
                 # Backward compatibility
-                if not fit_callback:
-                    fit_callback = self.fit_callback
-                if self.fit_callback:
-                    self.fit_callback(iteration, time.time() - s, loss)
+                if not callback:
+                    callback = self.fit_callback
+                if callback:
+                    callback(iteration, time.time() - s, loss)
 
         if self.calculate_training_loss:
             log.info("Final training loss %.4f", loss)

--- a/implicit/cpu/bpr.pyx
+++ b/implicit/cpu/bpr.pyx
@@ -122,7 +122,7 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
 
     @cython.cdivision(True)
     @cython.boundscheck(False)
-    def fit(self, user_items, show_progress=True, fit_callback=None):
+    def fit(self, user_items, show_progress=True, callback=None):
         """ Factorizes the user_items matrix
 
         Parameters
@@ -134,7 +134,7 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
             as a binary signal that the user liked the item.
         show_progress : bool, optional
             Whether to show a progress bar
-        fit_callback: Callable, optional
+        callback: Callable, optional
             Callable function on each epoch with such arguments as epoch, elapsed time and progress
         """
         rs = check_random_state(self.random_state)
@@ -204,8 +204,8 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
                         {"train_auc": "%.2f%%" % (100.0 * correct / (total - skipped)),
                          "skipped": "%.2f%%" % (100.0 * skipped / total)})
 
-                if fit_callback:
-                    fit_callback(epoch, time.time() - s, correct, skipped)
+                if callback:
+                    callback(epoch, time.time() - s, correct, skipped)
 
         self._check_fit_errors()
 

--- a/implicit/cpu/lmf.pyx
+++ b/implicit/cpu/lmf.pyx
@@ -112,7 +112,7 @@ class LogisticMatrixFactorization(MatrixFactorizationBase):
 
     @cython.cdivision(True)
     @cython.boundscheck(False)
-    def fit(self, user_items, show_progress=True, fit_callback=None):
+    def fit(self, user_items, show_progress=True, callback=None):
         """ Factorizes the user_items matrix
 
         Parameters
@@ -125,7 +125,7 @@ class LogisticMatrixFactorization(MatrixFactorizationBase):
             as a binary signal that the user liked the item.
         show_progress : bool, optional
             Whether to show a progress bar
-        fit_callback: Callable, optional
+        callback: Callable, optional
             Callable function on each epoch with such arguments as epoch, elapsed time and progress
         """
         rs = check_random_state(self.random_state)
@@ -196,8 +196,8 @@ class LogisticMatrixFactorization(MatrixFactorizationBase):
                            self.learning_rate, self.regularization, self.neg_prop, num_threads)
                 self.item_factors[:, -1] = 1.0
                 progress.update(1)
-                if fit_callback:
-                    fit_callback(epoch, time.time() - s)
+                if callback:
+                    callback(epoch, time.time() - s)
 
         self._check_fit_errors()
 

--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -74,7 +74,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         self._YtY = None
         self._XtX = None
 
-    def fit(self, user_items, show_progress=True, fit_callback=None):
+    def fit(self, user_items, show_progress=True, callback=None):
         """Factorizes the user_items matrix.
 
         After calling this method, the members 'user_factors' and 'item_factors' will be
@@ -98,7 +98,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
             and the value is the confidence that the user liked the item.
         show_progress : bool, optional
             Whether to show a progress bar during fitting
-        fit_callback: Callable, optional
+        callback: Callable, optional
             Callable function on each epoch with such arguments as epoch, elapsed time and progress
         """
         # initialize the random state
@@ -161,10 +161,10 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
                         log.info("loss %.4f", loss)
 
                 # Backward compatibility
-                if not fit_callback:
-                    fit_callback = self.fit_callback
-                if fit_callback:
-                    fit_callback(iteration, time.time() - s, loss)
+                if not callback:
+                    callback = self.fit_callback
+                if callback:
+                    callback(iteration, time.time() - s, loss)
 
         if self.calculate_training_loss:
             log.info("Final training loss %.4f", loss)

--- a/implicit/gpu/bpr.py
+++ b/implicit/gpu/bpr.py
@@ -66,7 +66,7 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
         self.verify_negative_samples = verify_negative_samples
         self.random_state = random_state
 
-    def fit(self, user_items, show_progress=True, fit_callback=None):
+    def fit(self, user_items, show_progress=True, callback=None):
         """Factorizes the user_items matrix
 
         Parameters
@@ -78,7 +78,7 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
             as a binary signal that the user liked the item.
         show_progress : bool, optional
             Whether to show a progress bar
-        fit_callback: Callable, optional
+        callback: Callable, optional
             Callable function on each epoch with such arguments as epoch, elapsed time and progress
         """
         rs = check_random_state(self.random_state)
@@ -154,8 +154,8 @@ class BayesianPersonalizedRanking(MatrixFactorizationBase):
                             "skipped": f"{100.0 * skipped / total:0.2f}%",
                         }
                     )
-                if fit_callback:
-                    fit_callback(_epoch, time.time() - s, correct, skipped)
+                if callback:
+                    callback(_epoch, time.time() - s, correct, skipped)
 
     def to_cpu(self) -> implicit.cpu.bpr.BayesianPersonalizedRanking:
         """Converts this model to an equivalent version running on the cpu"""

--- a/implicit/nearest_neighbours.py
+++ b/implicit/nearest_neighbours.py
@@ -27,10 +27,16 @@ class ItemItemRecommender(RecommenderBase):
         self.num_threads = num_threads
         self.scorer = None
 
-    def fit(self, weighted, show_progress=True):
+    def fit(self, weighted, show_progress=True, callback=None):
         """Computes and stores the similarity matrix"""
+        if callback:
+            raise NotImplementedError("callback isn't support on ItemItemRecommender.fit")
+
         self.similarity = all_pairs_knn(
-            weighted, self.K, show_progress=show_progress, num_threads=self.num_threads
+            weighted,
+            self.K,
+            show_progress=show_progress,
+            num_threads=self.num_threads,
         ).tocsr()
         self.scorer = NearestNeighboursScorer(self.similarity)
 
@@ -180,17 +186,17 @@ class ItemItemRecommender(RecommenderBase):
 class CosineRecommender(ItemItemRecommender):
     """An Item-Item Recommender on Cosine distances between items"""
 
-    def fit(self, counts, show_progress=True):
+    def fit(self, counts, show_progress=True, callback=None):
         # cosine distance is just the dot-product of a normalized matrix
-        ItemItemRecommender.fit(self, normalize(counts.T).T, show_progress)
+        ItemItemRecommender.fit(self, normalize(counts.T).T, show_progress, callback)
 
 
 class TFIDFRecommender(ItemItemRecommender):
     """An Item-Item Recommender on TF-IDF distances between items"""
 
-    def fit(self, counts, show_progress=True):
+    def fit(self, counts, show_progress=True, callback=None):
         weighted = normalize(tfidf_weight(counts.T)).T
-        ItemItemRecommender.fit(self, weighted, show_progress)
+        ItemItemRecommender.fit(self, weighted, show_progress, callback)
 
 
 class BM25Recommender(ItemItemRecommender):
@@ -201,9 +207,9 @@ class BM25Recommender(ItemItemRecommender):
         self.K1 = K1
         self.B = B
 
-    def fit(self, counts, show_progress=True):
+    def fit(self, counts, show_progress=True, callback=None):
         weighted = bm25_weight(counts.T, self.K1, self.B).T
-        ItemItemRecommender.fit(self, weighted, show_progress)
+        ItemItemRecommender.fit(self, weighted, show_progress, callback)
 
 
 def tfidf_weight(X):

--- a/implicit/recommender_base.py
+++ b/implicit/recommender_base.py
@@ -13,7 +13,7 @@ class RecommenderBase(metaclass=ABCMeta):
     """Defines a common interface for all recommendation models"""
 
     @abstractmethod
-    def fit(self, user_items, show_progress=True, fit_callback=None):
+    def fit(self, user_items, show_progress=True, callback=None):
         """
         Trains the model on a sparse matrix of user/item/weight
 
@@ -25,7 +25,7 @@ class RecommenderBase(metaclass=ABCMeta):
             The values are how confident you are that the item is liked by the user.
         show_progress : bool, optional
             Whether to show a progress bar during fitting
-        fit_callback: Callable, optional
+        callback: Callable, optional
             Callable function on each epoch with such arguments as epoch, elapsed time and progress
         """
 

--- a/tests/bpr_test.py
+++ b/tests/bpr_test.py
@@ -40,18 +40,11 @@ def test_fit_almost_empty_matrix():
 
 
 def test_fit_callback():
-    class FitCallback:
-        def __init__(self):
-            self.num_called = 0
+    num_called = 0
 
-        def get_num_called(self):
-            return self.num_called
-
-        def get_callback(self):
-            def inner(epoch, elapsed, correct, skipped):
-                self.num_called += 1
-
-            return inner
+    def callback(epoch, elapsed, correct, skipped):
+        nonlocal num_called
+        num_called += 1
 
     raw = [
         [1, 1, 0, 1, 0, 0],
@@ -64,7 +57,5 @@ def test_fit_callback():
     ]
     model = BayesianPersonalizedRanking(iterations=5, use_gpu=False)
 
-    fit_callback = FitCallback()
-    model.fit(csr_matrix(raw), show_progress=False, fit_callback=fit_callback.get_callback())
-
-    assert fit_callback.get_num_called() == model.iterations
+    model.fit(csr_matrix(raw), show_progress=False, callback=callback)
+    assert num_called == model.iterations

--- a/tests/recommender_base_test.py
+++ b/tests/recommender_base_test.py
@@ -431,3 +431,20 @@ class RecommenderBaseTestMixin:
             model.save(filename)
             reloaded = model.load(filename)
             assert model.__dict__ == reloaded.__dict__
+
+    def test_fit_callback(self):
+        model = self._get_model()
+
+        num_called = 0
+
+        def callback(*args, **kwargs):
+            nonlocal num_called
+            num_called += 1
+
+        try:
+            model.fit(get_checker_board(5), show_progress=False, callback=callback)
+        except NotImplementedError:
+            # callback isn't supported w/ ItemItem KNN models
+            return
+
+        assert num_called >= 1


### PR DESCRIPTION
* Rename the 'fit_callback' parameter on the '.fit' method to just
'callback' (since the fit_ is redundant)
* Update fit method signatures of subclasses like the ANN models and ItemItem models to
be consistent with the base class
* fix issue in implicit/cpu/als.py where the callback parameter wasn't being used, and add
a unittest that tests this