### PR TITLE
Fix incorrect test set values in leave_k_out splits with sparse user rows

### DIFF
--- a/implicit/evaluation.pyx
+++ b/implicit/evaluation.pyx
@@ -205,8 +205,13 @@ cpdef leave_k_out_split(
     candidate_items = items[full_candidate_mask]
     candidate_data = data[full_candidate_mask]
 
+    # reindex candidate_user indices so they are properly formatted for the
+    # calculations in _take_tails
+    xsorted = np.argsort(unique_candidate_users)
+    reindexed_candidate_users = np.searchsorted(unique_candidate_users[xsorted], candidate_users)
+
     test_idx, train_idx = _take_tails(
-        candidate_users, K, shuffled=True, return_complement=True
+        reindexed_candidate_users, K, shuffled=True, return_complement=True
     )
 
     # get all remaining remaining candidate user-item pairs, and prepare to append to

--- a/tests/evaluation_test.py
+++ b/tests/evaluation_test.py
@@ -18,17 +18,21 @@ def _get_matrix():
     mat = random(100, 100, density=0.1, format="csr", dtype=np.float32)
     return mat.tocoo()
 
+
 def _get_fixed_matrix():
-    mat =  csr_matrix([
-        [1, 0, 0, 0],
-        [3, 2, 1, 0],
-        [1, 0, 0, 0],
-        [0, 1, 0, 0],
-        [0, 0, 1, 0],
-        [0, 1, 1, 1],
-        [0, 0, 1, 0],
-    ])
+    mat = csr_matrix(
+        [
+            [1, 0, 0, 0],
+            [3, 2, 1, 0],
+            [1, 0, 0, 0],
+            [0, 1, 0, 0],
+            [0, 0, 1, 0],
+            [0, 1, 1, 1],
+            [0, 0, 1, 0],
+        ]
+    )
     return mat.tocoo()
+
 
 def test_train_test_split():
     seed = np.random.randint(1000)
@@ -44,7 +48,7 @@ def test_leave_k_out_returns_correct_shape():
     """
 
     mat = _get_matrix()
-    train, test = leave_k_out_split(mat, K=1) 
+    train, test = leave_k_out_split(mat, K=1)
     assert train.shape == mat.shape
     assert test.shape == mat.shape
 

--- a/tests/evaluation_test.py
+++ b/tests/evaluation_test.py
@@ -15,9 +15,20 @@ def _get_sample_matrix():
 
 
 def _get_matrix():
-    mat = random(100, 100, density=0.5, format="csr", dtype=np.float32)
+    mat = random(100, 100, density=0.1, format="csr", dtype=np.float32)
     return mat.tocoo()
 
+def _get_fixed_matrix():
+    mat =  csr_matrix([
+        [1, 0, 0, 0],
+        [3, 2, 1, 0],
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+        [0, 1, 1, 1],
+        [0, 0, 1, 0],
+    ])
+    return mat.tocoo()
 
 def test_train_test_split():
     seed = np.random.randint(1000)
@@ -33,7 +44,7 @@ def test_leave_k_out_returns_correct_shape():
     """
 
     mat = _get_matrix()
-    train, test = leave_k_out_split(mat, K=1)
+    train, test = leave_k_out_split(mat, K=1) 
     assert train.shape == mat.shape
     assert test.shape == mat.shape
 
@@ -45,6 +56,10 @@ def test_leave_k_out_outputs_produce_input():
     """
 
     mat = _get_matrix()
+    train, test = leave_k_out_split(mat, K=1)
+    assert ((train + test) - mat).nnz == 0
+
+    mat = _get_fixed_matrix()
     train, test = leave_k_out_split(mat, K=1)
     assert ((train + test) - mat).nnz == 0
 


### PR DESCRIPTION
Closes #639 

This PR fixes a bug in the evaluation of the `leave_k_out_split` in which the produced test matrix would contain values that were many multiples of their original value. Tests are also added on static (non-random) matrices that otherwise fail in the un-corrected implementation.

This bug resulted from a calculation that required an input array with sequential values - the fact that non-sequential values were provided led to an error in processing.

Specifically, the `arr` argument in [_take_tails](https://github.com/benfred/implicit/blob/871e0c7229b012108131b6211cd617e23a3b24bf/implicit/evaluation.pyx#L79)

>  
    ----------
    arr: ndarray
        The input array. This should be an array of integers in the range 0->n, where
        the ordered unique set of integers in said array should produce an array of
        consecutive integers. Concretely, the array [1, 0, 1, 1, 0, 3] would be invalid,
        but the array [1, 0, 1, 1, 0, 2] would not be.

was being provided as `candidate_users`, from which user indices falling below the threshold were removed, resulting in a list in which the ordered set of unique integers was not consecutive and therefore the provided array was invalid.