### PR TITLE
Fix for ALS calculate_loss on the cpu

### DIFF
--- a/implicit/cpu/_als.pyx
+++ b/implicit/cpu/_als.pyx
@@ -295,7 +295,7 @@ def _calculate_loss(Cui, integral[:] indptr, integral[:] indices, float[:] data,
                 loss += dot(&N, r, &one, &X[u, 0], &one)
                 user_norm += dot(&N, &X[u, 0], &one, &X[u, 0], &one)
 
-            for u in prange(users, schedule='dynamic', chunksize=8):
+            for i in prange(items, schedule='dynamic', chunksize=8):
                 item_norm += dot(&N, &Y[i, 0], &one, &Y[i, 0], &one)
 
         finally:

--- a/tests/als_test.py
+++ b/tests/als_test.py
@@ -302,7 +302,7 @@ def test_incremental_retrain(use_gpu):
 
 
 def test_calculate_loss_segfault():
-    # this previous snippet used to segfault, because of a bug in calculate_loss
+    # this code used to segfault, because of a bug in calculate_loss
     factors = 1
     regularization = 0
     n_users, n_items = 4, 4


### PR DESCRIPTION
We weren't calculating the loss correctly for CPU ALS models, when regularization was non-zero. In addition to incorrect results, this also could cause a segfault in certain conditions.

Fix.