### PR TITLE
Add `noexcept` declarations for Cython 3.0

### DIFF
--- a/implicit/cpu/_als.pyx
+++ b/implicit/cpu/_als.pyx
@@ -1,3 +1,5 @@
+#cython: legacy_implicit_noexcept=True
+
 import cython
 import numpy as np
 
@@ -15,40 +17,40 @@ from libc.string cimport memcpy, memset
 
 # lapack/blas wrappers for cython fused types
 cdef inline void axpy(int * n, floating * da, floating * dx, int * incx, floating * dy,
-                      int * incy) nogil:
+                      int * incy) noexcept nogil:
     if floating is double:
         cython_blas.daxpy(n, da, dx, incx, dy, incy)
     else:
         cython_blas.saxpy(n, da, dx, incx, dy, incy)
 
 cdef inline void symv(char *uplo, int *n, floating *alpha, floating *a, int *lda, floating *x,
-                      int *incx, floating *beta, floating *y, int *incy) nogil:
+                      int *incx, floating *beta, floating *y, int *incy) noexcept nogil:
     if floating is double:
         cython_blas.dsymv(uplo, n, alpha, a, lda, x, incx, beta, y, incy)
     else:
         cython_blas.ssymv(uplo, n, alpha, a, lda, x, incx, beta, y, incy)
 
-cdef inline floating dot(int *n, floating *sx, int *incx, floating *sy, int *incy) nogil:
+cdef inline floating dot(int *n, floating *sx, int *incx, floating *sy, int *incy) noexcept nogil:
     if floating is double:
         return cython_blas.ddot(n, sx, incx, sy, incy)
     else:
         return cython_blas.sdot(n, sx, incx, sy, incy)
 
-cdef inline void scal(int *n, floating *sa, floating *sx, int *incx) nogil:
+cdef inline void scal(int *n, floating *sa, floating *sx, int *incx) noexcept nogil:
     if floating is double:
         cython_blas.dscal(n, sa, sx, incx)
     else:
         cython_blas.sscal(n, sa, sx, incx)
 
 cdef inline void posv(char * u, int * n, int * nrhs, floating * a, int * lda, floating * b,
-                      int * ldb, int * info) nogil:
+                      int * ldb, int * info) noexcept nogil:
     if floating is double:
         cython_lapack.dposv(u, n, nrhs, a, lda, b, ldb, info)
     else:
         cython_lapack.sposv(u, n, nrhs, a, lda, b, ldb, info)
 
 cdef inline void gesv(int * n, int * nrhs, floating * a, int * lda, int * piv, floating * b,
-                      int * ldb, int * info) nogil:
+                      int * ldb, int * info) noexcept nogil:
     if floating is double:
         cython_lapack.dgesv(n, nrhs, a, lda, piv, b, ldb, info)
     else:

--- a/implicit/cpu/bpr.pyx
+++ b/implicit/cpu/bpr.pyx
@@ -37,7 +37,7 @@ cdef extern from "<random>" namespace "std":
 
     cdef cppclass uniform_int_distribution[T]:
         uniform_int_distribution(T, T)
-        T operator()(mt19937) nogil
+        T operator()(mt19937) noexcept nogil
 
 
 cdef class RNGVector(object):
@@ -55,13 +55,13 @@ cdef class RNGVector(object):
             self.rng.push_back(mt19937(rng_seeds[i]))
             self.dist.push_back(uniform_int_distribution[long](0, rows))
 
-    cdef inline long generate(self, int thread_id) nogil:
+    cdef inline long generate(self, int thread_id) noexcept nogil:
         return self.dist[thread_id](self.rng[thread_id])
 
 
 @cython.boundscheck(False)
 cdef bool has_non_zero(integral[:] indptr, integral[:] indices,
-                       integral rowid, integral colid) nogil:
+                       integral rowid, integral colid) noexcept nogil:
     """ Given a CSR matrix, returns whether the [rowid, colid] contains a non zero.
     Assumes the CSR matrix has sorted indices """
     return binary_search(&indices[indptr[rowid]], &indices[indptr[rowid + 1]], colid)

--- a/implicit/cpu/lmf.pyx
+++ b/implicit/cpu/lmf.pyx
@@ -52,7 +52,7 @@ cdef class RNGVector(object):
             self.rng.push_back(mt19937(rng_seeds[i]))
             self.dist.push_back(uniform_int_distribution[long](0, rows))
 
-    cdef inline long generate(self, int thread_id) nogil:
+    cdef inline long generate(self, int thread_id) noexcept nogil:
         return self.dist[thread_id](self.rng[thread_id])
 
 
@@ -218,7 +218,7 @@ class LogisticMatrixFactorization(MatrixFactorizationBase):
 
 
 @cython.cdivision(True)
-cdef inline floating sigmoid(floating x) nogil:
+cdef inline floating sigmoid(floating x) noexcept nogil:
     if x >= 0:
         return 1 / (1+exp(-x))
     else:

--- a/implicit/cpu/topk.pyx
+++ b/implicit/cpu/topk.pyx
@@ -9,7 +9,7 @@ from cython.parallel import parallel, prange
 cdef extern from "implicit/cpu/select.h" namespace "implicit" nogil:
     cdef void select[T](const T * batch,
                         int batch_rows, int batch_columns, int k,
-                        int * ids, T * distances) nogil except +
+                        int * ids, T * distances) noexcept nogil
 
 
 def topk(items, query, int k, item_norms=None, filter_query_items=None, filter_items=None, int num_threads=0):


### PR DESCRIPTION
This fixes a large performance regression with many of the CPU models.

For instance when training the ml100k dataset, when compiled with Cython 3.0.0:

* Without this change
```
DEBUG:implicit:trained model 'bpr' in 69.49404716491699
DEBUG:implicit:trained model 'lmf' in 42.24160981178284
DEBUG:implicit:trained model 'als' in 120.11413407325745
```

* With this change
```
DEBUG:implicit:trained model 'bpr' in 0.18895816802978516
DEBUG:implicit:trained model 'lmf' in 0.06523633003234863
DEBUG:implicit:trained model 'als' in 1.8809657096862793
```

Fixes #678