### PR TITLE
fix _take_tails

### DIFF
--- a/implicit/evaluation.pyx
+++ b/implicit/evaluation.pyx
@@ -122,7 +122,8 @@ cdef _take_tails(arr, int n, return_complement=False, shuffled=False):
     idx = arr.argsort()
     sorted_arr = arr[idx]
 
-    end = np.bincount(sorted_arr).cumsum() - 1
+    _, counts = np.unique(sorted_arr, return_counts=True)
+    end = counts.cumsum() - 1
     start = end - n
     ranges = np.linspace(start, end, num=n + 1, dtype=int)[1:]
 


### PR DESCRIPTION
When we use `train_only_size` **`> 0.0`** in the `leave_k_out_split` function,
the list of unique users is thinned at the entrance to the `_take_tails` function.

Then in the `_take_tails` function, the `bincount` method produces zeros in the middle of the array and the `cumsum' method starts duplicating the ends.

For example (operation of the `_take_tails` function):
arr = [0 0 0 4 4 4]
np.bincount(sorted_arr) = [3 0 0 0 3]
end = [2 2 2 2 5]

As a result of the operation of the `leave_k_out_split` function, ratings multiplied by 4 will appear in the test for user `0`

Must be:
arr = [0 0 0 2 2 2]
counts = [3 3]
end = [2 5]