### PR TITLE
Downgrade to raft 25.02

### DIFF
--- a/implicit/gpu/CMakeLists.txt
+++ b/implicit/gpu/CMakeLists.txt
@@ -16,8 +16,8 @@ else()
     add_compile_options(-DCCCL_IGNORE_DEPRECATED_STREAM_REF_HEADER)
 
     # use rapids-cmake to install dependencies
-    set(rapids-cmake-version "26.02")
-    file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/refs/heads/release/26.02/RAPIDS.cmake
+    set(rapids-cmake-version "25.02")
+    file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/refs/heads/branch-25.02/RAPIDS.cmake
         ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
     include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
     include(rapids-cmake)
@@ -37,11 +37,11 @@ else()
     include(${rapids-cmake-dir}/cpm/rmm.cmake)
     rapids_cpm_rmm()
 
-    rapids_cpm_find(raft 26.02
+    rapids_cpm_find(raft 25.02
         GLOBAL_TARGETS raft::raft
         CPM_ARGS
           GIT_REPOSITORY  https://github.com/rapidsai/raft.git
-          GIT_TAG         v26.02.00
+          GIT_TAG         v25.02.00
           SOURCE_SUBDIR   cpp
           OPTIONS
               "BUILD_TESTS OFF"

--- a/implicit/gpu/__init__.py
+++ b/implicit/gpu/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import warnings
+
 HAS_CUDA = False
 try:
     from ._cuda import *  # noqa
@@ -8,10 +10,10 @@ try:
     HAS_CUDA = True
 
 except RuntimeError as e:
-    import warnings
-
     warnings.warn(
         f"CUDA extension is built, but disabling GPU support because of '{e}'",
     )
-except ImportError:
-    pass
+except ImportError as e:
+    warnings.warn(
+        f"Disabling GPU support because of '{e}'",
+    )

--- a/implicit/gpu/knn.cu
+++ b/implicit/gpu/knn.cu
@@ -5,9 +5,9 @@
 #include <cub/device/device_segmented_radix_sort.cuh>
 #include <cuda_runtime.h>
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/mr/cuda_memory_resource.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
-#include <rmm/mr/pool_memory_resource.hpp>
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
 #include <thrust/device_ptr.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/constant_iterator.h>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = ["numpy>=1.17.0", "scipy>=0.16", "tqdm>=4.27", "threadpoolctl"]
 wheel.exclude = ["**.pyx", "**.cmake", "**.cuh", "**.hpp", "**.h", "**.hpp.in"]
 cmake.version = ">=3.21.0"
 ninja.version = ">=1.10"
+build-dir = "build"
 
 [tool.cibuildwheel]
 # skip testing in the cibuildwheel phase, will install the wheels later


### PR DESCRIPTION
RMM has recently moved away from header only operation in https://github.com/rapidsai/rmm/pull/1896, which complicates the wheel deployment here since we need to bring in a librmm.so. Temporarily downgrade to raft/rmm v25.02 which doesn't require a precompiled librmm.so or librapids_logger.so