### PR TITLE
Support using system CMake and Ninja when available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,6 @@ requires = [
     "scikit-build>=0.13.1",
     "Cython>=0.24",
     "scipy>=0.16",
-    "cmake>=3.18",
-    "ninja"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import io
 import os.path
+import shutil
 
 from setuptools import find_packages
 from skbuild import setup
@@ -16,6 +17,13 @@ def exclude_non_implicit_cmake_files(cmake_manifest):
     # we seem to be picking up a bunch of unrelated files from thrust/spdlog/rmm
     # filter the cmake manifest down to things from this package only
     return [f for f in cmake_manifest if "implicit" in f]
+
+
+setup_requires = []
+if shutil.which("cmake") is None:
+    setup_requires += ["cmake>=3.18"]
+if shutil.which("ninja") is None:
+    setup_requires += ["ninja"]
 
 
 setup(
@@ -44,6 +52,7 @@ setup(
         "Collaborative Filtering, Recommender Systems"
     ),
     packages=find_packages(),
+    setup_requires=setup_requires,
     install_requires=["numpy>=1.17.0", "scipy>=0.16", "tqdm>=4.27", "threadpoolctl"],
     cmake_process_manifest_hook=exclude_non_implicit_cmake_files,
 )


### PR DESCRIPTION
Add the requirements for `cmake` and `ninja` PyPI packages only when the respective system tools are not available, in order to permit using the system tools instead.  This avoids unnecessary dependencies on third-party executables, and permits users to benefit from greater portability due to downstream patching of CMake.