### PR TITLE
Set cython directives globally

### DIFF
--- a/implicit/CMakeLists.txt
+++ b/implicit/CMakeLists.txt
@@ -1,3 +1,9 @@
+if(NOT CYTHON_FLAGS)
+    set(CYTHON_FLAGS
+        "--directive always_allow_keywords=True,binding=True,embedsignature=True,language_level=3"
+    )
+endif()
+
 add_cython_target(_nearest_neighbours CXX)
 add_library(_nearest_neighbours MODULE ${_nearest_neighbours})
 python_extension_module(_nearest_neighbours)

--- a/implicit/cpu/bpr.pyx
+++ b/implicit/cpu/bpr.pyx
@@ -1,6 +1,3 @@
-# cython: language_level=3
-# cython: embedsignature=True
-
 import cython
 
 from cython cimport floating, integral

--- a/implicit/cpu/lmf.pyx
+++ b/implicit/cpu/lmf.pyx
@@ -1,6 +1,3 @@
-# cython: language_level=3
-# cython: embedsignature=True
-
 import cython
 
 from cython cimport floating, integral

--- a/implicit/evaluation.pyx
+++ b/implicit/evaluation.pyx
@@ -1,6 +1,4 @@
 # distutils: language = c++
-# cython: language_level=3
-# cython: embedsignature=True
 
 import cython
 import numpy as np


### PR DESCRIPTION
Set cython directives like `language_level=3` and `embedsignature=True` globally, so that they are applied to all the cython files, rather than manually in each one. This removes a bunch of build warnings about not specifying a language_level while building