### PR TITLE
use threadpoolctl for detecting BLAS threadpools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 scipy>=0.16.0
 Cython>=0.24.0
 tqdm>=4.27.0
+threadpoolctl

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(
         "Collaborative Filtering, Recommender Systems"
     ),
     packages=find_packages(),
-    install_requires=["numpy", "scipy>=0.16", "tqdm>=4.27"],
+    install_requires=["numpy", "scipy>=0.16", "tqdm>=4.27", "threadpoolctl"],
     cmake_process_manifest_hook=exclude_non_implicit_cmake_files,
 )


### PR DESCRIPTION
We were using numpy.__config__.get_info to figure out what BLAS library was being used, in an effort to warn people if they hadn't disabled the internal threadpool for the BLAS they were using. This method is removed in numpy 1.26, causing errors.

Fix by using the threadpoolctl library to detect both the BLAS library and the number of threads its configured for.

While we could automatically configure the BLAS library to reduce the threadpool size to 1, this is process wide - and would have side effects for our users. Instead just warn here, and give instructions for people on how to configure themselves.