### PR TITLE
Add ialspp optimizer in cpu.ALS

### DIFF
--- a/implicit/als.py
+++ b/implicit/als.py
@@ -11,6 +11,7 @@ def AlternatingLeastSquares(
     dtype=np.float32,
     use_native=True,
     use_cg=True,
+    use_ialspp=False,
     use_gpu=implicit.gpu.HAS_CUDA,
     iterations=15,
     calculate_training_loss=False,
@@ -42,6 +43,9 @@ def AlternatingLeastSquares(
         Use native extensions to speed up model fitting
     use_cg : bool, optional
         Use a faster Conjugate Gradient solver to calculate factors
+    use_ialspp: bool, optional
+        Use a faster Block Coordinate Descent solver to calculate factors. It works only with factors >= 64.
+        Only CPU version is available now.
     use_gpu : bool, optional
         Fit on the GPU if available, default is to run on GPU only if available
     iterations : int, optional
@@ -72,6 +76,7 @@ def AlternatingLeastSquares(
         dtype,
         use_native,
         use_cg,
+        use_ialspp,
         iterations,
         calculate_training_loss,
         num_threads,

--- a/implicit/cpu/_als.pyx
+++ b/implicit/cpu/_als.pyx
@@ -281,8 +281,7 @@ def _least_squares_ialspp(integral[:] indptr, integral[:] indices, float[:] data
                 if indptr[u] == indptr[u+1]:
                     memset(x, 0, sizeof(floating) * block_size)
                     continue
-                # 여기서 풀어야 하는 것
-                # TODO: Calculating YtCuPu once before the loop begins?
+
                 # calculate residual r = (YtCuPu - (YtCuY.dot(Xu)
                 temp = -1.0
                 symv(b"U", &block_size, &temp, &YtY[0, 0], &block_size, x, &one, &zero, r, &one)

--- a/implicit/cpu/_als.pyx
+++ b/implicit/cpu/_als.pyx
@@ -234,7 +234,7 @@ def _least_squares_cg(integral[:] indptr, integral[:] indices, float[:] data,
             free(r)
             free(Ap)
 
-def least_squares_ialspp(Cui, X, Y, regularization, num_threads=0, cg_steps=3, block_size=32):
+def least_squares_ialspp(Cui, X, Y, regularization, num_threads=0, cg_steps=3, block_size=128):
     dim = X.shape[1]
     pred = np.zeros_like(Cui.data).astype('float32')
     full_gramian = np.dot(Y.T, Y)
@@ -273,7 +273,7 @@ def _least_squares_ialspp(integral[:] indptr, integral[:] indices, float[:] data
         p = <floating *> malloc(sizeof(floating) * block_size)
         r = <floating *> malloc(sizeof(floating) * block_size)
         try:
-            for u in prange(users, schedule='dynamic', chunksize=32):
+            for u in prange(users, schedule='dynamic', chunksize=16):
                 # start from previous iteration
                 x = &X[u, block_beg]
 

--- a/implicit/cpu/_als.pyx
+++ b/implicit/cpu/_als.pyx
@@ -234,6 +234,120 @@ def _least_squares_cg(integral[:] indptr, integral[:] indices, float[:] data,
             free(r)
             free(Ap)
 
+def least_squares_ialspp(Cui, X, Y, regularization, num_threads=0, cg_steps=3, block_size=32):
+    dim = X.shape[1]
+    pred = np.zeros_like(Cui.data).astype('float32')
+    full_gramian = np.dot(Y.T, Y)
+    for block_beg in range(0, dim, block_size):
+        if block_beg + block_size >= dim:
+            block_size = dim - block_beg
+        if block_size == block_beg:
+            break
+        gramian = full_gramian[block_beg:block_beg + block_size, block_beg:block_beg + block_size]
+        _least_squares_ialspp(Cui.indptr, Cui.indices, Cui.data.astype('float32'), pred,
+                              X, Y, gramian, block_beg, block_size, regularization, num_threads, cg_steps)
+
+@cython.cdivision(True)
+@cython.boundscheck(False)
+def _least_squares_ialspp(integral[:] indptr, integral[:] indices, float[:] data, float[:] pred,
+                         floating[:, :] X, floating[:, :] Y, floating[:, :] gramian,
+                         int block_beg, int block_size, float regularization,
+                         int num_threads=0, int cg_steps=3):
+    dtype = np.float64 if floating is double else np.float32
+
+    cdef integral users = X.shape[0], u, i, index
+    cdef int one = 1, it
+    cdef floating confidence, temp, alpha, rsnew, rsold
+    cdef floating zero = 0.
+
+    cdef floating[:, :] YtY = gramian + regularization * np.eye(block_size, dtype=dtype)
+
+    cdef floating * x
+    cdef floating * p
+    cdef floating * r
+    cdef floating * Ap
+
+    with nogil, parallel(num_threads=num_threads):
+        # allocate temp memory for each thread
+        Ap = <floating *> malloc(sizeof(floating) * block_size)
+        p = <floating *> malloc(sizeof(floating) * block_size)
+        r = <floating *> malloc(sizeof(floating) * block_size)
+        try:
+            for u in prange(users, schedule='dynamic', chunksize=32):
+                # start from previous iteration
+                x = &X[u, block_beg]
+
+                # if we have no items for this user, skip and set to zero
+                if indptr[u] == indptr[u+1]:
+                    memset(x, 0, sizeof(floating) * block_size)
+                    continue
+                # 여기서 풀어야 하는 것
+                # TODO: Calculating YtCuPu once before the loop begins?
+                # calculate residual r = (YtCuPu - (YtCuY.dot(Xu)
+                temp = -1.0
+                symv(b"U", &block_size, &temp, &YtY[0, 0], &block_size, x, &one, &zero, r, &one)
+                for index in range(indptr[u], indptr[u + 1]):
+                    i = indices[index]
+                    confidence = data[index]
+
+                    if confidence > 0:
+                        temp = confidence
+                    else:
+                        temp = 0
+                        confidence = -1 * confidence
+
+                    temp = temp - (confidence - 1) * (dot(&block_size, &Y[i, block_beg], &one, x, &one) - pred[index])
+                    axpy(&block_size, &temp, &Y[i, block_beg], &one, r, &one)
+
+                memcpy(p, r, sizeof(floating) * block_size)
+                rsold = dot(&block_size, r, &one, r, &one)
+
+                if rsold < 1e-20:
+                    continue
+
+                for it in range(cg_steps):
+                    # calculate Ap = YtCuYp - without actually calculating YtCuY
+                    temp = 1.0
+                    symv(b"U", &block_size, &temp, &YtY[0, 0], &block_size, p, &one, &zero, Ap, &one)
+
+                    for index in range(indptr[u], indptr[u + 1]):
+                        i = indices[index]
+                        confidence = data[index]
+
+                        if confidence < 0:
+                            confidence = -1 * confidence
+
+                        temp = (confidence - 1) * dot(&block_size, &Y[i, block_beg], &one, p, &one)
+                        axpy(&block_size, &temp, &Y[i, 0], &one, Ap, &one)
+
+                    # alpha = rsold / p.dot(Ap);
+                    alpha = rsold / dot(&block_size, p, &one, Ap, &one)
+
+                    # x += alpha * p
+                    axpy(&block_size, &alpha, p, &one, x, &one)
+
+                    # r -= alpha * Ap
+                    temp = alpha * -1
+                    axpy(&block_size, &temp, Ap, &one, r, &one)
+
+                    rsnew = dot(&block_size, r, &one, r, &one)
+                    if rsnew < 1e-20:
+                        break
+
+                    # p = r + (rsnew/rsold) * p
+                    temp = rsnew / rsold
+                    scal(&block_size, &temp, p, &one)
+                    temp = 1.0
+                    axpy(&block_size, &temp, r, &one, p, &one)
+
+                    rsold = rsnew
+                for index in range(indptr[u], indptr[u + 1]):
+                    i = indices[index]
+                    pred[index] -= dot(&block_size, &Y[i, block_beg], &one, x, &one)
+        finally:
+            free(p)
+            free(r)
+            free(Ap)
 
 def calculate_loss(Cui, X, Y, regularization, num_threads=0):
     return _calculate_loss(Cui, Cui.indptr, Cui.indices, Cui.data.astype('float32'),

--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -571,7 +571,7 @@ def least_squares_cg(Cui, X, Y, regularization, num_threads=0, cg_steps=3):
         X[u] = x
 
 
-def least_squares_ialspp(Cui, X, Y, regularization, num_threads=0, cg_steps=3, block_size=32):
+def least_squares_ialspp(Cui, X, Y, regularization, num_threads=0, cg_steps=3, block_size=128):
     factors = X.shape[1]
     pred = np.zeros_like(Cui.data).astype(np.float32)
     full_gramian = np.dot(Y.T, Y)

--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -412,7 +412,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
     def solver(self):
         if self.use_ialspp:
             if self.factors < 512:
-                log.warn(
+                log.warning(
                     "it is highly recommended that ialspp used in higher dimension than or equal to 512"
                 )
             block_size = min(128, self.factors // 4)
@@ -592,7 +592,7 @@ def _least_squares_ialspp(
     Cui, pred, X, Y, gramian, regularization, block_beg, cg_steps, block_size
 ):
     YtY = gramian + regularization * np.eye(block_size, dtype=Y.dtype)
-    users, factors = X.shape
+    users = X.shape[0]
     for u in range(users):
         # start from previous iteration
         x = X[u, block_beg : block_beg + block_size]

--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -1,5 +1,4 @@
 """ Implicit Alternating Least Squares """
- """ Implicit Alternating Least Squares """
 import functools
 import heapq
 import logging

--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -1,4 +1,5 @@
 """ Implicit Alternating Least Squares """
+ """ Implicit Alternating Least Squares """
 import functools
 import heapq
 import logging
@@ -412,8 +413,10 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
     def solver(self):
         if self.use_ialspp:
             if self.factors < 512:
-                log.warn("it is highly recommended that ialspp used in higher dimension than or equal to 512")
-            block_size = min(64, self.factors // 2)
+                log.warn(
+                    "it is highly recommended that ialspp used in higher dimension than or equal to 512"
+                )
+            block_size = min(128, self.factors // 4)
             block_size = max(256, block_size)
             solver = _als.least_squares_ialspp
             return functools.partial(solver, cg_steps=self.cg_steps, block_size=block_size)

--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -38,6 +38,8 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         Use native extensions to speed up model fitting
     use_cg : bool, optional
         Use a faster Conjugate Gradient solver to calculate factors
+    use_ialspp: bool, optional
+        Use a faster Block Coordinate Descent solver to calculate factors. It works only with factors >= 64.
     iterations : int, optional
         The number of ALS iterations to use when fitting data
     calculate_training_loss : bool, optional
@@ -65,6 +67,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         dtype=np.float32,
         use_native=True,
         use_cg=True,
+        use_ialspp=False,
         iterations=15,
         calculate_training_loss=False,
         num_threads=0,
@@ -81,6 +84,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         self.dtype = np.dtype(dtype)
         self.use_native = use_native
         self.use_cg = use_cg
+        self.use_ialspp = use_ialspp
         self.iterations = iterations
         self.calculate_training_loss = calculate_training_loss
         self.fit_callback = None
@@ -406,9 +410,17 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
 
     @property
     def solver(self):
+        if self.use_ialspp:
+            if self.factors < 512:
+                log.warn("it is highly recommended that ialspp used in higher dimension than or equal to 512")
+            block_size = min(64, self.factors // 2)
+            block_size = max(256, block_size)
+            solver = _als.least_squares_ialspp
+            return functools.partial(solver, cg_steps=self.cg_steps, block_size=block_size)
         if self.use_cg:
-            solver = _als.least_squares_cg if self.use_native else least_squares_cg
+            solver = _als.least_squares_cg if self.use_native else least_squares_ialspp
             return functools.partial(solver, cg_steps=self.cg_steps)
+
         return _als.least_squares if self.use_native else least_squares
 
     @property
@@ -555,3 +567,75 @@ def least_squares_cg(Cui, X, Y, regularization, num_threads=0, cg_steps=3):
             rsold = rsnew
 
         X[u] = x
+
+
+def least_squares_ialspp(Cui, X, Y, regularization, num_threads=0, cg_steps=3, block_size=32):
+    factors = X.shape[1]
+    pred = np.zeros_like(Cui.data).astype(np.float32)
+    full_gramian = np.dot(Y.T, Y)
+    for block_beg in range(0, factors, block_size):
+        if block_beg + block_size >= factors:
+            block_size = factors - block_beg
+        if block_size == block_beg:
+            break
+        gramian = full_gramian[
+            block_beg : block_beg + block_size, block_beg : block_beg + block_size
+        ]
+        _least_squares_ialspp(
+            Cui, pred, X, Y, gramian, regularization, block_beg, cg_steps, block_size
+        )
+
+
+def _least_squares_ialspp(
+    Cui, pred, X, Y, gramian, regularization, block_beg, cg_steps, block_size
+):
+    YtY = gramian + regularization * np.eye(block_size, dtype=Y.dtype)
+    users, factors = X.shape
+    for u in range(users):
+        # start from previous iteration
+        x = X[u, block_beg : block_beg + block_size]
+
+        # calculate residual error r = (YtCuPu - (YtCuY.dot(Xu)
+        r = -YtY.dot(x)
+        for index in range(Cui.indptr[u], Cui.indptr[u + 1]):
+            i, confidence = Cui.indices[index], Cui.data[index]
+            _pred = pred[index]
+            y = Y[i, block_beg : block_beg + block_size]
+            if confidence > 0:
+                r += (confidence - (confidence - 1) * (y.dot(x) - _pred)) * y
+            else:
+                confidence *= -1
+                r += -(confidence - 1) * (y.dot(x) - _pred) * y
+
+        p = r.copy()
+        rsold = r.dot(r)
+        if rsold < 1e-20:
+            continue
+
+        for _ in range(cg_steps):
+            # calculate Ap = YtCuYp - without actually calculating YtCuY
+            Ap = YtY.dot(p)
+            for i, confidence in nonzeros(Cui, u):
+                if confidence < 0:
+                    confidence *= -1
+
+                Ap += (
+                    (confidence - 1)
+                    * Y[i, block_beg : block_beg + block_size].dot(p)
+                    * Y[i, block_beg : block_beg + block_size]
+                )
+
+            # standard CG update
+            alpha = rsold / p.dot(Ap)
+            x += alpha * p
+            r -= alpha * Ap
+            rsnew = r.dot(r)
+            if rsnew < 1e-20:
+                break
+            p = r + (rsnew / rsold) * p
+            rsold = rsnew
+
+        X[u, block_beg : block_beg + block_size] = x
+        for index in range(Cui.indptr[u], Cui.indptr[u + 1]):
+            i = Cui.indices[index]
+            pred[index] = -np.dot(x, Y[i, block_beg : block_beg + block_size])

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -297,8 +297,7 @@ def test_incremental_retrain(use_gpu):
 
 @pytest.mark.parametrize("use_native", [True, False] if HAS_CUDA else [False])
 def test_high_dim(use_native):
-    likes = get_checker_board(64)
-    tr, vali = train_test_split(likes, 0.5)
+    tr, vali = train_test_split(get_checker_board(64), 0.5)
     cg = AlternatingLeastSquares(
         factors=512,
         regularization=0,
@@ -322,8 +321,8 @@ def test_high_dim(use_native):
         calculate_training_loss=True,
     )
 
-    cg.fit(likes)
-    ialspp.fit(likes)
-    cg_pr = ranking_metrics_at_k(cg, likes, vali, 10)["precision"]
-    ialspp_pr = ranking_metrics_at_k(ialspp, likes, vali, 10)["precision"]
+    cg.fit(tr)
+    ialspp.fit(tr)
+    cg_pr = ranking_metrics_at_k(cg, tr, vali, 10)["precision"]
+    ialspp_pr = ranking_metrics_at_k(ialspp, tr, vali, 10)["precision"]
     assert (abs(cg_pr - ialspp_pr) / (1e-6 + max(cg_pr, ialspp_pr))) <= 0.03

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -9,7 +9,7 @@ from scipy.sparse import coo_matrix, csr_matrix, random
 
 from implicit.als import AlternatingLeastSquares
 from implicit.gpu import HAS_CUDA
-
+from implcit.evaluation import ranking_metrics_at_k, train_test_split
 # pylint: disable=consider-using-f-string
 
 

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -3,13 +3,13 @@ import unittest
 
 import numpy as np
 import pytest
+from implcit.evaluation import ranking_metrics_at_k, train_test_split
 from numpy.testing import assert_array_equal
 from recommender_base_test import RecommenderBaseTestMixin, get_checker_board
 from scipy.sparse import coo_matrix, csr_matrix, random
 
 from implicit.als import AlternatingLeastSquares
 from implicit.gpu import HAS_CUDA
-from implcit.evaluation import ranking_metrics_at_k, train_test_split
 
 # pylint: disable=consider-using-f-string
 

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -10,6 +10,7 @@ from scipy.sparse import coo_matrix, csr_matrix, random
 from implicit.als import AlternatingLeastSquares
 from implicit.gpu import HAS_CUDA
 from implcit.evaluation import ranking_metrics_at_k, train_test_split
+
 # pylint: disable=consider-using-f-string
 
 

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -296,7 +296,7 @@ def test_incremental_retrain(use_gpu):
 
 
 @pytest.mark.parametrize("use_native", [True, False] if HAS_CUDA else [False])
-def test_high_dim(use_native):
+def test_comparison_cg_alspp(use_native):
     tr, vali = train_test_split(get_checker_board(64), 0.5)
     cg = AlternatingLeastSquares(
         factors=512,
@@ -306,7 +306,7 @@ def test_high_dim(use_native):
         use_cg=True,
         use_gpu=False,
         use_ialspp=False,
-        iterations=2,
+        iterations=3,
         calculate_training_loss=True,
     )
     ialspp = AlternatingLeastSquares(
@@ -317,7 +317,7 @@ def test_high_dim(use_native):
         use_cg=False,
         use_gpu=False,
         use_ialspp=True,
-        iterations=2,
+        iterations=3,
         calculate_training_loss=True,
     )
 
@@ -325,4 +325,4 @@ def test_high_dim(use_native):
     ialspp.fit(tr)
     cg_pr = ranking_metrics_at_k(cg, tr, vali, 10)["precision"]
     ialspp_pr = ranking_metrics_at_k(ialspp, tr, vali, 10)["precision"]
-    assert (abs(cg_pr - ialspp_pr) / (1e-6 + max(cg_pr, ialspp_pr))) <= 0.03
+    assert (abs(cg_pr - ialspp_pr) / (1e-6 + max(cg_pr, ialspp_pr))) <= 0.05

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -3,12 +3,12 @@ import unittest
 
 import numpy as np
 import pytest
-from implcit.evaluation import ranking_metrics_at_k, train_test_split
 from numpy.testing import assert_array_equal
 from recommender_base_test import RecommenderBaseTestMixin, get_checker_board
 from scipy.sparse import coo_matrix, csr_matrix, random
 
 from implicit.als import AlternatingLeastSquares
+from implicit.evaluation import ranking_metrics_at_k, train_test_split
 from implicit.gpu import HAS_CUDA
 
 # pylint: disable=consider-using-f-string

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -323,6 +323,6 @@ def test_comparison_cg_alspp(use_native):
 
     cg.fit(tr)
     ialspp.fit(tr)
-    cg_pr = ranking_metrics_at_k(cg, tr, vali, 10)["precision"]
-    ialspp_pr = ranking_metrics_at_k(ialspp, tr, vali, 10)["precision"]
-    assert (abs(cg_pr - ialspp_pr) / (1e-6 + max(cg_pr, ialspp_pr))) <= 0.05
+    cg_pr = ranking_metrics_at_k(cg, tr, vali, 30)["precision"]
+    ialspp_pr = ranking_metrics_at_k(ialspp, tr, vali, 30)["precision"]
+    assert (abs(cg_pr - ialspp_pr) / (1e-6 + max(cg_pr, ialspp_pr))) <= 0.1


### PR DESCRIPTION
## This PR implements
- [iALS++: Speeding up Matrix Factorization with Subspace Optimization](https://arxiv.org/abs/2110.14044) 
- [Revisiting the Performance of iALS on Item Recommendation Benchmarks
](https://dl.acm.org/doi/abs/10.1145/3523227.3548486), which is an approximate updating method for ALS.

------------------------------------------------ 

## correctness verification
I get ml-1m data and preprocessed as below
```python
counts = get_movielens(variant='1m')
user_items = counts.T.tocsr()
user_items.data[user_items.data <= 4.0] = 0
user_items.eliminate_zeros()
user_items.data[:] = 1.0
```
and run 
ALS for both CG and ialspp approach using following hyperparameter set
```python
model = AlternatingLeastSquares(
    factors=512,
    regularization=2.0,
    alpha=5.0,
    use_native=True,
    use_cg=False,
    use_gpu=False,
    use_ialspp=True,
    iterations=10,
    calculate_training_loss=False,
    num_threads=12,
)
```
and ranking metrics give almost same results
```
ranking_metrics_at_k(model, tr, te, K=50)
> {'precision': 0.1126659490491568, 'map': 0.028802994722126836, 'ndcg': 0.07890071767410052, 'auc': 0.5602418716459558}
> {'precision': 0.11149982059562254, 'map': 0.029011087049113284, 'ndcg': 0.07887135532015757, 'auc': 0.5603164551005837}
```

-----------------------------------------------------------------

## Training Speed-Up
#### i found that this approach's performance gain vary across implementation. 
In [Buffalo](https://github.com/kakao/buffalo), I observed performance gain from 256 dim, but in Implicit, training becomes fast from `num factors` of 512.


### Speedup along dimensions

  | 512 | 1024 | 2048 | 4096
-- | -- | -- | -- | --
ials++ | 62.49 | 64.57 | 78.8 | 87.42
cg | 70.62 | 107.11 | 124.4 | 610.32
 
<img width="654" alt="image" src="https://user-images.githubusercontent.com/8970081/206890243-3730fa41-57a0-41c4-8f8d-ebddf09c1c4c.png">
<img width="661" alt="image" src="https://user-images.githubusercontent.com/8970081/206890246-ba43a744-d766-4b8e-bb2f-568b9267c024.png">

Average training time per iteration becomes 1.6-1.8 times faster in moderate dimensions [512, 2048], but extremely huge more than 4096 dimensions. However, I think it is not very realistic to use dimensions larger than 2048, though.
