### PR TITLE
Use pre-commit for linting in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/setup-python@v6
       with:
         python-version: 3.12
-    - uses: pre-commit/action@v4.6.0
+    - uses: pre-commit/action@v3.0.1
 
   build-wheels:
     needs: [lint]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,40 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-
-    - name: Set up Python
-      uses: actions/setup-python@v6
+    - uses: actions/setup-python@v6
       with:
-        python-version: 3.9
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=11 --max-line-length=127 --statistics
-        flake8 --filename='*.pyx,*.px*' --ignore E901,E225,E226,E227,E402,E999
-    - name: Lint with black
-      run: |
-        black --check .
-    - name: Lint with clang-format
-      run: |
-        sudo apt install clang-format
-        find implicit | grep -E '\.(cu|cuh|h|cpp)$' | xargs clang-format --dry-run --Werror
-      if: runner.os == 'Linux'
-    - name: Lint with isort
-      run: |
-        isort -c .
-    - name: Lint with codespell
-      run: |
-        codespell
-    - name: Lint with pylint
-      run: |
-        pylint implicit tests benchmarks examples
+        python-version: 3.12
+    - uses: pre-commit/action@v4.6.0
 
   build-wheels:
     needs: [lint]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,9 @@ repos:
         rev: v2.2.4
         hooks:
         - id: codespell
-      - repo: local
+      - repo: https://github.com/pre-commit/mirrors-clang-format
+        rev: v22.1.4
         hooks:
         - id: clang-format
-          name: clang-format
-          description: Format files with ClangFormat.
-          entry: clang-format --dry-run --Werror
-          language: system 
           files: \.(cu|cuh|h|cpp)$
 

--- a/implicit/gpu/utils.h
+++ b/implicit/gpu/utils.h
@@ -13,7 +13,9 @@ using std::invalid_argument;
 // and throws exceptions on failure (which cython can proxy back to python)
 
 #define CHECK_CUDA(code)                                                       \
-  { checkCuda((code), __FILE__, __LINE__); }
+  {                                                                            \
+    checkCuda((code), __FILE__, __LINE__);                                     \
+  }
 inline void checkCuda(cudaError_t code, const char *file, int line) {
   if (code != cudaSuccess) {
     std::stringstream err;
@@ -46,7 +48,9 @@ inline const char *cublasGetErrorString(cublasStatus_t status) {
 }
 
 #define CHECK_CUBLAS(code)                                                     \
-  { checkCublas((code), __FILE__, __LINE__); }
+  {                                                                            \
+    checkCublas((code), __FILE__, __LINE__);                                   \
+  }
 inline void checkCublas(cublasStatus_t code, const char *file, int line) {
   if (code != CUBLAS_STATUS_SUCCESS) {
     std::stringstream err;
@@ -57,7 +61,9 @@ inline void checkCublas(cublasStatus_t code, const char *file, int line) {
 }
 
 #define CHECK_CURAND(code)                                                     \
-  { checkCurand((code), __FILE__, __LINE__); }
+  {                                                                            \
+    checkCurand((code), __FILE__, __LINE__);                                   \
+  }
 inline void checkCurand(curandStatus_t code, const char *file, int line) {
   if (code != CURAND_STATUS_SUCCESS) {
     std::stringstream err;


### PR DESCRIPTION
Keep things consistent by using pre-commit for linting in CI, this ensures that the same version of the tools are used in the pre-commit hooks on developer machines and in CI.