### PR TITLE
Remove unnecessary argument

### DIFF
--- a/implicit/_nearest_neighbours.pyx
+++ b/implicit/_nearest_neighbours.pyx
@@ -49,7 +49,7 @@ cdef class NearestNeighboursScorer(object):
         self.lock = threading.RLock()
 
     @cython.boundscheck(False)
-    def recommend(self, int u, int[:] user_indptr, int[:] user_indices, floating[:] user_data,
+    def recommend(self, int[:] user_indptr, int[:] user_indices, floating[:] user_data,
                   int K=10, bool remove_own_likes=True):
         cdef int index1, index2, i, count
         cdef double weight

--- a/implicit/nearest_neighbours.py
+++ b/implicit/nearest_neighbours.py
@@ -81,7 +81,6 @@ class ItemItemRecommender(RecommenderBase):
                 raise IndexError("Some of selected itemids are not in the model")
 
         ids, scores = self.scorer.recommend(
-            userid,
             user_items.indptr,
             user_items.indices,
             user_items.data,


### PR DESCRIPTION
Remove `int u ` argument in recommend() method in NearestNeighboursScorer
#610
