### PR TITLE
Fix ALS loss calculation on GPU

### DIFF
--- a/implicit/cpu/_als.pyx
+++ b/implicit/cpu/_als.pyx
@@ -247,6 +247,7 @@ def _least_squares_cg(integral[:] indptr, integral[:] indices, float[:] data,
 
 
 def calculate_loss(Cui, X, Y, regularization, num_threads=0):
+    """ Calculates the loss for an ALS model """
     return _calculate_loss(Cui, Cui.indptr, Cui.indices, Cui.data.astype('float32'),
                            X, Y, regularization, num_threads)
 

--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -556,3 +556,6 @@ def least_squares_cg(Cui, X, Y, regularization, num_threads=0, cg_steps=3):
             rsold = rsnew
 
         X[u] = x
+
+
+calculate_loss = _als.calculate_loss

--- a/implicit/gpu/als.cu
+++ b/implicit/gpu/als.cu
@@ -256,7 +256,7 @@ float LeastSquaresSolver::calculate_loss(const CSRMatrix &Cui, const Matrix &X,
   size_t item_count = Y.rows, factors = Y.cols, user_count = X.rows;
 
   Matrix YtY(factors, factors, NULL);
-  calculate_yty(Y, &YtY, regularization);
+  calculate_yty(Y, &YtY, 0.0);
 
   float temp[2] = {0, 0};
   Matrix output(2, 1, temp);
@@ -276,7 +276,8 @@ float LeastSquaresSolver::calculate_loss(const CSRMatrix &Cui, const Matrix &X,
   CHECK_CUDA(cudaDeviceSynchronize());
   output.to_host(temp);
 
-  return temp[0] / (temp[1] + Cui.rows * Cui.cols - Cui.nonzeros);
+  size_t rows = Cui.rows, cols = Cui.cols;
+  return temp[0] / (temp[1] + rows * cols - Cui.nonzeros);
 }
 
 LeastSquaresSolver::~LeastSquaresSolver() {

--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -314,3 +314,17 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
             self._XtX = implicit.gpu.Matrix(self._XtX)
         if self._YtY is not None:
             self._YtY = implicit.gpu.Matrix(self._YtY)
+
+
+def calculate_loss(Cui, X, Y, regularization, solver=None):
+    """Calculates the loss for an ALS model"""
+    if not isinstance(Cui, implicit.gpu.CSRMatrix):
+        Cui = implicit.gpu.CSRMatrix(Cui)
+    if not isinstance(X, implicit.gpu.Matrix):
+        X = implicit.gpu.Matrix(X)
+    if not isinstance(Y, implicit.gpu.Matrix):
+        Y = implicit.gpu.Matrix(Y)
+    if solver is None:
+        solver = implicit.gpu.LeastSquaresSolver()
+
+    return solver.calculate_loss(Cui, X, Y, regularization)


### PR DESCRIPTION
The GPU ALS model would sometimes return incorrect results with the `calculate_training_loss` parameter enabled. This happend when the number_of_users * number_of_items was bigger than 2**31 due to an overflow in the loss function calculation.

Fix and add tests that would have caught this bug

Closes https://github.com/benfred/implicit/issues/367 
Closes https://github.com/benfred/implicit/issues/441