### PR TITLE
use raft 23.08

### DIFF
--- a/implicit/gpu/CMakeLists.txt
+++ b/implicit/gpu/CMakeLists.txt
@@ -14,7 +14,7 @@ else()
     add_cython_target(_cuda CXX)
 
     # use rapids-cmake to install dependencies
-    file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.06/RAPIDS.cmake
+    file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.08/RAPIDS.cmake
         ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
     include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
     include(rapids-cmake)
@@ -57,10 +57,10 @@ else()
     # get raft
     # note: we're using RAFT in header only mode right now - mainly to reduce binary
     # size of the compiled wheels
-    rapids_cpm_find(raft 23.06
+    rapids_cpm_find(raft 23.08
         CPM_ARGS
           GIT_REPOSITORY  https://github.com/rapidsai/raft.git
-          GIT_TAG         branch-23.06
+          GIT_TAG         branch-23.08
           DOWNLOAD_ONLY   YES
     )
     include_directories(${raft_SOURCE_DIR}/cpp/include)

--- a/implicit/gpu/knn.h
+++ b/implicit/gpu/knn.h
@@ -25,9 +25,6 @@ public:
                  const COOMatrix *query_filter = NULL,
                  Vector<int> *item_filter = NULL);
 
-  void argsort(const int *input_indices, const float *input_distances, int rows,
-               int cols, int *indices, float *distances);
-
 protected:
   std::unique_ptr<rmm::mr::device_memory_resource> mr;
   raft::resources handle;


### PR DESCRIPTION
Update to use the latest raft version. RAFT 23.08 includes a sort option as part of the select_k method https://github.com/rapidsai/raft/pull/1615 which means we don't have to sort the output ourselves.