### PR TITLE
Clear cached properties on partial_fit_*

### DIFF
--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -306,6 +306,10 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         # update the stored factors with the newly calculated values
         self.user_factors[userids] = user_factors
 
+        # clear any cached properties that are invalidated by this update
+        self._user_norms = self._user_norms_host = None
+        self._XtX = None
+
     def partial_fit_items(self, itemids, item_users):
         """Incrementally updates item factors
 
@@ -338,6 +342,10 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
 
         # update the stored factors with the newly calculated values
         self.item_factors[itemids] = item_factors
+
+        # clear any cached properties that are invalidated by this update
+        self._item_norms = self._item_norms_host = None
+        self._YtY = None
 
     def explain(self, userid, user_items, itemid, user_weights=None, N=10):
         """Provides explanations for why the item is liked by the user.

--- a/implicit/cpu/als.py
+++ b/implicit/cpu/als.py
@@ -307,7 +307,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         self.user_factors[userids] = user_factors
 
         # clear any cached properties that are invalidated by this update
-        self._user_norms = self._user_norms_host = None
+        self._user_norms = None
         self._XtX = None
 
     def partial_fit_items(self, itemids, item_users):
@@ -344,7 +344,7 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
         self.item_factors[itemids] = item_factors
 
         # clear any cached properties that are invalidated by this update
-        self._item_norms = self._item_norms_host = None
+        self._item_norms = None
         self._YtY = None
 
     def explain(self, userid, user_items, itemid, user_weights=None, N=10):

--- a/implicit/gpu/als.py
+++ b/implicit/gpu/als.py
@@ -234,6 +234,10 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
 
         self.user_factors.assign_rows(userids, user_factors)
 
+        # clear any cached properties that are invalidated by this update
+        self._user_norms = self._user_norms_host = None
+        self._XtX = None
+
     def partial_fit_items(self, itemids, item_users):
         """Incrementally updates item factors
 
@@ -265,6 +269,10 @@ class AlternatingLeastSquares(MatrixFactorizationBase):
 
         # update the stored factors with the newly calculated values
         self.item_factors.assign_rows(itemids, item_factors)
+
+        # clear any cached properties that are invalidated by this update
+        self._item_norms = self._item_norms_host = None
+        self._YtY = None
 
     @property
     def solver(self):


### PR DESCRIPTION
The item_norms/user_norms were incorrect, especially for new items, after calling the partial_fit methods. Fix.