### PR TITLE
Remove import of numpy.distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,6 @@ from skbuild import setup
 from skbuild.cmaker import get_cmake_version
 from skbuild.exceptions import SKBuildError
 
-try:
-    import numpy.distutils  # noqa
-except ImportError:
-    pass
 
 # Add CMake as a build requirement if cmake is not installed or is too low a version
 setup_requires = []

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ from skbuild import setup
 from skbuild.cmaker import get_cmake_version
 from skbuild.exceptions import SKBuildError
 
-
 # Add CMake as a build requirement if cmake is not installed or is too low a version
 setup_requires = []
 try:


### PR DESCRIPTION
It's deprecated, and was only put in place to work around build issues with setuptools that seem to be resolved