### PR TITLE
Add check_csr for partial_fit methods

### DIFF
--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -215,6 +215,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
             Sparse matrix of (users, items) that contain the users that liked
             each item.
         """
+        user_items = check_csr(user_items)
 
         # we're using the cholesky solver here on purpose, since for a full recompute
         users = 1 if np.isscalar(userid) else len(userid)
@@ -252,6 +253,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
             Sparse matrix of (items, users) that contain the users that liked
             each item
         """
+        item_users = check_csr(item_users)
 
         if self.alpha != 1.0:
             item_users = self.alpha * item_users

--- a/implicit/gpu/_cuda.pyx
+++ b/implicit/gpu/_cuda.pyx
@@ -9,6 +9,8 @@ from libc.stdint cimport uint16_t
 from libcpp cimport bool
 from libcpp.utility cimport move, pair
 
+from implicit.utils import check_csr
+
 from .als cimport LeastSquaresSolver as CppLeastSquaresSolver
 from .bpr cimport bpr_update as cpp_bpr_update
 from .knn cimport KnnQuery as CppKnnQuery
@@ -220,6 +222,8 @@ cdef class CSRMatrix(object):
     cdef CppCSRMatrix * c_matrix
 
     def __cinit__(self, X):
+        X = check_csr(X)
+
         cdef int[:] indptr = X.indptr
         cdef int[:] indices = X.indices
         cdef float[:] data = X.data.astype(np.float32)


### PR DESCRIPTION
We were seeing some poor result on partial_fit_*, that ended up caused by passing a CSC instead of a CSR matrix.  (#682)

Add the same `check_csr` code to the partial_fit methods that is already done in the fit method - this will warn if passed a non-csr matrix, and automatically convert.